### PR TITLE
Making heartbeat streams

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1928,6 +1928,7 @@ dependencies = [
  "figment",
  "flate2",
  "flexbuffers",
+ "h2 0.4.1",
  "hostname",
  "hyper 1.1.0",
  "hyper-util",
@@ -4676,6 +4677,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ bytes = "1"
 clap = { version = "4", features = ["derive"] }
 figment = { version = "0.10", features = ["yaml", "env"] }
 flexbuffers = { version = "2.0" }
+h2 = { version = "0.4.1" }
 hostname = { version = "0.3" }
 hyper = { version = "1", features = ["full"] }
 hyper-util = { version = "0.1", features = ["service"] }
@@ -68,7 +69,7 @@ strum = { version = "0.25", features = ["derive"] }
 thiserror = "1"
 tonic = { version = "0.10.2", features = ["prost"] }
 tokio = { version = "1", features = ["full"] }
-tokio-stream = "0.1"
+tokio-stream = {version = "0.1", features=["sync"]}
 tokio-rustls = { version = "0.25" }
 tower = { version = "0.4" }
 tracing = { version = "0.1", features = ["log"] }
@@ -101,6 +102,7 @@ bytes = { workspace = true }
 clap = { workspace = true }
 figment = { workspace = true }
 flexbuffers = { workspace = true }
+h2 = { workspace = true }
 hostname = { workspace = true }
 hyper = { workspace = true }
 hyper-util = { workspace = true }

--- a/proto/coordinator_service.proto
+++ b/proto/coordinator_service.proto
@@ -24,7 +24,7 @@ service CoordinatorService {
 
     rpc RegisterExecutor(RegisterExecutorRequest) returns (RegisterExecutorResponse) {}
 
-    rpc Heartbeat(HeartbeatRequest) returns (HeartbeatResponse) {}
+    rpc Heartbeat(stream HeartbeatRequest) returns (stream HeartbeatResponse) {}
 
     rpc ListIndexes(ListIndexesRequest) returns (ListIndexesResponse) {}
 

--- a/src/coordinator_client.rs
+++ b/src/coordinator_client.rs
@@ -28,7 +28,13 @@ impl CoordinatorClient {
 
         let client = CoordinatorServiceClient::connect(format!("http://{}", &self.addr))
             .await
-            .map_err(|e| anyhow!("unable to connect to coordinator: {} at addr {}", e, self.addr))?;
+            .map_err(|e| {
+                anyhow!(
+                    "unable to connect to coordinator: {} at addr {}",
+                    e,
+                    self.addr
+                )
+            })?;
         clients.insert(self.addr.to_string(), client.clone());
         Ok(client)
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,7 +1,39 @@
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::{
+    error::Error,
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use tonic::Status;
 
 pub fn timestamp_secs() -> u64 {
     let now = SystemTime::now();
     let duration = now.duration_since(UNIX_EPOCH).unwrap();
     duration.as_secs()
+}
+
+pub fn match_for_io_error(err_status: &Status) -> Option<&std::io::Error> {
+    let mut err: &(dyn Error + 'static) = err_status;
+
+    if let Some(err_source) = err_status.source() {
+        err = err_source;
+    }
+
+    loop {
+        if let Some(io_err) = err.downcast_ref::<std::io::Error>() {
+            return Some(io_err);
+        }
+
+        // h2::Error do not expose std::io::Error with `source()`
+        // https://github.com/hyperium/h2/pull/462
+        if let Some(h2_err) = err.downcast_ref::<h2::Error>() {
+            if let Some(io_err) = h2_err.get_io() {
+                return Some(io_err);
+            }
+        }
+
+        err = match err.source() {
+            Some(err) => err,
+            None => return None,
+        };
+    }
 }


### PR DESCRIPTION
* Stream heartbeats to server to achieve stickiness 
* Write to raft when heartbeat times out so that the scheduler reschedules tasks on other nodes 
* If the control plane goes away temporarily make the executor re-register first and then send heartbeats 