### PR TITLE
Make the scheduler reactive

### DIFF
--- a/src/coordinator.rs
+++ b/src/coordinator.rs
@@ -21,7 +21,7 @@ use crate::{
         Index,
         Task,
     },
-    state::SharedState,
+    state::{store::StateChange, SharedState},
     utils::timestamp_secs,
 };
 
@@ -304,6 +304,10 @@ impl Coordinator {
         self.shared_state
             .commit_task_assignments(task_assignments)
             .await
+    }
+
+    pub fn get_state_watcher(&self) -> Receiver<StateChange> {
+        self.shared_state.get_state_change_watcher()
     }
 
     pub async fn create_content_metadata(

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -24,7 +24,7 @@ use tracing::{error, info};
 
 use self::{
     grpc_server::RaftGrpcServer,
-    store::{ExecutorId, TaskId},
+    store::{ExecutorId, StateChange, TaskId},
 };
 use crate::{
     indexify_raft::raft_api_server::RaftApiServer,
@@ -107,7 +107,7 @@ impl App {
                 .validate()
                 .map_err(|e| anyhow!("invalid raft config: {}", e.to_string()))?,
         );
-        let store = Arc::new(Store::default());
+        let store = Arc::new(Store::new());
         let (log_store, state_machine) = Adaptor::new(store.clone());
         let network = Network::new();
 
@@ -186,6 +186,10 @@ impl App {
             .await
             .map_err(|e| anyhow!("unable to initialize raft: {}", e))?;
         Ok(())
+    }
+
+    pub fn get_state_change_watcher(&self) -> Receiver<StateChange> {
+        self.store.state_change_rx.clone()
     }
 
     pub async fn stop(&self) -> Result<()> {

--- a/src/state/store/mod.rs
+++ b/src/state/store/mod.rs
@@ -6,6 +6,7 @@ use std::{
     sync::{Arc, Mutex},
 };
 
+
 use openraft::{
     async_trait::async_trait,
     storage::{LogState, Snapshot},
@@ -116,6 +117,18 @@ pub type ExecutorId = String;
 pub type ExtractionEventId = String;
 pub type ExtractorName = String;
 
+#[derive(Clone)]
+pub enum ChangeType {
+    NewContent,
+    NewBinding,
+}
+
+#[derive(Clone)]
+pub struct StateChange {
+    pub id: String,
+    pub change_type: ChangeType,
+}
+
 /**
  * Here defines a state machine of the raft, this state represents a copy of
  * the data between each node. Note that we are using `serde` to serialize
@@ -161,7 +174,6 @@ pub struct StateMachine {
     pub index_table: HashMap<String, Index>,
 }
 
-#[derive(Debug, Default)]
 pub struct Store {
     last_purged_log_id: RwLock<Option<LogId<NodeId>>>,
 
@@ -177,6 +189,34 @@ pub struct Store {
     snapshot_idx: Arc<Mutex<u64>>,
 
     current_snapshot: RwLock<Option<StoredSnapshot>>,
+
+    pub state_change_tx: tokio::sync::watch::Sender<StateChange>,
+    pub state_change_rx: tokio::sync::watch::Receiver<StateChange>,
+}
+
+impl Default for Store {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Store {
+    pub fn new() -> Self {
+        let (tx, rx) = tokio::sync::watch::channel(StateChange {
+            id: "".to_string(),
+            change_type: ChangeType::NewContent,
+        });
+        Self {
+            last_purged_log_id: RwLock::new(None),
+            log: RwLock::new(BTreeMap::new()),
+            state_machine: RwLock::new(StateMachine::default()),
+            vote: RwLock::new(None),
+            snapshot_idx: Arc::new(Mutex::new(0)),
+            current_snapshot: RwLock::new(None),
+            state_change_tx: tx,
+            state_change_rx: rx,
+        }
+    }
 }
 
 #[async_trait]
@@ -356,6 +396,8 @@ impl RaftStorage<TypeConfig> for Arc<Store> {
 
         let mut sm = self.state_machine.write().await;
 
+        let mut change_events: Vec<StateChange> = Vec::new();
+
         for entry in entries {
             tracing::debug!(%entry.log_id, "replicate to sm");
 
@@ -438,6 +480,10 @@ impl RaftStorage<TypeConfig> for Arc<Store> {
                                 .entry(content.repository.clone())
                                 .or_default()
                                 .insert(content.id.clone());
+                            change_events.push(StateChange {
+                                id: content.id.clone(),
+                                change_type: ChangeType::NewContent,
+                            });
                         }
                         for event in extraction_events {
                             sm.extraction_events.insert(event.id.clone(), event.clone());
@@ -453,6 +499,10 @@ impl RaftStorage<TypeConfig> for Arc<Store> {
                             .entry(binding.repository.clone())
                             .or_default()
                             .insert(binding.clone());
+                        change_events.push(StateChange {
+                            id: binding.id.clone(),
+                            change_type: ChangeType::NewBinding,
+                        });
                         if let Some(extraction_event) = extraction_event {
                             sm.extraction_events
                                 .insert(extraction_event.id.clone(), extraction_event.clone());
@@ -513,6 +563,12 @@ impl RaftStorage<TypeConfig> for Arc<Store> {
                     res.push(Response { value: None })
                 }
             };
+        }
+
+        for change_event in change_events {
+            if let Err(err) = self.state_change_tx.send(change_event) {
+                tracing::error!("error sending state change event: {}", err);
+            }
         }
         Ok(res)
     }


### PR DESCRIPTION
Make the scheduler reactive to run only when we have ingested content or a new binding added. 