### PR TITLE
Raft log store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1362,6 +1362,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "float-cmp"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "flume"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1655,10 +1664,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "halfbrown"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5681137554ddff44396e5f149892c769d45301dd9aa19c51602a89ee214cb0ec"
+dependencies = [
+ "hashbrown 0.13.2",
+ "serde",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
+dependencies = [
+ "ahash",
+]
 
 [[package]]
 name = "hashbrown"
@@ -2034,6 +2062,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "serde_yaml",
+ "simd-json",
  "sled",
  "smart-default",
  "sqlx",
@@ -2233,6 +2262,70 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 dependencies = [
  "spin 0.5.2",
+]
+
+[[package]]
+name = "lexical-core"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cde5de06e8d4c2faabc400238f9ae1c74d5412d03a7bd067645ccbc47070e46"
+dependencies = [
+ "lexical-parse-float",
+ "lexical-parse-integer",
+ "lexical-util",
+ "lexical-write-float",
+ "lexical-write-integer",
+]
+
+[[package]]
+name = "lexical-parse-float"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683b3a5ebd0130b8fb52ba0bdc718cc56815b6a097e28ae5a6997d0ad17dc05f"
+dependencies = [
+ "lexical-parse-integer",
+ "lexical-util",
+ "static_assertions",
+]
+
+[[package]]
+name = "lexical-parse-integer"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d0994485ed0c312f6d965766754ea177d07f9c00c9b82a5ee62ed5b47945ee9"
+dependencies = [
+ "lexical-util",
+ "static_assertions",
+]
+
+[[package]]
+name = "lexical-util"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5255b9ff16ff898710eb9eb63cb39248ea8a5bb036bea8085b1a767ff6c4e3fc"
+dependencies = [
+ "static_assertions",
+]
+
+[[package]]
+name = "lexical-write-float"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accabaa1c4581f05a3923d1b4cfd124c329352288b7b9da09e766b0668116862"
+dependencies = [
+ "lexical-util",
+ "lexical-write-integer",
+ "static_assertions",
+]
+
+[[package]]
+name = "lexical-write-integer"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1b6f3d1f4422866b68192d62f77bc5c700bee84f3069f2469d7bc8c77852446"
+dependencies = [
+ "lexical-util",
+ "static_assertions",
 ]
 
 [[package]]
@@ -3667,6 +3760,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4846d4c50d1721b1a3bef8af76924eef20d5e723647333798c1b519b3a9473f"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fddb4f8d99b0a2ebafc65a87a69a7b9875e4b1ae1f00db265d300ef7f28bccc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+]
+
+[[package]]
 name = "regex"
 version = "1.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4213,6 +4326,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-json"
+version = "0.13.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a9511d2aa0b26dce65ea3860321cd680a8daeb6808b04f1e94429e0389ad952"
+dependencies = [
+ "getrandom",
+ "halfbrown",
+ "lexical-core",
+ "ref-cast",
+ "serde",
+ "serde_json",
+ "simdutf8",
+ "value-trait",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f27f6278552951f1f2b8cf9da965d10969b2efdea95a6ec47987ab46edfe263a"
+
+[[package]]
 name = "similar"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4554,6 +4689,12 @@ dependencies = [
  "url",
  "urlencoding",
 ]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stringprep"
@@ -5328,6 +5469,18 @@ name = "value-bag"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cdbaf5e132e593e9fc1de6a15bbec912395b11fb9719e061cf64f804524c503"
+
+[[package]]
+name = "value-trait"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea87257cfcbedcb9444eda79c59fdfea71217e6305afee8ee33f500375c2ac97"
+dependencies = [
+ "float-cmp",
+ "halfbrown",
+ "itoa",
+ "ryu",
+]
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,9 +63,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.5"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d664a92ecae85fd0a7392615844904654d1d5f5514837f471ddef4a057aba1b6"
+checksum = "6e2e1ebcb11de5c03c67de28a7df593d32191b44939c482e97702baaaa6ab6a5"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -139,9 +139,9 @@ dependencies = [
 
 [[package]]
 name = "askama_derive"
-version = "0.12.4"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ccf09143e56923c12e027b83a9553210a3c58322ed8419a53461b14a4dccd85"
+checksum = "19fe8d6cb13c4714962c072ea496f3392015f0989b1a2847bb4b2d9effd71d83"
 dependencies = [
  "askama_parser",
  "basic-toml",
@@ -161,9 +161,9 @@ checksum = "619743e34b5ba4e9703bba34deac3427c72507c7159f5fd030aea8cac0cfe341"
 
 [[package]]
 name = "askama_parser"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "262eb9cf7be51269c5f2951eeda9ccd14d6934e437457f47b4f066bf55a6770d"
+checksum = "acb1161c6b64d1c3d83108213c2a2533a342ac225aabd0bda218278c2ddb00c0"
 dependencies = [
  "nom",
 ]
@@ -194,9 +194,9 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc2d0cfb2a7388d34f590e76686704c494ed7aaceed62ee1ba35cbf363abc2a5"
+checksum = "a116f46a969224200a0a97f29cfd4c50e7534e4b4826bd23ea2c3c533039c82c"
 dependencies = [
  "flate2",
  "futures-core",
@@ -211,7 +211,7 @@ version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17ae5ebefcc48e7452b4987947920dac9450be1110cadf34d1b8c116bdbaf97c"
 dependencies = [
- "async-lock 3.2.0",
+ "async-lock 3.3.0",
  "async-task",
  "concurrent-queue",
  "fastrand 2.0.1",
@@ -227,8 +227,8 @@ checksum = "05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c"
 dependencies = [
  "async-channel 2.1.1",
  "async-executor",
- "async-io 2.2.2",
- "async-lock 3.2.0",
+ "async-io 2.3.0",
+ "async-lock 3.3.0",
  "blocking",
  "futures-lite 2.2.0",
  "once_cell",
@@ -256,18 +256,18 @@ dependencies = [
 
 [[package]]
 name = "async-io"
-version = "2.2.2"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6afaa937395a620e33dc6a742c593c01aced20aa376ffb0f628121198578ccc7"
+checksum = "fb41eb19024a91746eba0773aa5e16036045bbf45733766661099e182ea6a744"
 dependencies = [
- "async-lock 3.2.0",
+ "async-lock 3.3.0",
  "cfg-if",
  "concurrent-queue",
  "futures-io",
  "futures-lite 2.2.0",
  "parking",
- "polling 3.3.1",
- "rustix 0.38.28",
+ "polling 3.3.2",
+ "rustix 0.38.30",
  "slab",
  "tracing",
  "windows-sys 0.52.0",
@@ -284,9 +284,9 @@ dependencies = [
 
 [[package]]
 name = "async-lock"
-version = "3.2.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7125e42787d53db9dd54261812ef17e937c95a51e4d291373b670342fa44310c"
+checksum = "d034b430882f8381900d3fe6f0aaa3ad94f2cb4ac519b429692a1bc2dda4ae7b"
 dependencies = [
  "event-listener 4.0.3",
  "event-listener-strategy",
@@ -306,7 +306,7 @@ dependencies = [
  "cfg-if",
  "event-listener 3.1.0",
  "futures-lite 1.13.0",
- "rustix 0.38.28",
+ "rustix 0.38.30",
  "windows-sys 0.48.0",
 ]
 
@@ -316,13 +316,13 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e47d90f65a225c4527103a8d747001fc56e375203592b25ad103e1ca13124c5"
 dependencies = [
- "async-io 2.2.2",
+ "async-io 2.3.0",
  "async-lock 2.8.0",
  "atomic-waker",
  "cfg-if",
  "futures-core",
  "futures-io",
- "rustix 0.38.28",
+ "rustix 0.38.30",
  "signal-hook-registry",
  "slab",
  "windows-sys 0.48.0",
@@ -464,12 +464,12 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d09dbe0e490df5da9d69b36dca48a76635288a82f92eca90024883a56202026d"
+checksum = "1236b4b292f6c4d6dc34604bb5120d85c3fe1d1aa596bd5cc52ca054d13e7b9e"
 dependencies = [
  "async-trait",
- "axum-core 0.4.2",
+ "axum-core 0.4.3",
  "axum-macros",
  "bytes",
  "futures-util",
@@ -517,9 +517,9 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e87c8503f93e6d144ee5690907ba22db7ba79ab001a932ab99034f0fe836b3df"
+checksum = "a15c63fd72d41492dc4f497196f5da1fb04fb7529e631d73630d1b491e47a2e3"
 dependencies = [
  "async-trait",
  "bytes",
@@ -538,9 +538,9 @@ dependencies = [
 
 [[package]]
 name = "axum-macros"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a2edad600410b905404c594e2523549f1bcd4bded1e252c8f74524ccce0b867"
+checksum = "00c055ee2d014ae5981ce1016374e8213682aa14d9bf40e48ab48b5f3ef20eaa"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -554,7 +554,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05498d33363e05a88a33e7071053c43bb3585c89e0bccb71b2ad06425b23b14f"
 dependencies = [
- "axum 0.7.3",
+ "axum 0.7.4",
  "futures-util",
  "http 1.0.0",
  "http-body 1.0.0",
@@ -573,7 +573,7 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bdad298231394729042d1f155b93f9fdf0b5ee1aea0b62404c4d7341f7d8fe08"
 dependencies = [
- "axum 0.7.3",
+ "axum 0.7.4",
  "futures-core",
  "futures-util",
  "http 1.0.0",
@@ -602,9 +602,9 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.21.6"
+version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c79fed4cdb43e993fcdadc7e58a09fd0e3e649c4436fa11da71c9f1f3ee7feb9"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "base64ct"
@@ -617,6 +617,15 @@ name = "basic-toml"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2db21524cad41c5591204d22d75e1970a2d1f71060214ca931dc7d5afe2c14e5"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
  "serde",
 ]
@@ -644,9 +653,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.4.1"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
+checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
 dependencies = [
  "serde",
 ]
@@ -667,7 +676,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a37913e8dc4ddcc604f0c6d3bf2887c995153af3611de9e23c352b44c1b9118"
 dependencies = [
  "async-channel 2.1.1",
- "async-lock 3.2.0",
+ "async-lock 3.3.0",
  "async-task",
  "fastrand 2.0.1",
  "futures-io",
@@ -810,6 +819,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "cargo_metadata"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d886547e41f740c616ae73108f6eb70afe6d940c7bc697cb30f13daec073037"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -839,9 +862,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.4.14"
+version = "4.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33e92c5c1a78c62968ec57dbc2440366a2d6e5a23faf829970ff1585dc6b18e2"
+checksum = "1e578d6ec4194633722ccf9544794b71b1385c3c027efe0c55db226fc880865c"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -849,9 +872,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.4.14"
+version = "4.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4323769dc8a61e2c39ad7dc26f6f2800524691a44d74fe3d1071a5c24db6370"
+checksum = "4df4df40ec50c46000231c914968278b1eb05098cf8f1b3a518a95030e71d1c7"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1255,9 +1278,9 @@ checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
 
 [[package]]
 name = "figment"
-version = "0.10.13"
+version = "0.10.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7629b8c7bcd214a072c2c88b263b5bb3ceb54c34365d8c41c1665461aeae0993"
+checksum = "2b6e5bc7bd59d60d0d45a6ccab6cf0f4ce28698fb4e81e750ddf229c9b824026"
 dependencies = [
  "atomic",
  "pear",
@@ -1275,7 +1298,7 @@ checksum = "1ee447700ac8aa0b2f2bd7bc4462ad686ba06baa6727ac149a2d6277f0d240fd"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.4.1",
  "windows-sys 0.52.0",
 ]
 
@@ -1366,6 +1389,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "futures"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1415,7 +1448,7 @@ checksum = "1d930c203dd0b6ff06e0201a4a2fe9149b43c684fd4420555b26d21b1a02956f"
 dependencies = [
  "futures-core",
  "lock_api",
- "parking_lot",
+ "parking_lot 0.12.1",
 ]
 
 [[package]]
@@ -1504,6 +1537,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1552,9 +1594,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.22"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d6250322ef6e60f93f9a2162799302cd6f68f79f6e5d85c8c16f14d1d958178"
+checksum = "bb2c4422095b67ee78da96fbb51a4cc413b3b25883c7717ff7ca1ab31022c9c9"
 dependencies = [
  "bytes",
  "fnv",
@@ -1571,9 +1613,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "991910e35c615d8cab86b5ab04be67e6ad24d2bf5f4f11fdbbed26da999bbeab"
+checksum = "31d030e59af851932b72ceebadf4a2b5986dba4c3b99dd2493f8273a0f151943"
 dependencies = [
  "bytes",
  "fnv",
@@ -1624,9 +1666,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
+checksum = "5d3d0e0f38255e7fa3cf31335b3a56f05febd18025f4db5ef7a0cfb4f8da651f"
 
 [[package]]
 name = "hex"
@@ -1765,7 +1807,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.3.22",
+ "h2 0.3.24",
  "http 0.2.11",
  "http-body 0.4.6",
  "httparse",
@@ -1788,7 +1830,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "h2 0.4.1",
+ "h2 0.4.2",
  "http 1.0.0",
  "http-body 1.0.0",
  "httparse",
@@ -1918,17 +1960,19 @@ dependencies = [
  "anyhow",
  "askama",
  "async-trait",
- "axum 0.7.3",
+ "axum 0.7.4",
  "axum-otel-metrics",
  "axum-tracing-opentelemetry",
  "base64",
+ "bincode",
  "bollard",
+ "byteorder",
  "bytes",
  "clap",
  "figment",
  "flate2",
  "flexbuffers",
- "h2 0.4.1",
+ "h2 0.4.2",
  "hostname",
  "hyper 1.1.0",
  "hyper-util",
@@ -1947,6 +1991,7 @@ dependencies = [
  "opentelemetry-semantic-conventions 0.13.0",
  "opentelemetry-stdout",
  "opentelemetry_sdk 0.21.2",
+ "paste",
  "pgvector",
  "prost 0.12.3",
  "prost-types 0.12.3",
@@ -1964,6 +2009,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "serde_yaml",
+ "sled",
  "smart-default",
  "sqlx",
  "strum",
@@ -2094,9 +2140,9 @@ checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
 name = "js-sys"
-version = "0.3.66"
+version = "0.3.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cee9c64da59eae3b50095c18d3e74f8b73c0b86d2792824ff01bbce68ba229ca"
+checksum = "9a1d36f1235bc969acba30b7f5990b864423a6068a10f7c90ae8f0112e3a59d1"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -2120,7 +2166,7 @@ dependencies = [
  "memchr",
  "num-cmp",
  "once_cell",
- "parking_lot",
+ "parking_lot 0.12.1",
  "percent-encoding",
  "regex",
  "reqwest",
@@ -2167,9 +2213,9 @@ version = "0.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85c833ca1e66078851dba29046874e38f08b2c883700aa29a03ddd3b23814ee8"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.4.2",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.4.1",
 ]
 
 [[package]]
@@ -2191,9 +2237,9 @@ checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4cd1a83af159aa67994778be9070f0ae1bd732942279cabb14f86f986a21456"
+checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
 
 [[package]]
 name = "local-ip-address"
@@ -2333,7 +2379,7 @@ dependencies = [
  "crossbeam-utils",
  "futures-util",
  "once_cell",
- "parking_lot",
+ "parking_lot 0.12.1",
  "quanta",
  "rustc_version",
  "skeptic",
@@ -2426,7 +2472,7 @@ version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.4.2",
  "cfg-if",
  "libc",
 ]
@@ -2623,7 +2669,7 @@ dependencies = [
  "humantime",
  "hyper 0.14.28",
  "itertools 0.12.0",
- "parking_lot",
+ "parking_lot 0.12.1",
  "percent-encoding",
  "quick-xml",
  "rand",
@@ -2692,7 +2738,7 @@ version = "0.10.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8cde4d2d9200ad5909f8dac647e29482e07c3a35de8a13fce7c9c7747ad9f671"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.4.2",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -2949,12 +2995,37 @@ checksum = "bb813b8af86854136c6922af0598d719255ecb2179515e6e7730d468f05c9cae"
 
 [[package]]
 name = "parking_lot"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
+dependencies = [
+ "instant",
+ "lock_api",
+ "parking_lot_core 0.8.6",
+]
+
+[[package]]
+name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
 dependencies = [
  "lock_api",
- "parking_lot_core",
+ "parking_lot_core 0.9.9",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
+dependencies = [
+ "cfg-if",
+ "instant",
+ "libc",
+ "redox_syscall 0.2.16",
+ "smallvec",
+ "winapi",
 ]
 
 [[package]]
@@ -2965,7 +3036,7 @@ checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.4.1",
  "smallvec",
  "windows-targets 0.48.5",
 ]
@@ -3099,9 +3170,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69d3587f8a9e599cc7ec2c00e331f71c4e69a5f9a4b8a6efd5b07466b9736f9a"
+checksum = "2900ede94e305130c13ddd391e0ab7cbaeb783945ae07a279c268cb05109c6cb"
 
 [[package]]
 name = "polling"
@@ -3121,14 +3192,14 @@ dependencies = [
 
 [[package]]
 name = "polling"
-version = "3.3.1"
+version = "3.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf63fa624ab313c11656b4cda960bfc46c410187ad493c41f6ba2d8c1e991c9e"
+checksum = "545c980a3880efd47b2e262f6a4bb6daad6555cf3367aa9c4e52895f69537a41"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
  "pin-project-lite",
- "rustix 0.38.28",
+ "rustix 0.38.30",
  "tracing",
  "windows-sys 0.52.0",
 ]
@@ -3221,7 +3292,7 @@ dependencies = [
  "fnv",
  "lazy_static",
  "memchr",
- "parking_lot",
+ "parking_lot 0.12.1",
  "protobuf",
  "thiserror",
 ]
@@ -3339,7 +3410,7 @@ dependencies = [
  "indoc",
  "libc",
  "memoffset",
- "parking_lot",
+ "parking_lot 0.12.1",
  "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
@@ -3476,7 +3547,7 @@ version = "11.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d86a7c4638d42c44551f4791a20e687dbb4c3de1f33c43dd71e355cd429def1"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.4.2",
 ]
 
 [[package]]
@@ -3518,6 +3589,15 @@ checksum = "136fc13778b9fb91b5dfad24875088d411190a9a136d6815680e1a19b06dbec9"
 dependencies = [
  "futures",
  "redis",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+dependencies = [
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -3596,7 +3676,7 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2 0.3.22",
+ "h2 0.3.24",
  "http 0.2.11",
  "http-body 0.4.6",
  "hyper 0.14.28",
@@ -3731,14 +3811,14 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.28"
+version = "0.38.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72e572a5e8ca657d7366229cdde4bd14c4eb5499a9573d4d366fe1b599daa316"
+checksum = "322394588aaf33c24007e8bb3238ee3e4c5c09c084ab32bc73890b99ff326bca"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.4.2",
  "errno",
  "libc",
- "linux-raw-sys 0.4.12",
+ "linux-raw-sys 0.4.13",
  "windows-sys 0.52.0",
 ]
 
@@ -4082,7 +4162,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16d23b015676c90a0f01c197bfdc786c20342c73a0afdda9025adb0bc42940a8"
 dependencies = [
  "bytecount",
- "cargo_metadata",
+ "cargo_metadata 0.14.2",
  "error-chain",
  "glob",
  "pulldown-cmark",
@@ -4100,10 +4180,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "smallvec"
-version = "1.11.2"
+name = "sled"
+version = "0.34.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dccd0940a2dcdf68d092b8cbab7dc0ad8fa938bf95787e1b916b0e3d0e8e970"
+checksum = "7f96b4737c2ce5987354855aed3797279def4ebf734436c6aa4552cf8e169935"
+dependencies = [
+ "crc32fast",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "fs2",
+ "fxhash",
+ "libc",
+ "log",
+ "parking_lot 0.11.2",
+]
+
+[[package]]
+name = "smallvec"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
 
 [[package]]
 name = "smart-default"
@@ -4297,7 +4393,7 @@ checksum = "e37195395df71fd068f6e2082247891bc11e3289624bbc776a0cdfa1ca7f1ea4"
 dependencies = [
  "atoi",
  "base64",
- "bitflags 2.4.1",
+ "bitflags 2.4.2",
  "byteorder",
  "bytes",
  "crc",
@@ -4340,7 +4436,7 @@ checksum = "d6ac0ac3b7ccd10cc96c7ab29791a7dd236bd94021f31eec7ba3d46a74aa1c24"
 dependencies = [
  "atoi",
  "base64",
- "bitflags 2.4.1",
+ "bitflags 2.4.2",
  "byteorder",
  "crc",
  "dotenvy",
@@ -4471,16 +4567,16 @@ checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
 name = "sysinfo"
-version = "0.29.11"
+version = "0.30.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd727fc423c2060f6c92d9534cef765c65a6ed3f428a03d7def74a8c4348e666"
+checksum = "1fb4f3438c8f6389c864e61221cbc97e9bca98b4daf39a5beb7bea660f528bb2"
 dependencies = [
  "cfg-if",
  "core-foundation-sys",
  "libc",
  "ntapi",
  "once_cell",
- "winapi",
+ "windows",
 ]
 
 [[package]]
@@ -4535,8 +4631,8 @@ checksum = "01ce4141aa927a6d1bd34a041795abd0db1cccba5d5f24b009f694bdf3a1f3fa"
 dependencies = [
  "cfg-if",
  "fastrand 2.0.1",
- "redox_syscall",
- "rustix 0.38.28",
+ "redox_syscall 0.4.1",
+ "rustix 0.38.30",
  "windows-sys 0.52.0",
 ]
 
@@ -4627,7 +4723,7 @@ dependencies = [
  "libc",
  "mio",
  "num_cpus",
- "parking_lot",
+ "parking_lot 0.12.1",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2 0.5.5",
@@ -4743,7 +4839,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "h2 0.3.22",
+ "h2 0.3.24",
  "http 0.2.11",
  "http-body 0.4.6",
  "hyper 0.14.28",
@@ -4773,7 +4869,7 @@ dependencies = [
  "axum 0.6.20",
  "base64",
  "bytes",
- "h2 0.3.22",
+ "h2 0.3.24",
  "http 0.2.11",
  "http-body 0.4.6",
  "hyper 0.14.28",
@@ -5006,9 +5102,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f2528f27a9eb2b21e69c95319b30bd0efd85d09c379741b0f78ea1d86be2416"
+checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
 
 [[package]]
 name = "unicode-ident"
@@ -5115,7 +5211,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d331839f6de584865f20c8138b73868d515ba62349ae4c8c1f78ffa54069e78"
 dependencies = [
- "axum 0.7.3",
+ "axum 0.7.4",
  "serde",
  "serde_json",
  "utoipa",
@@ -5127,7 +5223,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01520ff2511e54c069eda8e93569fff9893b2548c53c1357655292f47ef6782f"
 dependencies = [
- "axum 0.7.3",
+ "axum 0.7.4",
  "serde",
  "serde_json",
  "utoipa",
@@ -5139,7 +5235,7 @@ version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f839caa8e09dddc3ff1c3112a91ef7da0601075ba5025d9f33ae99c4cb9b6e51"
 dependencies = [
- "axum 0.7.3",
+ "axum 0.7.4",
  "mime_guess",
  "regex",
  "rust-embed",
@@ -5151,9 +5247,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e395fcf16a7a3d8127ec99782007af141946b4795001f876d54fb0d55978560"
+checksum = "f00cc9702ca12d3c81455259621e676d0f7251cec66a21e98fe2e9a37db93b2a"
 dependencies = [
  "getrandom",
 ]
@@ -5178,11 +5274,14 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vergen"
-version = "8.2.6"
+version = "8.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1290fd64cc4e7d3c9b07d7f333ce0ce0007253e32870e632624835cc80b83939"
+checksum = "e27d6bdd219887a9eadd19e1c34f32e47fa332301184935c6d9bca26f3cca525"
 dependencies = [
  "anyhow",
+ "cargo_metadata 0.18.1",
+ "cfg-if",
+ "regex",
  "rustc_version",
  "rustversion",
  "sysinfo",
@@ -5234,9 +5333,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.89"
+version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ed0d4f68a3015cc185aff4db9506a015f4b96f95303897bfa23f846db54064e"
+checksum = "b1223296a201415c7fad14792dbefaace9bd52b62d33453ade1c5b5f07555406"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -5244,9 +5343,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.89"
+version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b56f625e64f3a1084ded111c4d5f477df9f8c92df113852fa5a374dbda78826"
+checksum = "fcdc935b63408d58a32f8cc9738a0bffd8f05cc7c002086c6ef20b7312ad9dcd"
 dependencies = [
  "bumpalo",
  "log",
@@ -5259,9 +5358,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.39"
+version = "0.4.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac36a15a220124ac510204aec1c3e5db8a22ab06fd6706d881dc6149f8ed9a12"
+checksum = "bde2032aeb86bdfaecc8b261eef3cba735cc426c1f3a3416d1e0791be95fc461"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -5271,9 +5370,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.89"
+version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0162dbf37223cd2afce98f3d0785506dcb8d266223983e4b5b525859e6e182b2"
+checksum = "3e4c238561b2d428924c49815533a8b9121c664599558a5d9ec51f8a1740a999"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5281,9 +5380,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.89"
+version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0eb82fcb7930ae6219a7ecfd55b217f5f0893484b7a13022ebb2b2bf20b5283"
+checksum = "bae1abb6806dc1ad9e560ed242107c0f6c84335f1749dd4e8ddb012ebd5e25a7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5294,9 +5393,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.89"
+version = "0.2.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ab9b36309365056cd639da3134bf87fa8f3d86008abf99e612384a6eecd459f"
+checksum = "4d91413b1c31d7539ba5ef2451af3f0b833a005eb27a631cec32bc0635a8602b"
 
 [[package]]
 name = "wasm-streams"
@@ -5313,9 +5412,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.66"
+version = "0.3.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50c24a44ec86bb68fbecd1b3efed7e85ea5621b39b35ef2766b66cd984f8010f"
+checksum = "58cd2333b6e0be7a39605f0e255892fd7418a682d8da8fe042fe25128794d2ed"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5346,7 +5445,7 @@ dependencies = [
  "either",
  "home",
  "once_cell",
- "rustix 0.38.28",
+ "rustix 0.38.30",
 ]
 
 [[package]]
@@ -5385,6 +5484,16 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
+dependencies = [
+ "windows-core",
+ "windows-targets 0.52.0",
+]
 
 [[package]]
 name = "windows-core"
@@ -5548,13 +5657,13 @@ dependencies = [
 
 [[package]]
 name = "xattr"
-version = "1.2.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "914566e6413e7fa959cc394fb30e563ba80f3541fbd40816d4c05a0fc3f2a0f1"
+checksum = "8da84f1a25939b27f6820d92aed108f83ff920fdf11a7b19366c27c4cda81d4f"
 dependencies = [
  "libc",
- "linux-raw-sys 0.4.12",
- "rustix 0.38.28",
+ "linux-raw-sys 0.4.13",
+ "rustix 0.38.30",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -602,6 +602,12 @@ dependencies = [
 
 [[package]]
 name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
@@ -691,7 +697,7 @@ version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f03db470b3c0213c47e978da93200259a1eb4dae2e5512cba9955e2b540a6fc6"
 dependencies = [
- "base64",
+ "base64 0.21.7",
  "bollard-buildkit-proto",
  "bollard-stubs",
  "bytes",
@@ -738,7 +744,7 @@ version = "1.43.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b58071e8fd9ec1e930efd28e3a90c1251015872a2ce49f81f36421b86466932e"
 dependencies = [
- "base64",
+ "base64 0.21.7",
  "bollard-buildkit-proto",
  "bytes",
  "prost 0.12.3",
@@ -927,6 +933,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d16048cd947b08fa32c24458a22f5dc5e835264f689f4f5653210c69fd107363"
 dependencies = [
  "crossbeam-utils",
+]
+
+[[package]]
+name = "console"
+version = "0.15.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e1f83fc076bd6dd27517eacdf25fef6c4dfe5f1d7448bafaaf3a26f13b5e4eb"
+dependencies = [
+ "encode_unicode",
+ "lazy_static",
+ "libc",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1167,6 +1185,12 @@ checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "encode_unicode"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "encoding_rs"
@@ -1963,7 +1987,7 @@ dependencies = [
  "axum 0.7.4",
  "axum-otel-metrics",
  "axum-tracing-opentelemetry",
- "base64",
+ "base64 0.21.7",
  "bincode",
  "bollard",
  "byteorder",
@@ -1976,6 +2000,7 @@ dependencies = [
  "hostname",
  "hyper 1.1.0",
  "hyper-util",
+ "insta",
  "itertools 0.12.0",
  "jsonschema",
  "local-ip-address",
@@ -2071,6 +2096,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb"
 
 [[package]]
+name = "insta"
+version = "1.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d64600be34b2fcfc267740a243fa7744441bb4947a619ac4e5bb6507f35fbfc"
+dependencies = [
+ "console",
+ "lazy_static",
+ "linked-hash-map",
+ "ron",
+ "serde",
+ "similar",
+ "yaml-rust",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2155,7 +2195,7 @@ checksum = "2a071f4f7efc9a9118dfb627a0a94ef247986e1ab8606a4c806ae2b3aa3b6978"
 dependencies = [
  "ahash",
  "anyhow",
- "base64",
+ "base64 0.21.7",
  "bytecount",
  "clap",
  "fancy-regex",
@@ -2228,6 +2268,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
@@ -2662,7 +2708,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d139f545f64630e2e3688fd9f81c470888ab01edeb72d13b4e86c566f1130000"
 dependencies = [
  "async-trait",
- "base64",
+ "base64 0.21.7",
  "bytes",
  "chrono",
  "futures",
@@ -2718,7 +2764,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd2846759315751e04d8b45a0bdbd89ce442282ffb916cf54f6b0adf8df4b44c"
 dependencies = [
- "base64",
+ "base64 0.21.7",
  "bytes",
  "dyn-clone",
  "lazy_static",
@@ -3671,7 +3717,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b1ae8d9ac08420c66222fb9096fc5de435c3c48542bc5336c51892cffafb41"
 dependencies = [
  "async-compression",
- "base64",
+ "base64 0.21.7",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -3723,6 +3769,17 @@ dependencies = [
  "spin 0.9.8",
  "untrusted",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "ron"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88073939a61e5b7680558e6be56b419e208420c2adb92be54921fa6b72283f1a"
+dependencies = [
+ "base64 0.13.1",
+ "bitflags 1.3.2",
+ "serde",
 ]
 
 [[package]]
@@ -3866,7 +3923,7 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
- "base64",
+ "base64 0.21.7",
 ]
 
 [[package]]
@@ -3875,7 +3932,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35e4980fa29e4c4b212ffb3db068a564cbf560e51d3944b7c88bd8bf5bec64f4"
 dependencies = [
- "base64",
+ "base64 0.21.7",
  "rustls-pki-types",
 ]
 
@@ -4054,7 +4111,7 @@ version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64cd236ccc1b7a29e7e2739f27c0b2dd199804abc4290e32f59f3b68d6405c23"
 dependencies = [
- "base64",
+ "base64 0.21.7",
  "chrono",
  "hex",
  "indexmap 1.9.3",
@@ -4154,6 +4211,12 @@ dependencies = [
  "digest",
  "rand_core",
 ]
+
+[[package]]
+name = "similar"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32fea41aca09ee824cc9724996433064c89f7777e60762749a4170a14abbfa21"
 
 [[package]]
 name = "skeptic"
@@ -4392,7 +4455,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e37195395df71fd068f6e2082247891bc11e3289624bbc776a0cdfa1ca7f1ea4"
 dependencies = [
  "atoi",
- "base64",
+ "base64 0.21.7",
  "bitflags 2.4.2",
  "byteorder",
  "bytes",
@@ -4435,7 +4498,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6ac0ac3b7ccd10cc96c7ab29791a7dd236bd94021f31eec7ba3d46a74aa1c24"
 dependencies = [
  "atoi",
- "base64",
+ "base64 0.21.7",
  "bitflags 2.4.2",
  "byteorder",
  "crc",
@@ -4835,7 +4898,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "axum 0.6.20",
- "base64",
+ "base64 0.21.7",
  "bytes",
  "futures-core",
  "futures-util",
@@ -4867,7 +4930,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "axum 0.6.20",
- "base64",
+ "base64 0.21.7",
  "bytes",
  "h2 0.3.24",
  "http 0.2.11",
@@ -5664,6 +5727,15 @@ dependencies = [
  "libc",
  "linux-raw-sys 0.4.13",
  "rustix 0.38.30",
+]
+
+[[package]]
+name = "yaml-rust"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+dependencies = [
+ "linked-hash-map",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -170,6 +170,7 @@ tar = { workspace = true }
 walkdir = { workspace = true }
 
 [dev-dependencies]
+insta = { version = "1.34.0", features = ["ron"] }
 tracing-test = { version = "0.2", features = ["no-env-filter"] }
 
 [build-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,7 @@ serde = { version = "1", features = ["derive"] }
 serde_with = {version="3.4.0"}
 serde_yaml = { version = "0.9" }
 serde_json = { version = "1" }
+simd-json = { version = "0.13", features = ["serde_impl", "runtime-detection", "value-no-dup-keys"] }
 smart-default = { version = "0.7" }
 sled = { version = "0.34" }
 sqlx = { version = "0.7", features = [ "runtime-tokio", "tls-native-tls", "postgres", "macros", "time", "json" ] }
@@ -143,6 +144,7 @@ serde = { workspace = true }
 serde_with = { workspace = true }
 serde_yaml = { workspace = true }
 serde_json = { workspace = true }
+simd-json = { workspace = true }
 sled = { workspace = true }
 smart-default = { workspace = true }
 sqlx = { workspace = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,12 @@ askama = { version = "0.12" }
 axum = { version = "0.7", features = ["multipart", "macros"] }
 axum-otel-metrics = "0.8"
 axum-tracing-opentelemetry = "0.16"
+backtrace = "0.3"
 base64 = "0.21.0"
+bincode = "1.3"
 bollard = { version = "0.15", features = ["buildkit"] }
 bytes = "1"
+byteorder = "1"
 clap = { version = "4", features = ["derive"] }
 figment = { version = "0.10", features = ["yaml", "env"] }
 flexbuffers = { version = "2.0" }
@@ -47,6 +50,7 @@ opentelemetry-stdout = { version = "0.2", features = [
     "metrics",
     "trace",
 ] }
+paste = { version = "1.0" }
 pgvector = { version = "0.3", features = ["sqlx"] }
 prost = { version = "0.12" }
 prost-types = { version = "0.12" }
@@ -64,6 +68,7 @@ serde_with = {version="3.4.0"}
 serde_yaml = { version = "0.9" }
 serde_json = { version = "1" }
 smart-default = { version = "0.7" }
+sled = { version = "0.34" }
 sqlx = { version = "0.7", features = [ "runtime-tokio", "tls-native-tls", "postgres", "macros", "time", "json" ] }
 strum = { version = "0.25", features = ["derive"] }
 thiserror = "1"
@@ -97,7 +102,9 @@ axum = { workspace = true }
 axum-otel-metrics = { workspace = true }
 axum-tracing-opentelemetry = { workspace = true }
 base64 = { workspace = true }
+bincode = { workspace = true }
 bollard = { workspace = true }
+byteorder = { workspace = true }
 bytes = { workspace = true }
 clap = { workspace = true }
 figment = { workspace = true }
@@ -119,6 +126,7 @@ opentelemetry_sdk = { workspace = true }
 opentelemetry-semantic-conventions = { workspace = true }
 opentelemetry-otlp = { workspace = true }
 opentelemetry-stdout = { workspace = true }
+paste = { workspace = true }
 pgvector = { workspace = true }
 prost = { workspace = true }
 prost-types = { workspace = true }
@@ -135,6 +143,7 @@ serde = { workspace = true }
 serde_with = { workspace = true }
 serde_yaml = { workspace = true }
 serde_json = { workspace = true }
+sled = { workspace = true }
 smart-default = { workspace = true }
 sqlx = { workspace = true }
 strum = { workspace = true }

--- a/local_server_config.yaml
+++ b/local_server_config.yaml
@@ -76,3 +76,7 @@ cache:
 
   memory:
     max_size: 1000000
+
+sled:
+  # provide a path to the sled storage
+  path: /tmp/indexify-sled

--- a/sample_config.yaml
+++ b/sample_config.yaml
@@ -76,3 +76,6 @@ cache:
 
   memory:
     max_size: 1000000
+
+sled:
+  path: /tmp/indexify-sled

--- a/src/coordinator.rs
+++ b/src/coordinator.rs
@@ -360,9 +360,9 @@ mod tests {
     use crate::{
         indexify_coordinator::ContentMetadata,
         internal_api::ExtractorBinding,
-        server_config::ServerConfig,
+        server_config::{ServerConfig, ServerPeer, SledConfig},
         state::App,
-        test_util::db_utils::{mock_extractor, DEFAULT_TEST_EXTRACTOR, DEFAULT_TEST_REPOSITORY},
+        test_util::db_utils::{mock_extractor, DEFAULT_TEST_EXTRACTOR, DEFAULT_TEST_REPOSITORY}, /* coordinator_service::CoordinatorServer, */
     };
 
     #[tokio::test]
@@ -468,4 +468,76 @@ mod tests {
         assert_eq!(0, shared_state.unassigned_tasks().await?.len());
         Ok(())
     }
+
+    // // mark this test to skip
+    // #[tokio::test]
+    // #[tracing_test::traced_test]
+    // #[ignore]
+    // async fn test_form_raft_cluster() -> Result<(), anyhow::Error> {
+    //     // create a random str for the data dirs
+    //     let append = nanoid::nanoid!();
+    //     // run multiple coordinators at multiple ports
+    //     let ports = vec![8950, 8951];
+    //     let mut config_list = Vec::new();
+    //     let sled_data_dirs = vec![
+    //         format!("/tmp/indexify/raft/{}/0", append),
+    //         format!("/tmp/indexify/raft/{}/1", append),
+    //     ];
+
+    //     // iterate over the ports and data dirs to create the configs
+    //     for (i, port) in ports.iter().enumerate() {
+    //         let node_id: u64 = i.try_into().unwrap();
+    //         let config = ServerConfig {
+    //             node_id,
+    //             coordinator_port: *port,
+    //             raft_port: *port,
+    //             peers: ports
+    //                 .iter()
+    //                 .enumerate()
+    //                 .filter(|(j, _)| *j != i)
+    //                 .map(|(_, p)| ServerPeer {
+    //                     node_id: (*p).try_into().unwrap(),
+    //                     addr: format!("localhost:{}", p),
+    //                 })
+    //                 .collect(),
+    //             sled: SledConfig {
+    //                 path: Some(sled_data_dirs[i].clone()),
+    //             },
+    //             ..Default::default()
+    //         };
+    //         config_list.push(Arc::new(config));
+    //     }
+
+    //     let mut coordinators = Vec::new();
+
+    //     for config in config_list {
+    //         let app = CoordinatorServer::new(config.clone())
+    //             .await
+    //             .expect("failed to create coordinator server");
+    //         coordinators.push(app);
+    //     }
+
+    //     // run all the coordinators in tokio
+    //     let mut handles = Vec::new();
+    //     // only start the first two
+    //     for (i, coordinator) in coordinators
+    //     .into_iter().enumerate().take(2) {
+    //         let ports = ports.clone();
+    //         let handle = tokio::spawn(async move {
+    //             coordinator.run().await.expect(format!("failed to run
+    // coordinator: {} at port {}", i, ports.clone()[i]).as_str());
+    //             Ok::<(), anyhow::Error>(())
+    //         });
+    //         handles.push(handle);
+
+    //         // wait a few seconds for the coordinator to start
+    //         tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+    //     }
+
+    //     for handle in handles {
+    //         handle.await?;
+    //     }
+
+    //     Ok(())
+    // }
 }

--- a/src/internal_api.rs
+++ b/src/internal_api.rs
@@ -64,13 +64,13 @@ impl From<indexify_coordinator::Index> for Index {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct EmbeddingSchema {
     pub dim: usize,
     pub distance: String,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub enum OutputSchema {
     #[serde(rename = "embedding")]
     Embedding(EmbeddingSchema),
@@ -78,7 +78,7 @@ pub enum OutputSchema {
     Attributes(serde_json::Value),
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct ExtractorDescription {
     pub name: String,
     pub description: String,
@@ -282,7 +282,7 @@ impl From<TaskOutcome> for indexify_coordinator::TaskOutcome {
     }
 }
 
-#[derive(Serialize, Debug, Deserialize, Clone)]
+#[derive(Serialize, Debug, Deserialize, Clone, PartialEq)]
 pub struct Task {
     pub id: String,
     pub extractor: String,
@@ -330,7 +330,7 @@ impl TryFrom<indexify_coordinator::Task> for Task {
     }
 }
 
-#[derive(Serialize, Debug, Deserialize, Display, Clone)]
+#[derive(Serialize, Debug, Deserialize, Display, Clone, PartialEq)]
 pub enum ExtractionEventPayload {
     ExtractorBindingAdded {
         repository: String,
@@ -341,7 +341,7 @@ pub enum ExtractionEventPayload {
     },
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct ExtractionEvent {
     pub id: String,
     pub repository: String,
@@ -396,7 +396,7 @@ impl From<ExtractorBinding> for indexify_coordinator::ExtractorBinding {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct ContentMetadata {
     pub id: String,
     pub parent_id: String,
@@ -443,7 +443,7 @@ impl TryFrom<indexify_coordinator::ContentMetadata> for ContentMetadata {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct ExecutorMetadata {
     pub id: String,
     pub last_seen: u64,

--- a/src/server_config.rs
+++ b/src/server_config.rs
@@ -319,6 +319,20 @@ pub struct ServerCacheConfig {
     pub memory: Option<MemoryConfig>,
 }
 
+/// SledConfig is a struct that contains the configuration for the sled
+/// database, which is used for Raft storage.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SledConfig {
+    /// path is the path to the sled database.
+    pub path: Option<String>,
+}
+
+impl Default for SledConfig {
+    fn default() -> Self {
+        Self { path: None }
+    }
+}
+
 /// ServerCacheBackend is an enum that represents the different cache backends
 /// supported by the server.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -363,6 +377,8 @@ pub struct ServerConfig {
     /// cache is the configuration for the server-side cache.
     #[serde(default)]
     pub cache: ServerCacheConfig,
+    #[serde(default)]
+    pub sled: SledConfig,
 }
 
 impl Default for ServerConfig {
@@ -389,6 +405,7 @@ impl Default for ServerConfig {
                 node_id: 0,
             }],
             cache: ServerCacheConfig::default(),
+            sled: SledConfig::default(),
         }
     }
 }

--- a/src/state/store/error.rs
+++ b/src/state/store/error.rs
@@ -1,0 +1,195 @@
+use std::{
+    backtrace::Backtrace,
+    error::Error,
+    fmt::{Display, Formatter},
+    string::FromUtf8Error,
+};
+
+use anyerror::AnyError;
+use openraft::{StorageError, StorageIOError};
+
+use super::SledStoreTree;
+use crate::state::NodeId;
+
+pub type StoreResult<T> = Result<T, StoreError>;
+
+#[derive(Debug, strum::Display, Clone, Copy)]
+#[strum(serialize_all = "title_case")]
+pub enum StoreErrorKind {
+    ParseError,
+    IoError,
+    Uncategorized,
+
+    // raft errors
+    ReadStateMachine,
+    WriteStateMachine,
+    ReadSnapshot,
+    WriteSnapshot,
+    ReadVote,
+    WriteVote,
+    ReadLogs,
+    WriteLogs,
+}
+
+impl StoreErrorKind {
+    pub fn build_with_source(&self, msg: impl Into<String>, source: Box<dyn Error>) -> StoreError {
+        StoreError::new(self.clone(), msg).with_source(source)
+    }
+
+    pub fn build_with_tree(
+        &self,
+        msg: impl Into<String>,
+        source: Box<dyn Error>,
+        tree: SledStoreTree,
+    ) -> StoreError {
+        StoreError::new(self.clone(), msg)
+            .with_source(source)
+            .with_tree(tree)
+    }
+
+    pub fn build_with_tree_and_key(
+        &self,
+        msg: impl Into<String>,
+        source: Box<dyn Error>,
+        tree: SledStoreTree,
+        key: impl Into<String>,
+    ) -> StoreError {
+        StoreError::new(self.clone(), msg)
+            .with_source(source)
+            .with_tree(tree)
+            .with_key(key)
+    }
+}
+
+#[derive(Debug)]
+pub struct StoreError {
+    kind: StoreErrorKind,
+    msg: String,
+    source: Option<Box<dyn Error + 'static>>,
+    tree: Option<SledStoreTree>,
+    key: Option<String>,
+    backtrace: Option<Backtrace>,
+}
+
+impl StoreError {
+    pub fn new(kind: StoreErrorKind, msg: impl Into<String>) -> Self {
+        StoreError {
+            kind,
+            msg: msg.into(),
+            source: None,
+            tree: None,
+            key: None,
+            backtrace: Some(Backtrace::capture()),
+        }
+    }
+
+    pub fn with_source(mut self, source: Box<dyn Error>) -> Self {
+        self.source = Some(source);
+        self
+    }
+
+    pub fn with_tree(mut self, tree: SledStoreTree) -> Self {
+        self.tree = Some(tree);
+        self
+    }
+
+    pub fn with_key(mut self, key: impl Into<String>) -> Self {
+        self.key = Some(key.into());
+        self
+    }
+}
+
+impl From<AnyError> for StoreError {
+    fn from(e: AnyError) -> Self {
+        StoreError {
+            kind: StoreErrorKind::Uncategorized,
+            msg: format!("{}", e),
+            source: Some(Box::new(e)),
+            tree: None,
+            key: None,
+            backtrace: Some(Backtrace::capture()),
+        }
+    }
+}
+
+impl Error for StoreError {}
+
+impl From<StoreError> for AnyError {
+    fn from(e: StoreError) -> Self {
+        AnyError::new(&e).add_context(|| "sled store error")
+    }
+}
+
+impl Display for StoreError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "sled store {} error: {}", self.kind, self.msg)?;
+        if let Some(source) = &self.source {
+            write!(f, ": {}", source)?;
+        }
+        if let Some(tree) = &self.tree {
+            write!(f, " (tree: {})", tree)?;
+        }
+        if let Some(key) = &self.key {
+            write!(f, " (key: {})", key)?;
+        }
+        if let Some(backtrace) = &self.backtrace {
+            write!(f, "\nBacktrace:\n{:?}", backtrace)?;
+        }
+        Ok(())
+    }
+}
+
+impl From<FromUtf8Error> for StoreError {
+    fn from(e: FromUtf8Error) -> Self {
+        StoreError {
+            kind: StoreErrorKind::ParseError,
+            msg: format!("{}", e),
+            source: Some(Box::new(e)),
+            tree: None,
+            key: None,
+            backtrace: Some(Backtrace::capture()),
+        }
+    }
+}
+
+impl From<sled::Error> for StoreError {
+    fn from(e: sled::Error) -> Self {
+        StoreError {
+            kind: StoreErrorKind::IoError,
+            msg: format!("{}", e),
+            source: Some(Box::new(e)),
+            tree: None,
+            key: None,
+            backtrace: Some(Backtrace::capture()),
+        }
+    }
+}
+
+impl From<StoreError> for StorageIOError<NodeId> {
+    fn from(e: StoreError) -> Self {
+        match e.kind {
+            StoreErrorKind::ReadStateMachine => StorageIOError::read_state_machine(&e),
+            StoreErrorKind::WriteStateMachine => StorageIOError::write_state_machine(&e),
+            StoreErrorKind::ReadSnapshot => StorageIOError::read(&e),
+            StoreErrorKind::WriteSnapshot => StorageIOError::write(&e),
+            StoreErrorKind::ReadVote => StorageIOError::read_vote(&e),
+            StoreErrorKind::WriteVote => StorageIOError::write_vote(&e),
+            StoreErrorKind::ReadLogs => StorageIOError::read_logs(&e),
+            StoreErrorKind::WriteLogs => StorageIOError::write_logs(&e),
+
+            // other type transformations aren't supported
+            _ => {
+                tracing::error!("unsupported sled store error: {}", e);
+                // cast to a generic read error
+                StorageIOError::read(&e)
+            }
+        }
+    }
+}
+
+impl From<StoreError> for StorageError<NodeId> {
+    fn from(e: StoreError) -> Self {
+        let io_error: StorageIOError<NodeId> = e.into();
+        io_error.into()
+    }
+}

--- a/src/state/store/impl_sledstoreable.rs
+++ b/src/state/store/impl_sledstoreable.rs
@@ -1,0 +1,562 @@
+use std::{
+    collections::{BTreeMap, BTreeSet, HashMap, HashSet},
+    error::Error,
+    fmt::Debug,
+    string::ToString,
+};
+
+use openraft::{
+    BasicNode,
+    Entry,
+    LeaderId,
+    LogId,
+    Membership,
+    SnapshotMeta,
+    StoredMembership,
+    Vote,
+};
+use serde::{Deserialize, Serialize};
+use sled::IVec;
+
+use super::{NodeId, TypeConfig, *};
+use crate::internal_api::{
+    ContentMetadata,
+    ExecutorMetadata,
+    ExtractionEvent,
+    ExtractionEventPayload,
+    ExtractorBinding,
+    ExtractorDescription,
+    Index,
+    OutputSchema,
+    Task,
+};
+
+pub trait SledStoreable: Serialize + for<'de> Deserialize<'de> + SledStoreableTestFactory {
+    fn to_saveable_value(&self) -> Result<IVec, Box<dyn Error>> {
+        let mut s = flexbuffers::FlexbufferSerializer::new();
+        self.serialize(&mut s)?;
+        Ok(s.take_buffer().into())
+    }
+    fn load_from_sled_value(raw_value: IVec) -> Result<Self, Box<dyn Error>>
+    where
+        Self: Sized,
+    {
+        // convert Vec<u8> to &[u8]
+        let raw_value = raw_value.to_vec();
+        let raw_value_slice = raw_value.as_slice();
+
+        let r = flexbuffers::Reader::get_root(raw_value_slice).map_err(|e| {
+            sled::Error::Io(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                format!(
+                    "Couldn't read a FlexBuffer bytestream from the cache: {}",
+                    e
+                ),
+            ))
+        })?;
+
+        let value = Self::deserialize(r).map_err(|e| {
+            sled::Error::Io(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                format!("Deserializer would not deserialize using FlexBuffer: {}", e),
+            ))
+        })?;
+        Ok(value)
+    }
+}
+
+impl SledStoreable for Vote<NodeId> {}
+
+impl SledStoreable for StoredSnapshot {
+    // use bincode because StoredSnapshot.meta contains a BTreeMap
+    fn to_saveable_value(&self) -> Result<IVec, Box<dyn Error>> {
+        let serialized_data = bincode::serialize(self)?;
+        Ok(serialized_data.into())
+    }
+
+    fn load_from_sled_value(raw_value: IVec) -> Result<Self, Box<dyn Error>>
+    where
+        Self: Sized,
+    {
+        let deserialized_data = bincode::deserialize(&raw_value)?;
+        Ok(deserialized_data)
+    }
+}
+
+/// Flexbuffer doesn't support serializing BTreeMaps, so we need to convert them
+/// to HashMaps using bincode instead.
+impl SledStoreable for Entry<TypeConfig> {
+    fn to_saveable_value(&self) -> Result<IVec, Box<dyn Error>> {
+        let serialized_data = bincode::serialize(self)?;
+        Ok(serialized_data.into())
+    }
+
+    fn load_from_sled_value(raw_value: IVec) -> Result<Self, Box<dyn Error>>
+    where
+        Self: Sized,
+    {
+        let deserialized_data = bincode::deserialize(&raw_value)?;
+        Ok(deserialized_data)
+    }
+}
+
+// all the state machine values can be stored in Sled
+impl SledStoreable for LogId<NodeId> {}
+impl SledStoreable for StoredMembership<NodeId, BasicNode> {
+    fn to_saveable_value(&self) -> Result<IVec, Box<dyn Error>> {
+        let serialized_data = bincode::serialize(self)?;
+        Ok(serialized_data.into())
+    }
+
+    fn load_from_sled_value(raw_value: IVec) -> Result<Self, Box<dyn Error>>
+    where
+        Self: Sized,
+    {
+        let deserialized_data = bincode::deserialize(&raw_value)?;
+        Ok(deserialized_data)
+    }
+}
+impl SledStoreable for SnapshotIndex {}
+
+impl SledStoreable for HashMap<ExecutorId, u64> {}
+impl SledStoreable for HashMap<ExecutorId, ExecutorMetadata> {}
+impl SledStoreable for HashMap<TaskId, Task> {}
+impl SledStoreable for HashMap<ExtractionEventId, ExtractionEvent> {}
+impl SledStoreable for HashMap<ContentId, ContentMetadata> {}
+impl SledStoreable for HashMap<String, HashSet<String>> {}
+impl SledStoreable for HashMap<RepositoryId, HashSet<ExtractorBinding>> {}
+impl SledStoreable for HashMap<ExtractorName, Vec<ExecutorId>> {}
+impl SledStoreable for HashMap<ExtractorName, ExtractorDescription> {}
+impl SledStoreable for HashSet<String> {}
+impl SledStoreable for HashMap<RepositoryId, HashSet<Index>> {}
+impl SledStoreable for HashMap<String, Index> {}
+impl SledStoreable for StateMachine {}
+impl SledStoreable for SnapshotMeta<u64, BasicNode> {
+    fn to_saveable_value(&self) -> Result<IVec, Box<dyn Error>> {
+        let serialized_data = bincode::serialize(self)?;
+        Ok(serialized_data.into())
+    }
+
+    fn load_from_sled_value(raw_value: IVec) -> Result<Self, Box<dyn Error>>
+    where
+        Self: Sized,
+    {
+        let deserialized_data = bincode::deserialize(&raw_value)?;
+        Ok(deserialized_data)
+    }
+}
+
+// factories
+impl SledStoreableTestFactory for LogId<NodeId> {
+    fn spawn_instance_for_store_test() -> Self {
+        LogId {
+            leader_id: LeaderId::new(0, 0),
+            index: 0,
+        }
+    }
+}
+
+impl SledStoreableTestFactory for StoredMembership<NodeId, BasicNode> {
+    fn spawn_instance_for_store_test() -> Self {
+        StoredMembership::new(
+            Some(LogId::spawn_instance_for_store_test()),
+            Membership::spawn_instance_for_store_test(),
+        )
+    }
+}
+
+impl SledStoreableTestFactory for Membership<NodeId, BasicNode> {
+    fn spawn_instance_for_store_test() -> Self {
+        Membership::new(
+            vec![{
+                let mut config_set = BTreeSet::new();
+                config_set.insert(0);
+                config_set
+            }],
+            {
+                let mut node_set = BTreeMap::new();
+                node_set.insert(0, BasicNode::new("localhost:8080".to_string()));
+            },
+        )
+    }
+}
+
+pub trait SledStoreableTestFactory {
+    fn spawn_instance_for_store_test() -> Self;
+}
+
+impl SledStoreableTestFactory for Vote<NodeId> {
+    fn spawn_instance_for_store_test() -> Self {
+        Vote {
+            leader_id: LeaderId::new(0, 0),
+            committed: true,
+        }
+    }
+}
+
+impl SledStoreableTestFactory for StoredSnapshot {
+    fn spawn_instance_for_store_test() -> Self {
+        StoredSnapshot {
+            meta: SnapshotMeta::spawn_instance_for_store_test(),
+            data: vec![0x01, 0x02, 0x03, 0x04, 0x05, 0x06],
+        }
+    }
+}
+
+impl SledStoreableTestFactory for SnapshotMeta<u64, BasicNode> {
+    fn spawn_instance_for_store_test() -> Self {
+        SnapshotMeta {
+            last_log_id: Some(LogId::spawn_instance_for_store_test()),
+            last_membership: StoredMembership::spawn_instance_for_store_test(),
+            snapshot_id: "test".to_string(),
+        }
+    }
+}
+
+impl SledStoreableTestFactory for Entry<TypeConfig> {
+    fn spawn_instance_for_store_test() -> Self {
+        Entry {
+            log_id: LogId::spawn_instance_for_store_test(),
+            payload: openraft::EntryPayload::Membership(Membership::spawn_instance_for_store_test()),
+        }
+    }
+}
+
+impl SledStoreableTestFactory for SnapshotIndex {
+    fn spawn_instance_for_store_test() -> Self {
+        SnapshotIndex(0)
+    }
+}
+
+impl SledStoreableTestFactory for StateMachine {
+    fn spawn_instance_for_store_test() -> Self {
+        StateMachine::default()
+    }
+}
+
+impl SledStoreableTestFactory for HashMap<ExecutorId, u64> {
+    fn spawn_instance_for_store_test() -> Self {
+        let mut hm = HashMap::new();
+        hm.insert("test".to_string(), 0);
+        hm
+    }
+}
+
+impl SledStoreableTestFactory for HashMap<ExecutorId, ExecutorMetadata> {
+    fn spawn_instance_for_store_test() -> Self {
+        let mut hm = HashMap::new();
+        hm.insert(
+            "test".to_string(),
+            ExecutorMetadata::spawn_instance_for_store_test(),
+        );
+        hm
+    }
+}
+
+impl SledStoreableTestFactory for HashMap<TaskId, Task> {
+    fn spawn_instance_for_store_test() -> Self {
+        let mut hm = HashMap::new();
+        hm.insert("test".to_string(), Task::spawn_instance_for_store_test());
+        hm
+    }
+}
+
+impl SledStoreableTestFactory for HashSet<String> {
+    fn spawn_instance_for_store_test() -> Self {
+        let mut hs = HashSet::new();
+        hs.insert("test".to_string());
+        hs
+    }
+}
+
+impl SledStoreableTestFactory for HashMap<ExtractionEventId, ExtractionEvent> {
+    fn spawn_instance_for_store_test() -> Self {
+        let mut hm = HashMap::new();
+        hm.insert(
+            "test".to_string(),
+            ExtractionEvent::spawn_instance_for_store_test(),
+        );
+        hm
+    }
+}
+
+impl SledStoreableTestFactory for HashMap<ContentId, ContentMetadata> {
+    fn spawn_instance_for_store_test() -> Self {
+        let mut hm = HashMap::new();
+        hm.insert(
+            "test".to_string(),
+            ContentMetadata::spawn_instance_for_store_test(),
+        );
+        hm
+    }
+}
+
+fn test_json_value() -> serde_json::Value {
+    serde_json::from_str(
+        r#"
+        {
+            "name": "test",
+            "description": "test",
+            "input_params": [],
+            "outputs": []
+        }
+        "#,
+    )
+    .unwrap()
+}
+
+impl SledStoreableTestFactory for ExtractorDescription {
+    fn spawn_instance_for_store_test() -> Self {
+        ExtractorDescription {
+            name: "test".to_string(),
+            description: "test".to_string(),
+            input_params: test_json_value(),
+            outputs: {
+                let mut outputs = HashMap::new();
+                outputs.insert(
+                    "test".to_string(),
+                    OutputSchema::Attributes(test_json_value()),
+                );
+                outputs
+            },
+        }
+    }
+}
+
+impl SledStoreableTestFactory for ExecutorMetadata {
+    fn spawn_instance_for_store_test() -> Self {
+        ExecutorMetadata {
+            id: "test".to_string(),
+            last_seen: 0,
+            addr: "localhost:8080".to_string(),
+            extractor: ExtractorDescription::spawn_instance_for_store_test(),
+        }
+    }
+}
+
+impl SledStoreableTestFactory for Task {
+    fn spawn_instance_for_store_test() -> Self {
+        Task {
+            id: "test".to_string(),
+            extractor: "test".to_string(),
+            extractor_binding: "test".to_string(),
+            output_index_table_mapping: HashMap::new(),
+            repository: "test".to_string(),
+            content_metadata: ContentMetadata::spawn_instance_for_store_test(),
+            input_params: test_json_value(),
+            outcome: crate::internal_api::TaskOutcome::Success,
+        }
+    }
+}
+
+impl SledStoreableTestFactory for ContentMetadata {
+    fn spawn_instance_for_store_test() -> Self {
+        ContentMetadata {
+            id: "test_id".to_string(),
+            parent_id: "test_parent_id".to_string(),
+            repository: "test_repository".to_string(),
+            name: "test_name".to_string(),
+            content_type: "test_content_type".to_string(),
+            labels: {
+                let mut labels = HashMap::new();
+                labels.insert("key1".to_string(), "value1".to_string());
+                labels.insert("key2".to_string(), "value2".to_string());
+                labels
+            },
+            storage_url: "http://example.com/test_url".to_string(),
+            created_at: 1234567890, // example timestamp
+            source: "test_source".to_string(),
+        }
+    }
+}
+
+impl SledStoreableTestFactory for ExtractionEvent {
+    fn spawn_instance_for_store_test() -> Self {
+        ExtractionEvent {
+            id: "test_id".to_string(),
+            repository: "test_repository".to_string(),
+            payload: ExtractionEventPayload::CreateContent {
+                content: ContentMetadata::spawn_instance_for_store_test(),
+            },
+            created_at: 1234567890,
+            processed_at: Some(1234567890),
+        }
+    }
+}
+
+impl SledStoreableTestFactory for ExtractorBinding {
+    fn spawn_instance_for_store_test() -> Self {
+        ExtractorBinding {
+            id: "test_id".to_string(),
+            name: "test_name".to_string(),
+            repository: "test_repository".to_string(),
+            extractor: "test_extractor".to_string(),
+            filters: {
+                let mut filters = HashMap::new();
+                filters.insert("key1".to_string(), "value1".to_string());
+                filters.insert("key2".to_string(), "value2".to_string());
+                filters
+            },
+            input_params: test_json_value(),
+            output_index_name_mapping: HashMap::new(),
+            index_name_table_mapping: HashMap::new(),
+            content_source: "test_content_source".to_string(),
+        }
+    }
+}
+
+impl SledStoreableTestFactory for Index {
+    fn spawn_instance_for_store_test() -> Self {
+        Index {
+            repository: "test_repository".to_string(),
+            name: "test_name".to_string(),
+            table_name: "test_table_name".to_string(),
+            schema: "test_schema".to_string(),
+            extractor_binding: "test_extractor_binding".to_string(),
+            extractor: "test_extractor".to_string(),
+        }
+    }
+}
+
+impl SledStoreableTestFactory for HashMap<String, Index> {
+    fn spawn_instance_for_store_test() -> Self {
+        let mut hm = HashMap::new();
+        hm.insert("test".to_string(), Index::spawn_instance_for_store_test());
+        hm
+    }
+}
+
+impl SledStoreableTestFactory for HashMap<ExtractorName, ExtractorDescription> {
+    fn spawn_instance_for_store_test() -> Self {
+        let mut hm = HashMap::new();
+        hm.insert(
+            "test".to_string(),
+            ExtractorDescription::spawn_instance_for_store_test(),
+        );
+        hm
+    }
+}
+
+impl SledStoreableTestFactory for HashMap<ExtractorName, Vec<ExecutorId>> {
+    fn spawn_instance_for_store_test() -> Self {
+        let mut hm = HashMap::new();
+        hm.insert("test".to_string(), vec!["test".to_string()]);
+        hm
+    }
+}
+
+impl SledStoreableTestFactory for HashMap<RepositoryId, HashSet<ExtractorBinding>> {
+    fn spawn_instance_for_store_test() -> Self {
+        let mut hm = HashMap::new();
+        hm.insert("test".to_string(), {
+            let mut hs = HashSet::new();
+            hs.insert(ExtractorBinding::spawn_instance_for_store_test());
+            hs
+        });
+        hm
+    }
+}
+
+impl SledStoreableTestFactory for HashMap<RepositoryId, HashSet<Index>> {
+    fn spawn_instance_for_store_test() -> Self {
+        let mut hm = HashMap::new();
+        hm.insert("test".to_string(), {
+            let mut hs = HashSet::new();
+            hs.insert(Index::spawn_instance_for_store_test());
+            hs
+        });
+        hm
+    }
+}
+
+impl SledStoreableTestFactory for HashMap<String, HashSet<String>> {
+    fn spawn_instance_for_store_test() -> Self {
+        let mut hm = HashMap::new();
+        hm.insert("test".to_string(), {
+            let mut hs = HashSet::new();
+            hs.insert("test".to_string());
+            hs
+        });
+        hm
+    }
+}
+
+trait SledTestObject: SledStoreable + SledStoreableTestFactory + Debug + PartialEq {}
+
+#[allow(unused_macros)]
+macro_rules! test_sled_storeable {
+    ($type:ty) => {
+        paste::item! {
+            #[test]
+            fn [<test_sled_storeable_ $type:snake>]() {
+                let instance: $type = <$type>::spawn_instance_for_store_test();
+                let serialized = instance.to_saveable_value().unwrap();
+
+                // Save to sled
+                let tree = sled::Config::new().temporary(true).open().unwrap();
+                tree.insert("test", &serialized).unwrap();
+
+                // Load from sled
+                let retrieved = tree.get("test").unwrap().unwrap();
+                assert_eq!(serialized, retrieved);
+
+                // Deserialize
+                let deserialized = <$type>::load_from_sled_value(serialized.into()).unwrap();
+                assert_eq!(instance, deserialized);
+            }
+        }
+    };
+}
+
+#[cfg(test)]
+mod sled_tests {
+    use super::*;
+
+    type TestLogId = LogId<NodeId>;
+    type TestStoredMembership = StoredMembership<NodeId, BasicNode>;
+    type TestExecutorHealthChecks = HashMap<ExecutorId, u64>;
+    type TestExecutors = HashMap<ExecutorId, ExecutorMetadata>;
+    type TestTasks = HashMap<TaskId, Task>;
+    type TestUnassignedTasks = HashSet<TaskId>;
+    type TestTaskAssignments = HashMap<ExecutorId, HashSet<TaskId>>;
+    type TestExtractionEvents = HashMap<ExtractionEventId, ExtractionEvent>;
+    type TestUnprocessedExtractionEvents = HashSet<ExtractionEventId>;
+    type TestContentTable = HashMap<ContentId, ContentMetadata>;
+    type TestContentRepositoryTable = HashMap<RepositoryId, HashSet<ContentId>>;
+    type TestBindingsTable = HashMap<RepositoryId, HashSet<ExtractorBinding>>;
+    type TestExtractorExecutorsTable = HashMap<ExtractorName, Vec<ExecutorId>>;
+    type TestExtractors = HashMap<ExtractorName, ExtractorDescription>;
+    type TestRepositories = HashSet<String>;
+    type TestRepositoryExtractors = HashMap<RepositoryId, HashSet<Index>>;
+    type TestIndexTable = HashMap<String, Index>;
+    type TestStateMachine = StateMachine;
+    type TestVoteNodeId = Vote<NodeId>;
+    type TestStoredSnapshot = StoredSnapshot;
+    type TestEntryTypeConfig = Entry<TypeConfig>;
+    type TestSnapshotIndex = SnapshotIndex;
+    type TestSnapshotMeta = SnapshotMeta<u64, BasicNode>;
+
+    test_sled_storeable!(TestStateMachine);
+    test_sled_storeable!(TestLogId);
+    test_sled_storeable!(TestStoredMembership);
+    test_sled_storeable!(TestExecutorHealthChecks);
+    test_sled_storeable!(TestExecutors);
+    test_sled_storeable!(TestTasks);
+    test_sled_storeable!(TestUnassignedTasks);
+    test_sled_storeable!(TestTaskAssignments);
+    test_sled_storeable!(TestExtractionEvents);
+    test_sled_storeable!(TestUnprocessedExtractionEvents);
+    test_sled_storeable!(TestContentTable);
+    test_sled_storeable!(TestContentRepositoryTable);
+    test_sled_storeable!(TestBindingsTable);
+    test_sled_storeable!(TestExtractorExecutorsTable);
+    test_sled_storeable!(TestExtractors);
+    test_sled_storeable!(TestRepositories);
+    test_sled_storeable!(TestRepositoryExtractors);
+    test_sled_storeable!(TestIndexTable);
+    test_sled_storeable!(TestVoteNodeId);
+    test_sled_storeable!(TestStoredSnapshot);
+    test_sled_storeable!(TestSnapshotMeta);
+    test_sled_storeable!(TestEntryTypeConfig);
+    test_sled_storeable!(TestSnapshotIndex);
+}

--- a/src/state/store/impl_sledstoreable.rs
+++ b/src/state/store/impl_sledstoreable.rs
@@ -131,21 +131,21 @@ impl SledStoreable for HashSet<String> {}
 impl SledStoreable for HashMap<RepositoryId, HashSet<Index>> {}
 impl SledStoreable for HashMap<String, Index> {}
 impl SledStoreable for StateMachine {
-	// can't use bincode: contains JSON Value
-	// can't use flexbuffers: contains BTreeMap
-	// use serde_json
-	fn to_saveable_value(&self) -> Result<IVec, Box<dyn Error>> {
-		let serialized_data = serde_json::to_vec(self)?;
-		Ok(serialized_data.into())
-	}
+    // can't use bincode: contains JSON Value
+    // can't use flexbuffers: contains BTreeMap
+    // use serde_json
+    fn to_saveable_value(&self) -> Result<IVec, Box<dyn Error>> {
+        let serialized_data = serde_json::to_vec(self)?;
+        Ok(serialized_data.into())
+    }
 
-	fn load_from_sled_value(raw_value: IVec) -> Result<Self, Box<dyn Error>>
-	where
-		Self: Sized,
-	{
-		let deserialized_data = serde_json::from_slice(&raw_value)?;
-		Ok(deserialized_data)
-	}
+    fn load_from_sled_value(raw_value: IVec) -> Result<Self, Box<dyn Error>>
+    where
+        Self: Sized,
+    {
+        let deserialized_data = serde_json::from_slice(&raw_value)?;
+        Ok(deserialized_data)
+    }
 }
 impl SledStoreable for SnapshotMeta<u64, BasicNode> {
     fn to_saveable_value(&self) -> Result<IVec, Box<dyn Error>> {
@@ -164,26 +164,34 @@ impl SledStoreable for SnapshotMeta<u64, BasicNode> {
 
 // factories
 impl SledStoreableTestFactory for StateMachine {
-	fn spawn_instance_for_store_test() -> Self {
-		StateMachine {
-			last_applied_log: Some(LogId::spawn_instance_for_store_test()),
-			last_membership: StoredMembership::spawn_instance_for_store_test(),
-			executors: HashMap::<ExecutorId, ExecutorMetadata>::spawn_instance_for_store_test(),
-			tasks: HashMap::<TaskId, Task>::spawn_instance_for_store_test(),
-			unassigned_tasks: HashSet::<TaskId>::spawn_instance_for_store_test(),
-			task_assignments: HashMap::<ExecutorId, HashSet<TaskId>>::spawn_instance_for_store_test(),
-			extraction_events: HashMap::<ExtractionEventId, ExtractionEvent>::spawn_instance_for_store_test(),
-			unprocessed_extraction_events: HashSet::<ExtractionEventId>::spawn_instance_for_store_test(),
-			content_table: HashMap::<ContentId, ContentMetadata>::spawn_instance_for_store_test(),
-			content_repository_table: HashMap::<RepositoryId, HashSet<ContentId>>::spawn_instance_for_store_test(),
-			bindings_table: HashMap::<RepositoryId, HashSet<ExtractorBinding>>::spawn_instance_for_store_test(),
-			extractor_executors_table: HashMap::<ExtractorName, HashSet<ExecutorId>>::spawn_instance_for_store_test(),
-			extractors: HashMap::<ExtractorName, ExtractorDescription>::spawn_instance_for_store_test(),
-			repositories: HashSet::<String>::spawn_instance_for_store_test(),
-			repository_extractors: HashMap::<RepositoryId, HashSet<Index>>::spawn_instance_for_store_test(),
-			index_table: HashMap::<String, Index>::spawn_instance_for_store_test(),
-		}
-	}
+    fn spawn_instance_for_store_test() -> Self {
+        StateMachine {
+            last_applied_log: Some(LogId::spawn_instance_for_store_test()),
+            last_membership: StoredMembership::spawn_instance_for_store_test(),
+            executors: HashMap::<ExecutorId, ExecutorMetadata>::spawn_instance_for_store_test(),
+            tasks: HashMap::<TaskId, Task>::spawn_instance_for_store_test(),
+            unassigned_tasks: HashSet::<TaskId>::spawn_instance_for_store_test(),
+            task_assignments: HashMap::<ExecutorId, HashSet<TaskId>>::spawn_instance_for_store_test(
+            ),
+            extraction_events:
+                HashMap::<ExtractionEventId, ExtractionEvent>::spawn_instance_for_store_test(),
+            unprocessed_extraction_events:
+                HashSet::<ExtractionEventId>::spawn_instance_for_store_test(),
+            content_table: HashMap::<ContentId, ContentMetadata>::spawn_instance_for_store_test(),
+            content_repository_table:
+                HashMap::<RepositoryId, HashSet<ContentId>>::spawn_instance_for_store_test(),
+            bindings_table:
+                HashMap::<RepositoryId, HashSet<ExtractorBinding>>::spawn_instance_for_store_test(),
+            extractor_executors_table:
+                HashMap::<ExtractorName, HashSet<ExecutorId>>::spawn_instance_for_store_test(),
+            extractors:
+                HashMap::<ExtractorName, ExtractorDescription>::spawn_instance_for_store_test(),
+            repositories: HashSet::<String>::spawn_instance_for_store_test(),
+            repository_extractors:
+                HashMap::<RepositoryId, HashSet<Index>>::spawn_instance_for_store_test(),
+            index_table: HashMap::<String, Index>::spawn_instance_for_store_test(),
+        }
+    }
 }
 
 impl SledStoreableTestFactory for LogId<NodeId> {
@@ -535,10 +543,10 @@ macro_rules! test_sled_storeable {
 
                 // Deserialize
                 let deserialized = <$type>::load_from_sled_value(serialized.into());
-				match deserialized {
-					Ok(deserialized) => assert_eq!(instance, deserialized),
-					Err(e) => panic!("Error deserializing: {}", e),
-				}
+                match deserialized {
+                    Ok(deserialized) => assert_eq!(instance, deserialized),
+                    Err(e) => panic!("Error deserializing: {}", e),
+                }
             }
         }
     };

--- a/src/state/store/impl_sledstoreable.rs
+++ b/src/state/store/impl_sledstoreable.rs
@@ -147,6 +147,29 @@ impl SledStoreable for SnapshotMeta<u64, BasicNode> {
 }
 
 // factories
+impl SledStoreableTestFactory for StateMachine {
+	fn spawn_instance_for_store_test() -> Self {
+		StateMachine {
+			last_applied_log: Some(LogId::spawn_instance_for_store_test()),
+			last_membership: StoredMembership::spawn_instance_for_store_test(),
+			executors: HashMap::<ExecutorId, ExecutorMetadata>::spawn_instance_for_store_test(),
+			tasks: HashMap::<TaskId, Task>::spawn_instance_for_store_test(),
+			unassigned_tasks: HashSet::<TaskId>::spawn_instance_for_store_test(),
+			task_assignments: HashMap::<ExecutorId, HashSet<TaskId>>::spawn_instance_for_store_test(),
+			extraction_events: HashMap::<ExtractionEventId, ExtractionEvent>::spawn_instance_for_store_test(),
+			unprocessed_extraction_events: HashSet::<ExtractionEventId>::spawn_instance_for_store_test(),
+			content_table: HashMap::<ContentId, ContentMetadata>::spawn_instance_for_store_test(),
+			content_repository_table: HashMap::<RepositoryId, HashSet<ContentId>>::spawn_instance_for_store_test(),
+			bindings_table: HashMap::<RepositoryId, HashSet<ExtractorBinding>>::spawn_instance_for_store_test(),
+			extractor_executors_table: HashMap::<ExtractorName, HashSet<ExecutorId>>::spawn_instance_for_store_test(),
+			extractors: HashMap::<ExtractorName, ExtractorDescription>::spawn_instance_for_store_test(),
+			repositories: HashSet::<String>::spawn_instance_for_store_test(),
+			repository_extractors: HashMap::<RepositoryId, HashSet<Index>>::spawn_instance_for_store_test(),
+			index_table: HashMap::<String, Index>::spawn_instance_for_store_test(),
+		}
+	}
+}
+
 impl SledStoreableTestFactory for LogId<NodeId> {
     fn spawn_instance_for_store_test() -> Self {
         LogId {
@@ -225,12 +248,6 @@ impl SledStoreableTestFactory for Entry<TypeConfig> {
 impl SledStoreableTestFactory for SnapshotIndex {
     fn spawn_instance_for_store_test() -> Self {
         SnapshotIndex(0)
-    }
-}
-
-impl SledStoreableTestFactory for StateMachine {
-    fn spawn_instance_for_store_test() -> Self {
-        StateMachine::default()
     }
 }
 

--- a/src/state/store/mod.rs
+++ b/src/state/store/mod.rs
@@ -868,14 +868,15 @@ fn get_current_snapshot_err(e: Box<dyn Error>) -> StorageError<NodeId> {
 
 #[cfg(test)]
 mod test_state_machine_snapshot {
-    use super::*;
-    use super::impl_sledstoreable::SledStoreableTestFactory;
     use insta;
+
+    use super::{impl_sledstoreable::SledStoreableTestFactory, *};
 
     #[test]
     fn test_state_machine_snapshot() {
-        // if this test fails, it means the Schema of StateMachine has changed. It is imperative to ensure the new StateMachine is
-        //   compatible with the old one. This can be done by running raft against the old state machine db
+        // if this test fails, it means the Schema of StateMachine has changed. It is
+        // imperative to ensure the new StateMachine is   compatible with the
+        // old one. This can be done by running raft against the old state machine db
         let sm = StateMachine::spawn_instance_for_store_test();
         insta::with_settings!({sort_maps => true}, {
             insta::assert_ron_snapshot!(sm);

--- a/src/state/store/mod.rs
+++ b/src/state/store/mod.rs
@@ -1,11 +1,20 @@
+mod error;
+mod impl_sledstoreable;
+mod store;
+
 use std::{
-    collections::{BTreeMap, HashMap, HashSet},
+    collections::{HashMap, HashSet},
+    error::Error,
     fmt::Debug,
     io::Cursor,
     ops::RangeBounds,
-    sync::{Arc, Mutex},
+    string::ToString,
+    sync::Arc,
 };
 
+use anyerror::AnyError;
+use error::*;
+use impl_sledstoreable::SledStoreable;
 use openraft::{
     async_trait::async_trait,
     storage::{LogState, Snapshot},
@@ -24,7 +33,9 @@ use openraft::{
     Vote,
 };
 use serde::{Deserialize, Serialize};
-use tokio::sync::RwLock;
+pub use store::Store;
+use store::*;
+use tracing::info;
 
 use super::{NodeId, TypeConfig};
 use crate::internal_api::{
@@ -37,7 +48,7 @@ use crate::internal_api::{
     Task,
 };
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub enum Request {
     RegisterExecutor {
         addr: String,
@@ -99,7 +110,7 @@ pub struct Response {
     pub value: Option<String>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 pub struct StoredSnapshot {
     pub meta: SnapshotMeta<NodeId, BasicNode>,
 
@@ -133,7 +144,7 @@ pub struct StateChange {
  * this test we set both the key and value as String, but you could set any
  * type of value that has the serialization impl.
  */
-#[derive(Serialize, Deserialize, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq)]
 pub struct StateMachine {
     pub last_applied_log: Option<LogId<NodeId>>,
 
@@ -166,69 +177,47 @@ pub struct StateMachine {
     pub repository_extractors: HashMap<RepositoryId, HashSet<Index>>,
 
     pub index_table: HashMap<String, Index>,
-}
-
-pub struct Store {
-    last_purged_log_id: RwLock<Option<LogId<NodeId>>>,
-
-    /// The Raft log.
-    log: RwLock<BTreeMap<u64, Entry<TypeConfig>>>,
-
-    /// The Raft state machine.
-    pub state_machine: RwLock<StateMachine>,
-
-    /// The current granted vote.
-    vote: RwLock<Option<Vote<NodeId>>>,
-
-    snapshot_idx: Arc<Mutex<u64>>,
-
-    current_snapshot: RwLock<Option<StoredSnapshot>>,
-
-    pub state_change_tx: tokio::sync::watch::Sender<StateChange>,
-    pub state_change_rx: tokio::sync::watch::Receiver<StateChange>,
-}
-
-impl Default for Store {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl Store {
-    pub fn new() -> Self {
-        let (tx, rx) = tokio::sync::watch::channel(StateChange {
-            id: "".to_string(),
-            change_type: ChangeType::NewContent,
-        });
-        Self {
-            last_purged_log_id: RwLock::new(None),
-            log: RwLock::new(BTreeMap::new()),
-            state_machine: RwLock::new(StateMachine::default()),
-            vote: RwLock::new(None),
-            snapshot_idx: Arc::new(Mutex::new(0)),
-            current_snapshot: RwLock::new(None),
-            state_change_tx: tx,
-            state_change_rx: rx,
-        }
-    }
+    // IMPORTANT: Adding a field here? You need to also update the
+    // StateMachine::try_from_sled_tree block so that the field is
+    // properly initialized from the sled database.
+    // TODO: replace with a procedural macro
 }
 
 #[async_trait]
 impl RaftLogReader<TypeConfig> for Arc<Store> {
     async fn get_log_state(&mut self) -> Result<LogState<TypeConfig>, StorageError<NodeId>> {
-        let log = self.log.read().await;
-        let last = log.iter().next_back().map(|(_, ent)| ent.log_id);
+        let last_purged = self
+            .get_last_purged_log_id()
+            .map_err(|e| StorageError::IO {
+                source: StorageIOError::read_logs(&e),
+            })?;
 
-        let last_purged = *self.last_purged_log_id.read().await;
+        let last_log = self
+            .get_last_log()
+            .map_err(|e| StorageError::IO {
+                source: StorageIOError::read_logs(&e),
+            })?
+            .map(|(log_id, _)| log_id);
 
-        let last = match last {
-            None => last_purged,
-            Some(x) => Some(x),
+        let last_log_id = match (last_purged, last_log) {
+            // If we have both last_purged and last_log, we take the max of the two
+            (Some(purged), Some(log)) => std::cmp::max(purged, log),
+            // If we only have last log, we use that
+            (None, Some(log)) => log,
+            // If we only have last purged, we use that
+            (Some(purged), None) => purged,
+            // If we have no log at all, we return None
+            (None, None) => {
+                return Ok(LogState {
+                    last_purged_log_id: None,
+                    last_log_id: None,
+                })
+            }
         };
 
         Ok(LogState {
             last_purged_log_id: last_purged,
-            last_log_id: last,
+            last_log_id: Some(last_log_id),
         })
     }
 
@@ -236,12 +225,35 @@ impl RaftLogReader<TypeConfig> for Arc<Store> {
         &mut self,
         range: RB,
     ) -> Result<Vec<Entry<TypeConfig>>, StorageError<NodeId>> {
-        let log = self.log.read().await;
-        let response = log
-            .range(range.clone())
-            .map(|(_, val)| val.clone())
-            .collect::<Vec<_>>();
-        Ok(response)
+        let start_bound = range.start_bound();
+        let start = match start_bound {
+            std::ops::Bound::Included(x) => LogKey::from(*x).to_raw_log_key(),
+            std::ops::Bound::Excluded(x) => LogKey::from(*x + 1).to_raw_log_key(),
+            std::ops::Bound::Unbounded => LogKey::from(0).to_raw_log_key(),
+        };
+
+        let logs_tree = self.open_tree(SledStoreTree::Logs);
+
+        logs_tree
+            .range::<&[u8], _>(start.as_slice()..)
+            .try_fold(vec![], |mut acc, res| {
+                let (raw_log_key, raw_entry) = res.map_err(|e| StorageError::IO {
+                    source: StorageIOError::read_logs(&e),
+                })?;
+
+                let log_key = LogKey::from(raw_log_key);
+                let entry = Entry::<TypeConfig>::load_from_sled_value(raw_entry).map_err(|e| {
+                    StorageError::IO {
+                        source: StorageIOError::read_logs(AnyError::from_dyn(&*e, None)),
+                    }
+                })?;
+
+                if range.contains(&log_key.into()) {
+                    acc.push(entry);
+                }
+
+                Ok(acc)
+            })
     }
 }
 
@@ -249,51 +261,46 @@ impl RaftLogReader<TypeConfig> for Arc<Store> {
 impl RaftSnapshotBuilder<TypeConfig> for Arc<Store> {
     #[tracing::instrument(level = "trace", skip(self))]
     async fn build_snapshot(&mut self) -> Result<Snapshot<TypeConfig>, StorageError<NodeId>> {
-        let data;
-        let last_applied_log;
-        let last_membership;
+        let state_machine = self.state_machine.read().await;
+        let storeable_state_machine = state_machine
+            .to_saveable_value()
+            .map_err(|e| build_snapshot_err(e.into()))?;
 
-        {
-            // Serialize the data of the state machine.
-            let state_machine = self.state_machine.read().await;
-            data = serde_json::to_vec(&*state_machine)
-                .map_err(|e| StorageIOError::read_state_machine(&e))?;
+        let last_applied_log = self
+            .get_last_applied_log()
+            .map_err(|e| build_snapshot_err(e.into()))?;
+        let last_membership = self
+            .get_last_membership()
+            .map_err(|e| build_snapshot_err(e.into()))?;
 
-            last_applied_log = state_machine.last_applied_log;
-            last_membership = state_machine.last_membership.clone();
-        }
+        let snapshot_idx = self
+            .get_snapshot_index()
+            .map_err(|e| build_snapshot_err(e.into()))?
+            .map_or(0, |idx| idx + 1);
 
-        let snapshot_idx = {
-            let mut l = self.snapshot_idx.lock().unwrap();
-            *l += 1;
-            *l
-        };
-
-        let snapshot_id = if let Some(last) = last_applied_log {
-            format!("{}-{}-{}", last.leader_id, last.index, snapshot_idx)
-        } else {
-            format!("--{}", snapshot_idx)
-        };
+        let snapshot_id = last_applied_log
+            .as_ref()
+            .map(|last| format!("{}-{}-{}", last.leader_id, last.index, snapshot_idx))
+            .unwrap_or_else(|| format!("--{}", snapshot_idx));
 
         let meta = SnapshotMeta {
             last_log_id: last_applied_log,
-            last_membership,
+            last_membership: last_membership.unwrap_or_default(),
             snapshot_id,
         };
 
         let snapshot = StoredSnapshot {
             meta: meta.clone(),
-            data: data.clone(),
+            data: storeable_state_machine.to_vec(),
         };
 
-        {
-            let mut current_snapshot = self.current_snapshot.write().await;
-            *current_snapshot = Some(snapshot);
-        }
+        self.set_current_snapshot(snapshot.clone())
+            .await
+            .map_err(|e| build_snapshot_err(e.into()))?;
 
         Ok(Snapshot {
             meta,
-            snapshot: Box::new(Cursor::new(data)),
+            snapshot: Box::new(Cursor::new(snapshot.data)),
         })
     }
 }
@@ -305,13 +312,13 @@ impl RaftStorage<TypeConfig> for Arc<Store> {
 
     #[tracing::instrument(level = "trace", skip(self))]
     async fn save_vote(&mut self, vote: &Vote<NodeId>) -> Result<(), StorageError<NodeId>> {
-        let mut v = self.vote.write().await;
-        *v = Some(*vote);
-        Ok(())
+        self.insert_vote(*vote)
+            .await
+            .map_err(|e| save_vote_err(e.into()))
     }
 
     async fn read_vote(&mut self) -> Result<Option<Vote<NodeId>>, StorageError<NodeId>> {
-        Ok(*self.vote.read().await)
+        self.get_vote().map_err(|e| read_vote_err(e.into()))
     }
 
     #[tracing::instrument(level = "trace", skip(self, entries))]
@@ -319,10 +326,16 @@ impl RaftStorage<TypeConfig> for Arc<Store> {
     where
         I: IntoIterator<Item = Entry<TypeConfig>> + Send,
     {
-        let mut log = self.log.write().await;
-        for entry in entries {
-            log.insert(entry.log_id.index, entry);
+        let logs_tree = self.open_tree(SledStoreTree::Logs);
+        let mut batch = sled::Batch::default();
+        for entry in entries.into_iter() {
+            let log_key = LogKey::from_log(&entry);
+            let log_value = entry.to_saveable_value().map_err(append_log_err)?;
+            batch.insert(&log_key.to_raw_log_key(), log_value);
         }
+        logs_tree
+            .apply_batch(batch)
+            .map_err(|e| append_log_err(e.into()))?;
         Ok(())
     }
 
@@ -331,15 +344,27 @@ impl RaftStorage<TypeConfig> for Arc<Store> {
         &mut self,
         log_id: LogId<NodeId>,
     ) -> Result<(), StorageError<NodeId>> {
-        tracing::debug!("delete_log: [{:?}, +oo)", log_id);
+        tracing::debug!("delete_conflict_logs_since: [{:?}, +oo)", log_id);
 
-        let mut log = self.log.write().await;
-        let keys = log
-            .range(log_id.index..)
-            .map(|(k, _v)| *k)
+        // fetch the logs tree
+        let logs_tree = self.open_tree(SledStoreTree::Logs);
+
+        // find all keys greater than the given log id
+        let keys: Vec<LogKey> = logs_tree
+            .range(LogKey::from_log_id(&log_id).to_raw_log_key()..)
+            .map(|res| res.expect("Failed to read log entry").0)
+            .map(|log_key| LogKey::from(log_key))
             .collect::<Vec<_>>();
-        for key in keys {
-            log.remove(&key);
+
+        // delete all keys greater than the given log id
+        // we aren't using a transaction here for performance reasons,
+        // but deleting the keys in reverse order should ensure that
+        // we don't leave any holes in the log
+        for key in keys.iter().rev() {
+            let tx_key = key.to_raw_log_key();
+            logs_tree
+                .remove(tx_key)
+                .map_err(|e| delete_conflict_logs_since_err(e.into()))?;
         }
 
         Ok(())
@@ -349,23 +374,40 @@ impl RaftStorage<TypeConfig> for Arc<Store> {
     async fn purge_logs_upto(&mut self, log_id: LogId<NodeId>) -> Result<(), StorageError<NodeId>> {
         tracing::debug!("delete_log: [{:?}, +oo)", log_id);
 
-        {
-            let mut ld = self.last_purged_log_id.write().await;
-            assert!(*ld <= Some(log_id));
-            *ld = Some(log_id);
+        // fetch the logs tree
+        let logs_tree = self.open_tree(SledStoreTree::Logs);
+
+        // create a batch to delete all logs up to and including the given log id
+        let mut batch = sled::Batch::default();
+
+        let start = LogKey::from_log_id(&log_id).to_raw_log_key();
+        let end = LogKey::from(log_id.index + 1).to_raw_log_key();
+
+        // iterate over all logs up to and including the given log id
+        for result in logs_tree.range(start..end) {
+            let (raw_log_key, _) = result.map_err(|e| StorageError::IO {
+                source: StorageIOError::read_logs(&e),
+            })?;
+
+            let log_key = LogKey::from(raw_log_key);
+
+            // remove the log from the batch
+            batch.remove(&log_key.to_raw_log_key());
         }
 
-        {
-            let mut log = self.log.write().await;
+        logs_tree
+            .apply_batch(batch)
+            .map_err(|e| purge_logs_upto_err(e.into()))?;
 
-            let keys = log
-                .range(..=log_id.index)
-                .map(|(k, _v)| *k)
-                .collect::<Vec<_>>();
-            for key in keys {
-                log.remove(&key);
-            }
-        }
+        // set the last purged log id
+        let store_tree = self.open_tree(SledStoreTree::Store);
+        let key = StoreKey::LastPurgedLogId.to_string();
+        let value = log_id
+            .to_saveable_value()
+            .map_err(|e| purge_logs_upto_err(e.into()))?;
+        store_tree
+            .insert(key, value)
+            .map_err(|e| purge_logs_upto_err(e.into()))?;
 
         Ok(())
     }
@@ -374,11 +416,13 @@ impl RaftStorage<TypeConfig> for Arc<Store> {
         &mut self,
     ) -> Result<(Option<LogId<NodeId>>, StoredMembership<NodeId, BasicNode>), StorageError<NodeId>>
     {
-        let state_machine = self.state_machine.read().await;
-        Ok((
-            state_machine.last_applied_log,
-            state_machine.last_membership.clone(),
-        ))
+        let last_applied_log = self
+            .get_last_applied_log()
+            .map_err(|e| last_applied_state_err(e.into()))?;
+        let last_membership = self
+            .get_last_membership()
+            .map_err(|e| last_applied_state_err(e.into()))?;
+        Ok((last_applied_log, last_membership.unwrap_or_default()))
     }
 
     #[tracing::instrument(level = "trace", skip(self, entries))]
@@ -389,6 +433,8 @@ impl RaftStorage<TypeConfig> for Arc<Store> {
         let mut res = Vec::with_capacity(entries.len());
 
         let mut sm = self.state_machine.write().await;
+
+        let state_machine_tree = self.open_tree(SledStoreTree::StateMachine);
 
         let mut change_events: Vec<StateChange> = Vec::new();
 
@@ -419,6 +465,21 @@ impl RaftStorage<TypeConfig> for Arc<Store> {
                             extractor: extractor.clone(),
                         };
                         sm.executors.insert(executor_id.clone(), executor_info);
+                        sm.overwrite_sled_kv(
+                            &state_machine_tree,
+                            "extractors",
+                            Box::new(sm.extractors.clone()),
+                        )?;
+                        sm.overwrite_sled_kv(
+                            &state_machine_tree,
+                            "extractor_executors_table",
+                            Box::new(sm.extractor_executors_table.clone()),
+                        )?;
+                        sm.overwrite_sled_kv(
+                            &state_machine_tree,
+                            "executors",
+                            Box::new(sm.executors.clone()),
+                        )?;
                         res.push(Response { value: None })
                     }
                     Request::RemoveExecutor { executor_id } => {
@@ -432,6 +493,17 @@ impl RaftStorage<TypeConfig> for Arc<Store> {
                                 .or_default();
                             executors.remove(executor_meta.extractor.name.as_str());
                         }
+                        // update the state machine in sled
+                        sm.overwrite_sled_kv(
+                            &state_machine_tree,
+                            "executors",
+                            Box::new(sm.executors.clone()),
+                        )?;
+                        sm.overwrite_sled_kv(
+                            &state_machine_tree,
+                            "extractor_executors_table",
+                            Box::new(sm.extractor_executors_table.clone()),
+                        )?;
                         res.push(Response { value: None })
                     }
                     Request::CreateTasks { tasks } => {
@@ -439,6 +511,11 @@ impl RaftStorage<TypeConfig> for Arc<Store> {
                             sm.tasks.insert(task.id.clone(), task.clone());
                             sm.unassigned_tasks.insert(task.id.clone());
                         }
+                        sm.overwrite_sled_kv(
+                            &state_machine_tree,
+                            "tasks",
+                            Box::new(sm.tasks.clone()),
+                        )?;
                         res.push(Response { value: None })
                     }
                     Request::AssignTask { assignments } => {
@@ -449,11 +526,31 @@ impl RaftStorage<TypeConfig> for Arc<Store> {
                                 .insert(task_id.clone());
                             sm.unassigned_tasks.remove(task_id);
                         }
+                        sm.overwrite_sled_kv(
+                            &state_machine_tree,
+                            "task_assignments",
+                            Box::new(sm.task_assignments.clone()),
+                        )?;
+                        sm.overwrite_sled_kv(
+                            &state_machine_tree,
+                            "unassigned_tasks",
+                            Box::new(sm.unassigned_tasks.clone()),
+                        )?;
                         res.push(Response { value: None })
                     }
                     Request::AddExtractionEvent { event } => {
                         sm.extraction_events.insert(event.id.clone(), event.clone());
                         sm.unprocessed_extraction_events.insert(event.id.clone());
+                        sm.overwrite_sled_kv(
+                            &state_machine_tree,
+                            "extraction_events",
+                            Box::new(sm.extraction_events.clone()),
+                        )?;
+                        sm.overwrite_sled_kv(
+                            &state_machine_tree,
+                            "unprocessed_extraction_events",
+                            Box::new(sm.unprocessed_extraction_events.clone()),
+                        )?;
                         res.push(Response { value: None })
                     }
                     Request::MarkExtractionEventProcessed { event_id, ts_secs } => {
@@ -466,6 +563,16 @@ impl RaftStorage<TypeConfig> for Arc<Store> {
                         if let Some(event) = event {
                             sm.extraction_events.insert(event_id.clone(), event);
                         }
+                        sm.overwrite_sled_kv(
+                            &state_machine_tree,
+                            "extraction_events",
+                            Box::new(sm.extraction_events.clone()),
+                        )?;
+                        sm.overwrite_sled_kv(
+                            &state_machine_tree,
+                            "unprocessed_extraction_events",
+                            Box::new(sm.unprocessed_extraction_events.clone()),
+                        )?;
 
                         res.push(Response { value: None })
                     }
@@ -488,6 +595,27 @@ impl RaftStorage<TypeConfig> for Arc<Store> {
                             sm.extraction_events.insert(event.id.clone(), event.clone());
                             sm.unprocessed_extraction_events.insert(event.id.clone());
                         }
+                        sm.overwrite_sled_kv(
+                            &state_machine_tree,
+                            "content_table",
+                            Box::new(sm.content_table.clone()),
+                        )?;
+                        sm.overwrite_sled_kv(
+                            &state_machine_tree,
+                            "content_repository_table",
+                            Box::new(sm.content_repository_table.clone()),
+                        )?;
+                        sm.overwrite_sled_kv(
+                            &state_machine_tree,
+                            "extraction_events",
+                            Box::new(sm.extraction_events.clone()),
+                        )?;
+                        sm.overwrite_sled_kv(
+                            &state_machine_tree,
+                            "unprocessed_extraction_events",
+                            Box::new(sm.unprocessed_extraction_events.clone()),
+                        )?;
+
                         res.push(Response { value: None })
                     }
                     Request::CreateBinding {
@@ -508,10 +636,30 @@ impl RaftStorage<TypeConfig> for Arc<Store> {
                             sm.unprocessed_extraction_events
                                 .insert(extraction_event.id.clone());
                         }
+                        sm.overwrite_sled_kv(
+                            &state_machine_tree,
+                            "bindings_table",
+                            Box::new(sm.bindings_table.clone()),
+                        )?;
+                        sm.overwrite_sled_kv(
+                            &state_machine_tree,
+                            "extraction_events",
+                            Box::new(sm.extraction_events.clone()),
+                        )?;
+                        sm.overwrite_sled_kv(
+                            &state_machine_tree,
+                            "unprocessed_extraction_events",
+                            Box::new(sm.unprocessed_extraction_events.clone()),
+                        )?;
                         res.push(Response { value: None })
                     }
                     Request::CreateRepository { name } => {
                         sm.repositories.insert(name.clone());
+                        sm.overwrite_sled_kv(
+                            &state_machine_tree,
+                            "repositories",
+                            Box::new(sm.repositories.clone()),
+                        )?;
                         res.push(Response { value: None })
                     }
                     Request::CreateIndex {
@@ -524,6 +672,16 @@ impl RaftStorage<TypeConfig> for Arc<Store> {
                             .or_default()
                             .insert(index.clone());
                         sm.index_table.insert(id.clone(), index.clone());
+                        sm.overwrite_sled_kv(
+                            &state_machine_tree,
+                            "repository_extractors",
+                            Box::new(sm.repository_extractors.clone()),
+                        )?;
+                        sm.overwrite_sled_kv(
+                            &state_machine_tree,
+                            "index_table",
+                            Box::new(sm.index_table.clone()),
+                        )?;
                         res.push(Response { value: None })
                     }
                     Request::UpdateTask {
@@ -554,11 +712,26 @@ impl RaftStorage<TypeConfig> for Arc<Store> {
                             sm.extraction_events.insert(event.id.clone(), event.clone());
                             sm.unprocessed_extraction_events.insert(event.id.clone());
                         }
+                        sm.overwrite_sled_kv(
+                            &state_machine_tree,
+                            "tasks",
+                            Box::new(sm.tasks.clone()),
+                        )?;
+                        sm.overwrite_sled_kv(
+                            &state_machine_tree,
+                            "unassigned_tasks",
+                            Box::new(sm.unassigned_tasks.clone()),
+                        )?;
                         res.push(Response { value: None })
                     }
                 },
                 EntryPayload::Membership(ref mem) => {
                     sm.last_membership = StoredMembership::new(Some(entry.log_id), mem.clone());
+                    sm.overwrite_sled_kv(
+                        &state_machine_tree,
+                        "last_membership",
+                        Box::new(sm.last_membership.clone()),
+                    )?;
                     res.push(Response { value: None })
                 }
             };
@@ -597,17 +770,20 @@ impl RaftStorage<TypeConfig> for Arc<Store> {
 
         // Update the state machine.
         {
-            let updated_state_machine: StateMachine = serde_json::from_slice(&new_snapshot.data)
-                .map_err(|e| {
-                    StorageIOError::read_snapshot(Some(new_snapshot.meta.signature()), &e)
-                })?;
+            let updated_state_machine =
+                StateMachine::load_from_sled_value(new_snapshot.data.clone().into())
+                    .map_err(install_snapshot_err)?;
             let mut state_machine = self.state_machine.write().await;
+            updated_state_machine
+                .try_save_to_sled_tree(&self.open_tree(SledStoreTree::StateMachine))
+                .map_err(|e| install_snapshot_err(e.into()))?;
             *state_machine = updated_state_machine;
         }
 
         // Update current snapshot.
-        let mut current_snapshot = self.current_snapshot.write().await;
-        *current_snapshot = Some(new_snapshot);
+        self.set_current_snapshot(new_snapshot)
+            .await
+            .map_err(|e| install_snapshot_err(e.into()))?;
         Ok(())
     }
 
@@ -615,7 +791,11 @@ impl RaftStorage<TypeConfig> for Arc<Store> {
     async fn get_current_snapshot(
         &mut self,
     ) -> Result<Option<Snapshot<TypeConfig>>, StorageError<NodeId>> {
-        match &*self.current_snapshot.read().await {
+        let result = self
+            .db
+            .get_current_snapshot()
+            .map_err(|e| get_current_snapshot_err(e.into()))?;
+        match result {
             Some(snapshot) => {
                 let data = snapshot.data.clone();
                 Ok(Some(Snapshot {
@@ -634,4 +814,50 @@ impl RaftStorage<TypeConfig> for Arc<Store> {
     async fn get_snapshot_builder(&mut self) -> Self::SnapshotBuilder {
         self.clone()
     }
+}
+
+fn build_snapshot_err(e: Box<dyn Error>) -> StorageError<NodeId> {
+    StoreErrorKind::WriteSnapshot
+        .build_with_source("build snapshot failed", e)
+        .into()
+}
+fn save_vote_err(e: Box<dyn Error>) -> StorageError<NodeId> {
+    StoreErrorKind::WriteVote
+        .build_with_source("save vote failed", e)
+        .into()
+}
+fn read_vote_err(e: Box<dyn Error>) -> StorageError<NodeId> {
+    StoreErrorKind::ReadVote
+        .build_with_source("read vote failed", e)
+        .into()
+}
+fn append_log_err(e: Box<dyn Error>) -> StorageError<NodeId> {
+    StoreErrorKind::WriteLogs
+        .build_with_source("append log failed", e)
+        .into()
+}
+fn last_applied_state_err(e: Box<dyn Error>) -> StorageError<NodeId> {
+    StoreErrorKind::ReadStateMachine
+        .build_with_source("last applied state failed", e)
+        .into()
+}
+fn purge_logs_upto_err(e: Box<dyn Error>) -> StorageError<NodeId> {
+    StoreErrorKind::WriteLogs
+        .build_with_source("purge logs upto failed", e)
+        .into()
+}
+fn delete_conflict_logs_since_err(e: Box<dyn Error>) -> StorageError<NodeId> {
+    StoreErrorKind::WriteLogs
+        .build_with_source("delete conflict logs since failed", e)
+        .into()
+}
+fn install_snapshot_err(e: Box<dyn Error>) -> StorageError<NodeId> {
+    StoreErrorKind::WriteSnapshot
+        .build_with_source("install snapshot failed", e)
+        .into()
+}
+fn get_current_snapshot_err(e: Box<dyn Error>) -> StorageError<NodeId> {
+    StoreErrorKind::ReadSnapshot
+        .build_with_source("get current snapshot failed", e)
+        .into()
 }

--- a/src/state/store/mod.rs
+++ b/src/state/store/mod.rs
@@ -148,6 +148,7 @@ pub struct StateChange {
  * - have SledStoreable implemented
  * - have a test in ./impl_sledstoreable.rs
  * - be handled in the StateMachine::try_from_sled_tree fn
+ * - be handled in the StateMachine::try_save_to_sled_tree fn
  *
  * TODO: make the StateMachine migrate-able
  */
@@ -863,4 +864,21 @@ fn get_current_snapshot_err(e: Box<dyn Error>) -> StorageError<NodeId> {
     StoreErrorKind::ReadSnapshot
         .build_with_source("get current snapshot failed", e)
         .into()
+}
+
+#[cfg(test)]
+mod test_state_machine_snapshot {
+    use super::*;
+    use super::impl_sledstoreable::SledStoreableTestFactory;
+    use insta;
+
+    #[test]
+    fn test_state_machine_snapshot() {
+        // if this test fails, it means the Schema of StateMachine has changed. It is imperative to ensure the new StateMachine is
+        //   compatible with the old one. This can be done by running raft against the old state machine db
+        let sm = StateMachine::spawn_instance_for_store_test();
+        insta::with_settings!({sort_maps => true}, {
+            insta::assert_ron_snapshot!(sm);
+        });
+    }
 }

--- a/src/state/store/mod.rs
+++ b/src/state/store/mod.rs
@@ -143,6 +143,13 @@ pub struct StateChange {
  * the `data`, which has a implementation to be serialized. Note that for
  * this test we set both the key and value as String, but you could set any
  * type of value that has the serialization impl.
+ *
+ * IMPORTANT: All fields of StateMachine must:
+ * - have SledStoreable implemented
+ * - have a test in ./impl_sledstoreable.rs
+ * - be handled in the StateMachine::try_from_sled_tree fn
+ *
+ * TODO: make the StateMachine migrate-able
  */
 #[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq)]
 pub struct StateMachine {
@@ -177,10 +184,6 @@ pub struct StateMachine {
     pub repository_extractors: HashMap<RepositoryId, HashSet<Index>>,
 
     pub index_table: HashMap<String, Index>,
-    // IMPORTANT: Adding a field here? You need to also update the
-    // StateMachine::try_from_sled_tree block so that the field is
-    // properly initialized from the sled database.
-    // TODO: replace with a procedural macro
 }
 
 #[async_trait]

--- a/src/state/store/snapshots/indexify__state__store__test_state_machine_snapshot__state_machine_snapshot.snap
+++ b/src/state/store/snapshots/indexify__state__store__test_state_machine_snapshot__state_machine_snapshot.snap
@@ -1,0 +1,218 @@
+---
+source: src/state/store/mod.rs
+expression: sm
+---
+StateMachine(
+  last_applied_log: Some(LogId(
+    leader_id: LeaderId(
+      term: 0,
+      node_id: 0,
+    ),
+    index: 0,
+  )),
+  last_membership: StoredMembership(
+    log_id: Some(LogId(
+      leader_id: LeaderId(
+        term: 0,
+        node_id: 0,
+      ),
+      index: 0,
+    )),
+    membership: Membership(
+      configs: [
+        [
+          0,
+        ],
+      ],
+      nodes: {
+        0: BasicNode(
+          addr: "",
+        ),
+      },
+    ),
+  ),
+  executors: {
+    "test": ExecutorMetadata(
+      id: "test",
+      last_seen: 0,
+      addr: "localhost:8080",
+      extractor: ExtractorDescription(
+        name: "test",
+        description: "test",
+        input_params: {
+          "description": "test",
+          "input_params": [],
+          "name": "test",
+          "outputs": [],
+        },
+        outputs: {
+          "test": attributes({
+            "description": "test",
+            "input_params": [],
+            "name": "test",
+            "outputs": [],
+          }),
+        },
+      ),
+    ),
+  },
+  tasks: {
+    "test": Task(
+      id: "test",
+      extractor: "test",
+      extractor_binding: "test",
+      output_index_table_mapping: {},
+      repository: "test",
+      content_metadata: ContentMetadata(
+        id: "test_id",
+        parent_id: "test_parent_id",
+        repository: "test_repository",
+        name: "test_name",
+        content_type: "test_content_type",
+        labels: {
+          "key1": "value1",
+          "key2": "value2",
+        },
+        storage_url: "http://example.com/test_url",
+        created_at: 1234567890,
+        source: "test_source",
+      ),
+      input_params: {
+        "description": "test",
+        "input_params": [],
+        "name": "test",
+        "outputs": [],
+      },
+      outcome: Success,
+    ),
+  },
+  unassigned_tasks: [
+    "test",
+  ],
+  task_assignments: {
+    "test": [
+      "test",
+    ],
+  },
+  extraction_events: {
+    "test": ExtractionEvent(
+      id: "test_id",
+      repository: "test_repository",
+      payload: CreateContent(
+        content: ContentMetadata(
+          id: "test_id",
+          parent_id: "test_parent_id",
+          repository: "test_repository",
+          name: "test_name",
+          content_type: "test_content_type",
+          labels: {
+            "key1": "value1",
+            "key2": "value2",
+          },
+          storage_url: "http://example.com/test_url",
+          created_at: 1234567890,
+          source: "test_source",
+        ),
+      ),
+      created_at: 1234567890,
+      processed_at: Some(1234567890),
+    ),
+  },
+  unprocessed_extraction_events: [
+    "test",
+  ],
+  content_table: {
+    "test": ContentMetadata(
+      id: "test_id",
+      parent_id: "test_parent_id",
+      repository: "test_repository",
+      name: "test_name",
+      content_type: "test_content_type",
+      labels: {
+        "key1": "value1",
+        "key2": "value2",
+      },
+      storage_url: "http://example.com/test_url",
+      created_at: 1234567890,
+      source: "test_source",
+    ),
+  },
+  content_repository_table: {
+    "test": [
+      "test",
+    ],
+  },
+  bindings_table: {
+    "test": [
+      ExtractorBinding(
+        id: "test_id",
+        name: "test_name",
+        repository: "test_repository",
+        extractor: "test_extractor",
+        filters: {
+          "key1": "value1",
+          "key2": "value2",
+        },
+        input_params: {
+          "description": "test",
+          "input_params": [],
+          "name": "test",
+          "outputs": [],
+        },
+        output_index_name_mapping: {},
+        index_name_table_mapping: {},
+        content_source: "test_content_source",
+      ),
+    ],
+  },
+  extractor_executors_table: {
+    "test": [
+      "test",
+    ],
+  },
+  extractors: {
+    "test": ExtractorDescription(
+      name: "test",
+      description: "test",
+      input_params: {
+        "description": "test",
+        "input_params": [],
+        "name": "test",
+        "outputs": [],
+      },
+      outputs: {
+        "test": attributes({
+          "description": "test",
+          "input_params": [],
+          "name": "test",
+          "outputs": [],
+        }),
+      },
+    ),
+  },
+  repositories: [
+    "test",
+  ],
+  repository_extractors: {
+    "test": [
+      Index(
+        repository: "test_repository",
+        name: "test_name",
+        table_name: "test_table_name",
+        schema: "test_schema",
+        extractor_binding: "test_extractor_binding",
+        extractor: "test_extractor",
+      ),
+    ],
+  },
+  index_table: {
+    "test": Index(
+      repository: "test_repository",
+      name: "test_name",
+      table_name: "test_table_name",
+      schema: "test_schema",
+      extractor_binding: "test_extractor_binding",
+      extractor: "test_extractor",
+    ),
+  },
+)

--- a/src/state/store/store.rs
+++ b/src/state/store/store.rs
@@ -622,12 +622,6 @@ impl StateMachine {
                     )?;
                 }
                 tx.insert(
-                    "executor_health_checks",
-                    self.executor_health_checks
-                        .to_saveable_value()
-                        .map_err(|e| err_fn(e, "executor_health_checks".to_string()))?,
-                )?;
-                tx.insert(
                     "executors",
                     self.executors
                         .to_saveable_value()

--- a/src/state/store/store.rs
+++ b/src/state/store/store.rs
@@ -391,17 +391,6 @@ impl StateMachine {
                                 )
                             })?;
                 }
-                "executor_health_checks" => {
-                    state_machine.executor_health_checks =
-                        HashMap::<ExecutorId, u64>::load_from_sled_value(value).map_err(|e| {
-                            err_kind.build_with_tree_and_key(
-                                "failed to load executor_health_checks",
-                                e.into(),
-                                SledStoreTree::StateMachine,
-                                key.clone(),
-                            )
-                        })?;
-                }
                 "executors" => {
                     state_machine.executors =
                         HashMap::<ExecutorId, ExecutorMetadata>::load_from_sled_value(value)
@@ -511,7 +500,7 @@ impl StateMachine {
                 }
                 "extractor_executors_table" => {
                     state_machine.extractor_executors_table =
-                        HashMap::<ExtractorName, Vec<ExecutorId>>::load_from_sled_value(value)
+                        HashMap::<ExtractorName, HashSet<ExecutorId>>::load_from_sled_value(value)
                             .map_err(|e| {
                                 err_kind.build_with_tree_and_key(
                                     "failed to load extractor_executors_table",

--- a/src/state/store/store.rs
+++ b/src/state/store/store.rs
@@ -1,0 +1,957 @@
+use std::{
+    collections::{HashMap, HashSet},
+    error::Error,
+    fmt::{Debug, Display, Formatter},
+    ops::Deref,
+    string::ToString,
+    sync::Arc,
+};
+
+use byteorder::{BigEndian, ByteOrder};
+use openraft::{BasicNode, Entry, LogId, StoredMembership, Vote};
+use serde::{Deserialize, Serialize};
+use sled::{transaction::ConflictableTransactionError, IVec};
+use tokio::sync::RwLock;
+
+use super::{error::*, impl_sledstoreable::SledStoreable, NodeId, TypeConfig, *};
+use crate::{
+    internal_api::{
+        ContentMetadata,
+        ExecutorMetadata,
+        ExtractionEvent,
+        ExtractorBinding,
+        ExtractorDescription,
+        Index,
+        Task,
+    },
+    server_config::SledConfig,
+};
+
+pub struct Store {
+    /// sled database
+    pub(super) db: Arc<SledStoreDb>,
+
+    /// in-memory state machine
+    pub state_machine: RwLock<StateMachine>,
+
+    pub state_change_tx: tokio::sync::watch::Sender<StateChange>,
+    pub state_change_rx: tokio::sync::watch::Receiver<StateChange>,
+}
+
+impl Store {
+    pub async fn new(config: SledConfig) -> Store {
+        let (tx, rx) = tokio::sync::watch::channel(StateChange {
+            id: "".to_string(),
+            change_type: ChangeType::NewContent,
+        });
+
+        let sled_config = match config.path {
+            None => {
+                tracing::warn!("sled store path not set - using default tmp path");
+                sled::Config::default().temporary(true)
+            }
+            Some(path) => sled::Config::default().path(path),
+        };
+
+        let db = Arc::new(
+            sled_config
+                .open()
+                .expect(format!("failed to open sled db with {:?}", sled_config).as_str()),
+        );
+
+        let store_db = Arc::new(SledStoreDb(db.clone()));
+
+        let state_machine = RwLock::new(
+            StateMachine::from_sled_db(db.clone())
+                .expect("failed to load state machine from sled db"),
+        );
+
+        Store {
+            db: store_db,
+            state_machine,
+            state_change_tx: tx,
+            state_change_rx: rx,
+        }
+    }
+}
+
+impl Deref for Store {
+    type Target = Arc<SledStoreDb>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.db
+    }
+}
+
+#[derive(Debug)]
+pub struct SledStoreDb(Arc<sled::Db>);
+
+impl SledStoreDb {
+    pub fn open_tree(&self, name: SledStoreTree) -> sled::Tree {
+        self.0
+            .open_tree(name.to_string())
+            .expect("open tree failed")
+    }
+
+    pub fn get_last_log(&self) -> StoreResult<Option<(LogId<NodeId>, Entry<TypeConfig>)>> {
+        let tree = self.open_tree(SledStoreTree::Logs);
+        let last = tree.last().map_err(|e| {
+            StoreErrorKind::ReadLogs.build_with_tree(
+                "get last log failed: {}",
+                e.into(),
+                SledStoreTree::Logs,
+            )
+        })?;
+        match last {
+            Some((_, raw_entry)) => {
+                let entry = Entry::<TypeConfig>::load_from_sled_value(raw_entry).map_err(|e| {
+                    StoreErrorKind::ReadLogs.build_with_tree(
+                        "get last log failed to parse",
+                        e,
+                        SledStoreTree::Logs,
+                    )
+                })?;
+
+                StoreResult::Ok(Some((entry.log_id, entry)))
+            }
+            None => StoreResult::Ok(None),
+        }
+    }
+
+    pub fn get_last_purged_log_id(&self) -> StoreResult<Option<LogId<NodeId>>> {
+        let tree = self.open_tree(SledStoreTree::Store);
+        let key = StoreKey::LastPurgedLogId.to_string();
+
+        let value_option = tree.get(&key).map_err(|e| {
+            StoreErrorKind::ReadLogs.build_with_tree_and_key(
+                "get last purged log id failed",
+                e.into(),
+                SledStoreTree::Store,
+                key.clone(),
+            )
+        })?;
+
+        value_option
+            .map(|value| {
+                LogId::<NodeId>::load_from_sled_value(value).map_err(|e| {
+                    StoreErrorKind::ReadLogs.build_with_tree_and_key(
+                        "failed to parse last log id",
+                        e.into(),
+                        SledStoreTree::Store,
+                        key,
+                    )
+                })
+            })
+            .transpose()
+    }
+
+    pub fn get_snapshot_index(&self) -> StoreResult<Option<u64>> {
+        let tree = self.open_tree(SledStoreTree::Store);
+        let key = StoreKey::SnapshotIndex.to_string();
+
+        let value_option = tree.get(&key).map_err(|e| {
+            StoreErrorKind::ReadSnapshot.build_with_tree_and_key(
+                "get snapshot index failed",
+                e.into(),
+                SledStoreTree::Store,
+                key.clone(),
+            )
+        })?;
+
+        value_option
+            .map(|value| {
+                SnapshotIndex::load_from_sled_value(value)
+                    .map_err(|e| {
+                        StoreErrorKind::ReadSnapshot.build_with_tree_and_key(
+                            "failed to parse snapshot index",
+                            e.into(),
+                            SledStoreTree::Store,
+                            key,
+                        )
+                    })
+                    .map(|SnapshotIndex(index)| index)
+            })
+            .transpose()
+    }
+
+    pub fn get_current_snapshot(&self) -> StoreResult<Option<StoredSnapshot>> {
+        let tree = self.open_tree(SledStoreTree::Store);
+        let key = StoreKey::CurrentSnapshot.to_string();
+
+        let value_option = tree.get(&key).map_err(|e| {
+            StoreErrorKind::ReadSnapshot.build_with_tree_and_key(
+                "get current snapshot failed",
+                e.into(),
+                SledStoreTree::Store,
+                key.clone(),
+            )
+        })?;
+
+        value_option
+            .map(|value| {
+                StoredSnapshot::load_from_sled_value(value).map_err(|e| {
+                    StoreErrorKind::ReadSnapshot.build_with_tree_and_key(
+                        "failed to parse current snapshot",
+                        e.into(),
+                        SledStoreTree::Store,
+                        key,
+                    )
+                })
+            })
+            .transpose()
+    }
+
+    pub async fn set_current_snapshot(&self, snapshot: StoredSnapshot) -> StoreResult<()> {
+        let tree = self.open_tree(SledStoreTree::Store);
+        let key = StoreKey::CurrentSnapshot.to_string();
+
+        let result = snapshot.to_saveable_value().map_err(|e| {
+            StoreErrorKind::WriteSnapshot.build_with_tree_and_key(
+                "set current snapshot failed",
+                e.into(),
+                SledStoreTree::Store,
+                key.clone(),
+            )
+        })?;
+
+        tree.insert(key.clone(), result).map(|_| ()).map_err(|e| {
+            StoreErrorKind::WriteSnapshot.build_with_tree_and_key(
+                "set current snapshot failed",
+                e.into(),
+                SledStoreTree::Store,
+                key.clone(),
+            )
+        })
+    }
+
+    pub fn get_vote(&self) -> StoreResult<Option<Vote<NodeId>>> {
+        let tree = self.open_tree(SledStoreTree::Store);
+        let key = StoreKey::Vote.to_string();
+
+        let value_option = tree.get(&key).map_err(|e| {
+            StoreErrorKind::ReadVote.build_with_tree_and_key(
+                "get vote failed",
+                e.into(),
+                SledStoreTree::Store,
+                key.clone(),
+            )
+        })?;
+
+        value_option
+            .map(|value| {
+                Vote::<NodeId>::load_from_sled_value(value).map_err(|e| {
+                    StoreErrorKind::ReadVote.build_with_tree_and_key(
+                        "failed to parse vote",
+                        e.into(),
+                        SledStoreTree::Store,
+                        key,
+                    )
+                })
+            })
+            .transpose()
+    }
+
+    pub async fn insert_vote(&self, vote: Vote<NodeId>) -> StoreResult<()> {
+        let tree = self.open_tree(SledStoreTree::Store);
+        let key = StoreKey::Vote.to_string();
+
+        let result = vote.to_saveable_value().map_err(|e| {
+            StoreErrorKind::WriteVote.build_with_tree_and_key(
+                "insert vote failed",
+                e.into(),
+                SledStoreTree::Store,
+                key.clone(),
+            )
+        })?;
+
+        tree.insert(key.clone(), result).map(|_| ()).map_err(|e| {
+            StoreErrorKind::WriteVote.build_with_tree_and_key(
+                "insert vote failed",
+                e.into(),
+                SledStoreTree::Store,
+                key.clone(),
+            )
+        })
+    }
+
+    pub fn get_last_membership(&self) -> StoreResult<Option<StoredMembership<NodeId, BasicNode>>> {
+        let tree = self.open_tree(SledStoreTree::StateMachine);
+        let key = StateMachineKey::LastMembership.to_string();
+
+        let value_option = tree.get(&key).map_err(|e| {
+            StoreErrorKind::ReadLogs.build_with_tree_and_key(
+                "get last membership failed",
+                e.into(),
+                SledStoreTree::StateMachine,
+                key.clone(),
+            )
+        })?;
+
+        value_option
+            .map(|value| {
+                StoredMembership::<NodeId, BasicNode>::load_from_sled_value(value).map_err(|e| {
+                    StoreErrorKind::ReadLogs.build_with_tree_and_key(
+                        "failed to parse last membership",
+                        e.into(),
+                        SledStoreTree::StateMachine,
+                        key,
+                    )
+                })
+            })
+            .transpose()
+    }
+
+    pub fn get_last_applied_log(&self) -> StoreResult<Option<LogId<NodeId>>> {
+        let tree = self.open_tree(SledStoreTree::StateMachine);
+        let key = StateMachineKey::LastAppliedLog.to_string();
+
+        let value_option = tree.get(&key).map_err(|e| {
+            StoreErrorKind::ReadLogs.build_with_tree_and_key(
+                "get last applied log failed",
+                e.into(),
+                SledStoreTree::StateMachine,
+                key.clone(),
+            )
+        })?;
+
+        value_option
+            .map(|value| {
+                LogId::<NodeId>::load_from_sled_value(value).map_err(|e| {
+                    StoreErrorKind::ReadLogs.build_with_tree_and_key(
+                        "failed to parse last applied log",
+                        e.into(),
+                        SledStoreTree::StateMachine,
+                        key,
+                    )
+                })
+            })
+            .transpose()
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum StateMachineKey {
+    LastMembership,
+    LastAppliedLog,
+}
+
+impl Display for StateMachineKey {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            StateMachineKey::LastMembership => write!(f, "last_membership"),
+            StateMachineKey::LastAppliedLog => write!(f, "last_applied_log"),
+        }
+    }
+}
+
+impl StateMachine {
+    pub fn try_from_sled_tree(tree: sled::Tree) -> Result<StateMachine, StoreError> {
+        let mut state_machine = StateMachine::default();
+
+        for res in tree.iter() {
+            let (key, value) = res.map_err(|e| {
+                StoreErrorKind::ReadStateMachine.build_with_tree(
+                    "failed to read state machine entry",
+                    e.into(),
+                    SledStoreTree::StateMachine,
+                )
+            })?;
+            let key = String::from_utf8(key.to_vec()).map_err(|e| {
+                StoreErrorKind::ParseError.build_with_tree(
+                    "failed to parse state machine key",
+                    e.into(),
+                    SledStoreTree::StateMachine,
+                )
+            })?;
+            let err_kind = StoreErrorKind::ReadStateMachine;
+            match key.as_str() {
+                "last_applied_log" => {
+                    state_machine.last_applied_log =
+                        Some(LogId::<NodeId>::load_from_sled_value(value).map_err(
+                            |e: Box<dyn Error>| {
+                                err_kind.build_with_tree_and_key(
+                                    "failed to load last_applied_log",
+                                    e,
+                                    SledStoreTree::StateMachine,
+                                    key.clone(),
+                                )
+                            },
+                        )?);
+                }
+                "last_membership" => {
+                    state_machine.last_membership =
+                        StoredMembership::<NodeId, BasicNode>::load_from_sled_value(value)
+                            .map_err(|e| {
+                                err_kind.build_with_tree_and_key(
+                                    "failed to load last_membership",
+                                    e.into(),
+                                    SledStoreTree::StateMachine,
+                                    key.clone(),
+                                )
+                            })?;
+                }
+                "executor_health_checks" => {
+                    state_machine.executor_health_checks =
+                        HashMap::<ExecutorId, u64>::load_from_sled_value(value).map_err(|e| {
+                            err_kind.build_with_tree_and_key(
+                                "failed to load executor_health_checks",
+                                e.into(),
+                                SledStoreTree::StateMachine,
+                                key.clone(),
+                            )
+                        })?;
+                }
+                "executors" => {
+                    state_machine.executors =
+                        HashMap::<ExecutorId, ExecutorMetadata>::load_from_sled_value(value)
+                            .map_err(|e| {
+                                err_kind.build_with_tree_and_key(
+                                    "failed to load executors",
+                                    e.into(),
+                                    SledStoreTree::StateMachine,
+                                    key.clone(),
+                                )
+                            })?;
+                }
+                "tasks" => {
+                    state_machine.tasks = HashMap::<TaskId, Task>::load_from_sled_value(value)
+                        .map_err(|e| {
+                            err_kind.build_with_tree_and_key(
+                                "failed to load tasks",
+                                e.into(),
+                                SledStoreTree::StateMachine,
+                                key.clone(),
+                            )
+                        })?;
+                }
+                "unassigned_tasks" => {
+                    state_machine.unassigned_tasks = HashSet::<TaskId>::load_from_sled_value(value)
+                        .map_err(|e| {
+                            err_kind.build_with_tree_and_key(
+                                "failed to load unassigned_tasks",
+                                e.into(),
+                                SledStoreTree::StateMachine,
+                                key.clone(),
+                            )
+                        })?;
+                }
+                "task_assignments" => {
+                    state_machine.task_assignments =
+                        HashMap::<ExecutorId, HashSet<TaskId>>::load_from_sled_value(value)
+                            .map_err(|e| {
+                                err_kind.build_with_tree_and_key(
+                                    "failed to load task_assignments",
+                                    e.into(),
+                                    SledStoreTree::StateMachine,
+                                    key.clone(),
+                                )
+                            })?;
+                }
+                "extraction_events" => {
+                    state_machine.extraction_events =
+                        HashMap::<ExtractionEventId, ExtractionEvent>::load_from_sled_value(value)
+                            .map_err(|e| {
+                                err_kind.build_with_tree_and_key(
+                                    "failed to load extraction_events",
+                                    e.into(),
+                                    SledStoreTree::StateMachine,
+                                    key.clone(),
+                                )
+                            })?;
+                }
+                "unprocessed_extraction_events" => {
+                    state_machine.unprocessed_extraction_events =
+                        HashSet::<ExtractionEventId>::load_from_sled_value(value).map_err(|e| {
+                            err_kind.build_with_tree_and_key(
+                                "failed to load unprocessed_extraction_events",
+                                e.into(),
+                                SledStoreTree::StateMachine,
+                                key.clone(),
+                            )
+                        })?;
+                }
+                "content_table" => {
+                    state_machine.content_table =
+                        HashMap::<ContentId, ContentMetadata>::load_from_sled_value(value)
+                            .map_err(|e| {
+                                err_kind.build_with_tree_and_key(
+                                    "failed to load content_table",
+                                    e.into(),
+                                    SledStoreTree::StateMachine,
+                                    key.clone(),
+                                )
+                            })?;
+                }
+                "content_repository_table" => {
+                    state_machine.content_repository_table =
+                        HashMap::<RepositoryId, HashSet<ContentId>>::load_from_sled_value(value)
+                            .map_err(|e| {
+                                err_kind.build_with_tree_and_key(
+                                    "failed to load content_repository_table",
+                                    e.into(),
+                                    SledStoreTree::StateMachine,
+                                    key.clone(),
+                                )
+                            })?;
+                }
+                "bindings_table" => {
+                    state_machine.bindings_table =
+                        HashMap::<RepositoryId, HashSet<ExtractorBinding>>::load_from_sled_value(
+                            value,
+                        )
+                        .map_err(|e| {
+                            err_kind.build_with_tree_and_key(
+                                "failed to load bindings_table",
+                                e.into(),
+                                SledStoreTree::StateMachine,
+                                key.clone(),
+                            )
+                        })?;
+                }
+                "extractor_executors_table" => {
+                    state_machine.extractor_executors_table =
+                        HashMap::<ExtractorName, Vec<ExecutorId>>::load_from_sled_value(value)
+                            .map_err(|e| {
+                                err_kind.build_with_tree_and_key(
+                                    "failed to load extractor_executors_table",
+                                    e.into(),
+                                    SledStoreTree::StateMachine,
+                                    key.clone(),
+                                )
+                            })?;
+                }
+                "extractors" => {
+                    state_machine.extractors =
+                        HashMap::<ExtractorName, ExtractorDescription>::load_from_sled_value(value)
+                            .map_err(|e| {
+                                err_kind.build_with_tree_and_key(
+                                    "failed to load extractors",
+                                    e.into(),
+                                    SledStoreTree::StateMachine,
+                                    key.clone(),
+                                )
+                            })?;
+                }
+                "repositories" => {
+                    state_machine.repositories = HashSet::<String>::load_from_sled_value(value)
+                        .map_err(|e| {
+                            err_kind.build_with_tree_and_key(
+                                "failed to load repositories",
+                                e.into(),
+                                SledStoreTree::StateMachine,
+                                key.clone(),
+                            )
+                        })?;
+                }
+                "repository_extractors" => {
+                    state_machine.repository_extractors =
+                        HashMap::<RepositoryId, HashSet<Index>>::load_from_sled_value(value)
+                            .map_err(|e| {
+                                err_kind.build_with_tree_and_key(
+                                    "failed to load repository_extractors",
+                                    e.into(),
+                                    SledStoreTree::StateMachine,
+                                    key.clone(),
+                                )
+                            })?;
+                }
+                "index_table" => {
+                    state_machine.index_table =
+                        HashMap::<String, Index>::load_from_sled_value(value).map_err(|e| {
+                            err_kind.build_with_tree_and_key(
+                                "failed to load index_table",
+                                e.into(),
+                                SledStoreTree::StateMachine,
+                                key.clone(),
+                            )
+                        })?;
+                }
+                _ => {
+                    return Err(StoreError::new(
+                        StoreErrorKind::ParseError,
+                        format!("unknown key {}", key),
+                    )
+                    .with_tree(SledStoreTree::StateMachine)
+                    .with_key(key))?
+                }
+            }
+        }
+        Ok(state_machine)
+    }
+
+    pub fn overwrite_sled_kv(
+        &self,
+        tree: &sled::Tree,
+        key: &str,
+        raw_value: Box<impl SledStoreable>,
+    ) -> Result<(), StoreError> {
+        let value = raw_value.to_saveable_value().map_err(|e| {
+            StoreError::new(
+                StoreErrorKind::WriteStateMachine,
+                format!(
+                    "failed to serialize state machine from sled with key {}",
+                    key
+                ),
+            )
+            .with_tree(SledStoreTree::StateMachine)
+            .with_key(key)
+            .with_source(e.into())
+        })?;
+
+        tree.insert(key, value).map(|_| ()).map_err(|e| {
+            StoreError::new(
+                StoreErrorKind::WriteStateMachine,
+                format!("failed to write state machine to sled with key {}", key),
+            )
+            .with_tree(SledStoreTree::StateMachine)
+            .with_key(key)
+            .with_source(e.into())
+        })
+    }
+
+    pub fn try_save_to_sled_tree(&self, tree: &sled::Tree) -> Result<(), StoreError> {
+        let err_fn = |e: Box<dyn Error>, key: String| {
+            ConflictableTransactionError::Abort(StoreErrorKind::WriteStateMachine.build_with_tree(
+                format!(
+                    "failed to serialize state machine from sled with key {}",
+                    key
+                ),
+                e.into(),
+                SledStoreTree::StateMachine,
+            ))
+        };
+        let _tx: () = tree
+            .transaction(|tx| {
+                // insert last applied log if it exists
+                if let Some(last_applied_log) = &self.last_applied_log {
+                    tx.insert(
+                        "last_applied_log",
+                        last_applied_log
+                            .to_saveable_value()
+                            .map_err(|e| err_fn(e, "last_applied_log".to_string()))?,
+                    )?;
+                }
+                tx.insert(
+                    "executor_health_checks",
+                    self.executor_health_checks
+                        .to_saveable_value()
+                        .map_err(|e| err_fn(e, "executor_health_checks".to_string()))?,
+                )?;
+                tx.insert(
+                    "executors",
+                    self.executors
+                        .to_saveable_value()
+                        .map_err(|e| err_fn(e, "executors".to_string()))?,
+                )?;
+                tx.insert(
+                    "tasks",
+                    self.tasks
+                        .to_saveable_value()
+                        .map_err(|e| err_fn(e, "tasks".to_string()))?,
+                )?;
+                tx.insert(
+                    "unassigned_tasks",
+                    self.unassigned_tasks
+                        .to_saveable_value()
+                        .map_err(|e| err_fn(e, "unassigned_tasks".to_string()))?,
+                )?;
+                tx.insert(
+                    "task_assignments",
+                    self.task_assignments
+                        .to_saveable_value()
+                        .map_err(|e| err_fn(e, "task_assignments".to_string()))?,
+                )?;
+                tx.insert(
+                    "extraction_events",
+                    self.extraction_events
+                        .to_saveable_value()
+                        .map_err(|e| err_fn(e, "extraction_events".to_string()))?,
+                )?;
+                tx.insert(
+                    "unprocessed_extraction_events",
+                    self.unprocessed_extraction_events
+                        .to_saveable_value()
+                        .map_err(|e| err_fn(e, "unprocessed_extraction_events".to_string()))?,
+                )?;
+                tx.insert(
+                    "content_table",
+                    self.content_table
+                        .to_saveable_value()
+                        .map_err(|e| err_fn(e, "content_table".to_string()))?,
+                )?;
+                tx.insert(
+                    "content_repository_table",
+                    self.content_repository_table
+                        .to_saveable_value()
+                        .map_err(|e| err_fn(e, "content_repository_table".to_string()))?,
+                )?;
+                tx.insert(
+                    "bindings_table",
+                    self.bindings_table
+                        .to_saveable_value()
+                        .map_err(|e| err_fn(e, "bindings_table".to_string()))?,
+                )?;
+                tx.insert(
+                    "extractor_executors_table",
+                    self.extractor_executors_table
+                        .to_saveable_value()
+                        .map_err(|e| err_fn(e, "extractor_executors_table".to_string()))?,
+                )?;
+                tx.insert(
+                    "extractors",
+                    self.extractors
+                        .to_saveable_value()
+                        .map_err(|e| err_fn(e, "extractors".to_string()))?,
+                )?;
+                tx.insert(
+                    "repositories",
+                    self.repositories
+                        .to_saveable_value()
+                        .map_err(|e| err_fn(e, "repositories".to_string()))?,
+                )?;
+                tx.insert(
+                    "repository_extractors",
+                    self.repository_extractors
+                        .to_saveable_value()
+                        .map_err(|e| err_fn(e, "repository_extractors".to_string()))?,
+                )?;
+                tx.insert(
+                    "index_table",
+                    self.index_table
+                        .to_saveable_value()
+                        .map_err(|e| err_fn(e, "index_table".to_string()))?,
+                )?;
+                Ok(())
+            })
+            .map_err(|e| {
+                StoreError::new(
+                    StoreErrorKind::WriteStateMachine,
+                    format!("failed to write state machine to sled"),
+                )
+                .with_tree(SledStoreTree::StateMachine)
+                .with_source(e.into())
+            })?;
+        Ok(())
+    }
+
+    pub fn from_sled_db(db: Arc<sled::Db>) -> Result<StateMachine, StoreError> {
+        let tree = db.open_tree(SledStoreTree::StateMachine.to_string())?;
+
+        let state_machine = StateMachine::try_from_sled_tree(tree)?;
+
+        Ok(state_machine)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct SnapshotIndex(pub u64);
+
+#[cfg(test)]
+mod store_tests {
+    use std::collections::BTreeSet;
+
+    use openraft::{LeaderId, Membership};
+
+    use super::*;
+
+    // test serialization and deserialization of SledStoreValues and log keys
+    #[test]
+    fn test_store_retrieve_log() {
+        let mut nodes = BTreeSet::<NodeId>::new();
+        nodes.insert(1);
+        nodes.insert(2);
+        let log = Entry::<TypeConfig> {
+            log_id: LogId {
+                index: 1,
+                leader_id: LeaderId::new(1, 1),
+            },
+            payload: EntryPayload::Membership(Membership::new(vec![], nodes)),
+        };
+        let log_key = LogKey::from_log(&log);
+        // let log_value = SledStoreValues::log(log.clone());
+        let serialized_log_value = log.to_saveable_value();
+        let serialized_log_value = match serialized_log_value {
+            Ok(v) => v,
+            Err(e) => {
+                panic!("failed to serialize log: {}", e);
+            }
+        };
+        // put into a sled tree and retrieve it
+        let temp_sled_db = sled::Config::default().temporary(true).open().unwrap();
+        let tree = "test-log";
+        let tree = temp_sled_db.open_tree(tree).unwrap();
+        let _ = tree
+            .insert(log_key.to_raw_log_key(), serialized_log_value.clone())
+            .unwrap();
+        let retrieved_log_value = tree.get(log_key.to_raw_log_key()).unwrap();
+        assert_eq!(retrieved_log_value, Some(serialized_log_value));
+        let retrieved_log_value = retrieved_log_value.unwrap();
+
+        let deserialized_log_value =
+            Entry::<TypeConfig>::load_from_sled_value(retrieved_log_value).unwrap();
+        assert_eq!(deserialized_log_value, log);
+        assert_eq!(log_key, LogKey::from_log(&log));
+        assert_eq!(log_key, LogKey::from_log_id(&log.log_id));
+        assert_eq!(log_key, LogKey::from_u64(1));
+        assert_eq!(log_key, LogKey::from(1));
+    }
+
+    #[test]
+    fn test_store_retrieve_snapshot() {
+        let snapshot = StoredSnapshot {
+            meta: SnapshotMeta {
+                last_log_id: Some(LogId {
+                    index: 1,
+                    leader_id: LeaderId::new(1, 1),
+                }),
+                last_membership: StoredMembership::new(
+                    Some(LogId {
+                        index: 1,
+                        leader_id: LeaderId::new(1, 1),
+                    }),
+                    Membership::new(vec![], ()),
+                ),
+                snapshot_id: "test".to_string(),
+            },
+            data: vec![],
+        };
+        let serialized_snapshot_value = snapshot.to_saveable_value().unwrap();
+        let deserialized_snapshot_value =
+            StoredSnapshot::load_from_sled_value(serialized_snapshot_value).unwrap();
+        assert_eq!(deserialized_snapshot_value, snapshot);
+    }
+
+    #[test]
+    fn test_store_retrieve_vote() {
+        let vote = Vote::<NodeId> {
+            leader_id: LeaderId::new(1, 1),
+            committed: true,
+        };
+        let serialized_vote_value = vote.to_saveable_value().unwrap();
+        let deserialized_vote_value =
+            Vote::<u64>::load_from_sled_value(serialized_vote_value).unwrap();
+        assert_eq!(deserialized_vote_value, vote);
+    }
+
+    #[test]
+    fn test_store_retrieve_state_machine() {
+        let state_machine = StateMachine::default();
+        let temp_sled_db = sled::Config::default().temporary(true).open().unwrap();
+        let tree = "test-state-machine";
+        let tree = temp_sled_db.open_tree(tree).unwrap();
+        let _ = state_machine.try_save_to_sled_tree(&tree).unwrap();
+        let deserialized_state_machine_value = StateMachine::try_from_sled_tree(tree).unwrap();
+        // remove the db from the filesystem
+        temp_sled_db
+            .flush()
+            .expect("failed to flush sled db to disk");
+        temp_sled_db
+            .clear()
+            .expect("failed to clear sled db from disk");
+
+        assert_eq!(deserialized_state_machine_value, state_machine);
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SledStoreTree {
+    Store,
+    StateMachine,
+    Logs,
+}
+
+impl Display for SledStoreTree {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SledStoreTree::Store => write!(f, "store"),
+            SledStoreTree::StateMachine => write!(f, "state_machine"),
+            SledStoreTree::Logs => write!(f, "logs"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum StoreKey {
+    LastPurgedLogId,
+    SnapshotIndex,
+    Vote,
+    CurrentSnapshot,
+}
+
+impl Display for StoreKey {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            StoreKey::LastPurgedLogId => write!(f, "last_purged_log_id"),
+            StoreKey::SnapshotIndex => write!(f, "snapshot_index"),
+            StoreKey::Vote => write!(f, "vote"),
+            StoreKey::CurrentSnapshot => write!(f, "current_snapshot"),
+        }
+    }
+}
+
+// converts an id to a byte vector for storing in the database.
+/// Note that we're using big endian encoding to ensure correct sorting of keys
+/// with notes form: <https://github.com/spacejam/sled#a-note-on-lexicographic-ordering-and-endianness>
+fn log_idx_to_bin(id: u64) -> [u8; 8] {
+    let mut buf: [u8; 8] = [0; 8];
+    BigEndian::write_u64(&mut buf, id);
+    buf
+}
+
+fn bin_to_log_idx(buf: &[u8]) -> u64 {
+    BigEndian::read_u64(&buf[0..8])
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct LogKey([u8; 8]);
+
+impl LogKey {
+    pub fn from_u64(id: u64) -> Self {
+        Self(log_idx_to_bin(id))
+    }
+
+    pub fn from_log(log: &Entry<TypeConfig>) -> Self {
+        Self::from_u64(log.log_id.index)
+    }
+
+    pub fn from_log_id(log_id: &LogId<NodeId>) -> Self {
+        Self::from_u64(log_id.index)
+    }
+
+    pub fn to_raw_log_key(&self) -> [u8; 8] {
+        self.0
+    }
+}
+
+impl From<LogKey> for [u8; 8] {
+    fn from(key: LogKey) -> Self {
+        key.0
+    }
+}
+
+impl From<LogKey> for u64 {
+    fn from(key: LogKey) -> Self {
+        bin_to_log_idx(&key.0)
+    }
+}
+
+impl From<u64> for LogKey {
+    fn from(id: u64) -> Self {
+        Self::from_u64(id)
+    }
+}
+
+impl From<IVec> for LogKey {
+    fn from(ivec: IVec) -> Self {
+        Self::from_u64(bin_to_log_idx(&ivec))
+    }
+}
+
+impl AsRef<[u8]> for LogKey {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}


### PR DESCRIPTION
Testing done:
- run with one node
- run multiple nodes

DONE
- Replace serde_json with flexbuffer and bincode

TODO
- Restart node after stopping
- Get automated testing to work
- run different failure scenarios

    Integrate Sled as Raft Backend Storage
    
    - Integrated sled version 0.34 as the storage backend for the Raft consensus algorithm.
    - Refactored Store into store/store.rs - added Sled
    - Implemented critical Raft traits (RaftStorage, RaftLogReader, RaftSnapshotBuilder) utilizing Sled.
    - Adjusted Cargo.toml to include sled in the project dependencies.