### PR TITLE
making the server detect client dropouts more reliably

### DIFF
--- a/src/executor.rs
+++ b/src/executor.rs
@@ -166,12 +166,12 @@ pub async fn heartbeat(
         .await?;
     let mut resp_stream = response.into_inner();
     info!("starting heartbeat");
-    while let Some(recieved) = resp_stream.next().await {
-        if let Err(err) = recieved {
-            error!("unable to recieve heartbeat: {:?}", err);
+    while let Some(received) = resp_stream.next().await {
+        if let Err(err) = received {
+            error!("unable to receive heartbeat: {:?}", err);
             break;
         }
-        let hb_resp = recieved.map_err(|e| anyhow!("error recieving heartbeat: {:?}", e))?;
+        let hb_resp = received.map_err(|e| anyhow!("error receiving heartbeat: {:?}", e))?;
         let mut tasks = Vec::new();
         for task in hb_resp.tasks {
             if task_store.has_finished(&task.id) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,6 +33,7 @@ mod internal_api;
 mod task_store;
 mod test_util;
 mod tls;
+mod tonic_streamer;
 mod utils;
 mod vector_index;
 mod vectordbs;

--- a/src/tonic_streamer.rs
+++ b/src/tonic_streamer.rs
@@ -1,0 +1,28 @@
+use core::task::{Context, Poll};
+use std::{ops::Deref, pin::Pin};
+
+use tokio::sync::mpsc;
+
+pub struct DropReceiver<T> {
+    pub inner: mpsc::Receiver<T>,
+}
+
+impl<T> tokio_stream::Stream for DropReceiver<T> {
+    type Item = T;
+
+    fn poll_next(mut self: std::pin::Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<T>> {
+        Pin::new(&mut self.inner).poll_recv(cx)
+    }
+}
+
+impl<T> Deref for DropReceiver<T> {
+    type Target = mpsc::Receiver<T>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl<T> Drop for DropReceiver<T> {
+    fn drop(&mut self) {}
+}


### PR DESCRIPTION
We can now detect heartbeats stopping more reliably. Clients dropping off is faster so we could do work rebalancing faster and also send less calls to extract on-demand to failed executors. 