### PR TITLE
Removing Extractor Schema

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ paste = { version = "1.0" }
 pgvector = { version = "0.3", features = ["sqlx"] }
 prost = { version = "0.12" }
 prost-types = { version = "0.12" }
-pyo3 = { version = "0.20", features = ["auto-initialize"] }
+pyo3 = { version = "0.20.2", features = ["auto-initialize"] }
 qdrant-client = "1"
 rand = { version = "0.8" }
 redis = { version = "0.24", features = ["async-std-rustls-comp", "default", "cluster", "cluster-async"] }

--- a/indexify_extractor_sdk/__init__.py
+++ b/indexify_extractor_sdk/__init__.py
@@ -1,11 +1,10 @@
-from .base_extractor import Content, Extractor, Feature, EmbeddingSchema, ExtractorSchema
+from .base_extractor import Content, Extractor, Feature, EmbeddingSchema
 from .sentence_transformer import SentenceTransformersEmbedding
 
 __all__ = [
     "Content",
     "EmbeddingSchema",
     "Extractor",
-    "ExtractorSchema",
     "Feature",
     "SentenceTransformersEmbedding"
 ]

--- a/indexify_extractor_sdk/mock_extractor.py
+++ b/indexify_extractor_sdk/mock_extractor.py
@@ -1,4 +1,5 @@
-from .base_extractor import Extractor, Content, Feature, EmbeddingSchema, ExtractorSchema
+from indexify_extractor_sdk.base_extractor import Content
+from .base_extractor import Extractor, Content, Feature
 
 from typing import List
 
@@ -11,14 +12,14 @@ class InputParams(BaseModel):
     b: str = ""
 
 class MockExtractor(Extractor):
+    input_mimes = ["text/plain", "application/pdf", "image/jpeg"]
     def __init__(self):
         super().__init__()
 
     def extract(
-        self, content: List[Content], params: InputParams
-    ) -> List[List[Content]]:
+        self, content: Content, params: InputParams
+    ) -> List[Content]:
         return [
-            [
                 Content.from_text(
                     text="Hello World", feature=Feature.embedding(value=[1, 2, 3])
                 ),
@@ -31,29 +32,16 @@ class MockExtractor(Extractor):
                     labels={"label1": "val1", "label2": "val2"}
                 ),
             ]
-        ]
     
-
-    def extract_query_embeddings(self, query: str) -> List[float]:
-        return [1, 2, 3]
-
-    @classmethod
-    def schemas(cls) -> ExtractorSchema:
-        """
-        Returns a list of options for indexing.
-        """
-        return ExtractorSchema(
-            features={"embedding": EmbeddingSchema(distance_metric="cosine", dim=3)},
-        )
-
-
+    def sample_input(self) -> Content:
+        return Content.from_text("hello world")
+    
 class MockExtractorNoInputParams(Extractor):
     def __init__(self):
         super().__init__()
 
-    def extract(self, content: List[Content], params=None) -> List[List[Content]]:
+    def extract(self, content: Content, params=None) -> List[Content]:
         return [
-            [
                 Content.from_text(
                     text="Hello World", feature=Feature.embedding(value=[1, 2, 3])
                 ),
@@ -61,13 +49,6 @@ class MockExtractorNoInputParams(Extractor):
                     text="Pipe Baz", feature=Feature.embedding(value=[1, 2, 3])
                 ),
             ]
-        ]
-
-    @classmethod
-    def schemas(cls) -> ExtractorSchema:
-        """
-        Returns a list of options for indexing.
-        """
-        return ExtractorSchema(
-            features={"embedding": EmbeddingSchema(distance_metric="cosine", dim=3)},
-        )
+    
+    def sample_input(self) -> Content:
+        return Content.from_text("hello world")

--- a/src/extractor/extractor_runner.rs
+++ b/src/extractor/extractor_runner.rs
@@ -53,7 +53,7 @@ impl ExtractorRunner {
             .embedding_schemas
             .into_iter()
             .map(|(name, schema)| {
-                let distance = IndexDistance::from_str(&schema.distance_metric).unwrap();
+                let distance = IndexDistance::from_str(&schema.distance).unwrap();
                 (
                     name,
                     api::ExtractorOutputSchema::Embedding(api::EmbeddingSchema {

--- a/src/extractor/mod.rs
+++ b/src/extractor/mod.rs
@@ -20,7 +20,7 @@ mod scaffold;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, FromPyObject)]
 pub struct EmbeddingSchema {
-    pub distance_metric: String,
+    pub distance: String,
     pub dim: usize,
 }
 
@@ -47,7 +47,9 @@ pub trait ExtractorCli {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ExtractorSchema {
     pub embedding_schemas: HashMap<String, EmbeddingSchema>,
+    pub metadata_schemas: HashMap<String, serde_json::Value>,
     pub input_params: serde_json::Value,
+    pub input_mimes: Vec<String>,
 }
 pub type ExtractorTS = Arc<dyn Extractor + Sync + Send>;
 

--- a/src/internal_api.rs
+++ b/src/internal_api.rs
@@ -126,12 +126,12 @@ impl From<api::ExtractorDescription> for ExtractorDescription {
         for (output_name, embedding_schema) in extractor.outputs {
             match embedding_schema {
                 api::ExtractorOutputSchema::Embedding(embedding_schema) => {
-                    let distance_metric = embedding_schema.distance.to_string();
+                    let distance = embedding_schema.distance.to_string();
                     output_schema.insert(
                         output_name,
                         OutputSchema::Embedding(EmbeddingSchema {
                             dim: embedding_schema.dim,
-                            distance: distance_metric,
+                            distance,
                         }),
                     );
                 }


### PR DESCRIPTION
Removing Extractor Schema so that it's easier to write extractors. Indexify will automatically discover the schema from the extracted output and a sample input. 