### PR TITLE
Enhance Metadata Filtering with Parent ID and Label matching support

### DIFF
--- a/crates/indexify_proto/src/indexify_coordinator.rs
+++ b/crates/indexify_proto/src/indexify_coordinator.rs
@@ -216,6 +216,15 @@ pub struct ListContentRequest {
     pub repository: ::prost::alloc::string::String,
     #[prost(string, tag = "2")]
     pub source: ::prost::alloc::string::String,
+    #[prost(string, tag = "3")]
+    pub parent_id: ::prost::alloc::string::String,
+    #[prost(bool, tag = "4")]
+    pub has_labels_eq_filter: bool,
+    #[prost(map = "string, string", tag = "5")]
+    pub labels_eq_filter: ::std::collections::HashMap<
+        ::prost::alloc::string::String,
+        ::prost::alloc::string::String,
+    >,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/crates/indexify_proto/src/indexify_coordinator.rs
+++ b/crates/indexify_proto/src/indexify_coordinator.rs
@@ -218,10 +218,8 @@ pub struct ListContentRequest {
     pub source: ::prost::alloc::string::String,
     #[prost(string, tag = "3")]
     pub parent_id: ::prost::alloc::string::String,
-    #[prost(bool, tag = "4")]
-    pub has_labels_eq_filter: bool,
-    #[prost(map = "string, string", tag = "5")]
-    pub labels_eq_filter: ::std::collections::HashMap<
+    #[prost(map = "string, string", tag = "4")]
+    pub labels_eq: ::std::collections::HashMap<
         ::prost::alloc::string::String,
         ::prost::alloc::string::String,
     >,

--- a/crates/indexify_proto/src/lib.rs
+++ b/crates/indexify_proto/src/lib.rs
@@ -1,2 +1,4 @@
+#[rustfmt::skip]
 pub mod indexify_coordinator;
+#[rustfmt::skip]
 pub mod indexify_raft;

--- a/docs/docs/getting_started.md
+++ b/docs/docs/getting_started.md
@@ -79,6 +79,19 @@ Sometimes you might want to read all the metadata of the content for use in anot
 
     ```
 
+Content can be filtered:
+
+=== "curl"
+    ```
+    curl -v http://localhost:8900/repositories/default/content?source=some_source&parent_id=some_parent_id&labels_eq=key1:value1,key2:value2
+    ```
+=== "api spec"
+    ```
+    source: string
+    parent_id: string
+    labels_eq: <key>:<value>,<key>:<value>...
+    ```
+
 ### Using extractors
 
 Extractors are used to extract information from the documents in our repository. The extracted information can be structured (entities, keywords, etc.) or unstructured (embeddings) in nature, and is stored in an index for retrieval. 

--- a/proto/coordinator_service.proto
+++ b/proto/coordinator_service.proto
@@ -179,9 +179,7 @@ message ListContentRequest {
     string repository = 1;
     string source = 2;
     string parent_id = 3;
-
-    bool has_labels_eq_filter = 4;
-    map<string, string> labels_eq_filter = 5;
+    map<string, string> labels_eq = 4;
 }
 
 message ListContentResponse {

--- a/proto/coordinator_service.proto
+++ b/proto/coordinator_service.proto
@@ -178,6 +178,10 @@ message GetRepositoryResponse {
 message ListContentRequest {
     string repository = 1;
     string source = 2;
+    string parent_id = 3;
+
+    bool has_labels_eq_filter = 4;
+    map<string, string> labels_eq_filter = 5;
 }
 
 message ListContentResponse {

--- a/src/api.rs
+++ b/src/api.rs
@@ -13,6 +13,7 @@ use strum::{Display, EnumString};
 use utoipa::{IntoParams, ToSchema};
 
 use crate::{
+    api_utils,
     attribute_index,
     internal_api::{self, TaskOutcome},
     vectordbs,
@@ -278,9 +279,20 @@ impl From<attribute_index::ExtractedMetadata> for ExtractedMetadata {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, ToSchema)]
-pub struct ContentSourceFilter {
+#[derive(Debug, Serialize, Deserialize, ToSchema, PartialEq, Clone)]
+pub struct ListContentParams {
+    #[serde(
+        deserialize_with = "api_utils::deserialize_none_to_empty_string",
+        default
+    )]
     pub source: String,
+    #[serde(
+        deserialize_with = "api_utils::deserialize_none_to_empty_string",
+        default
+    )]
+    pub parent_id: String,
+    #[serde(default, deserialize_with = "api_utils::deserialize_labels_eq_filter")]
+    pub labels_eq: Option<HashMap<String, String>>,
 }
 
 #[derive(Debug, Serialize, Deserialize, IntoParams, ToSchema)]

--- a/src/api.rs
+++ b/src/api.rs
@@ -280,7 +280,7 @@ impl From<attribute_index::ExtractedMetadata> for ExtractedMetadata {
 }
 
 #[derive(Debug, Serialize, Deserialize, ToSchema, PartialEq, Clone)]
-pub struct ListContentParams {
+pub struct ListContentFilters {
     #[serde(
         deserialize_with = "api_utils::deserialize_none_to_empty_string",
         default

--- a/src/api_utils.rs
+++ b/src/api_utils.rs
@@ -1,0 +1,418 @@
+use std::collections::HashMap;
+
+use serde::Deserialize;
+
+pub fn validate_label_key(key: &str) -> Result<(), String> {
+    let validations = [
+        (key.is_ascii(), "must be ASCII"),
+        (key.len() <= 63, "must be 63 characters or less"),
+        (
+            key.chars()
+                .next()
+                .map_or(false, |c| c.is_ascii_alphanumeric()),
+            "must begin with an alphanumeric character",
+        ),
+        (
+            key.chars()
+                .last()
+                .map_or(false, |c| c.is_ascii_alphanumeric()),
+            "must end with an alphanumeric character",
+        ),
+        (
+            key.chars()
+                .all(|c| c.is_ascii_alphanumeric() || ['-', '_', '.'].contains(&c)),
+            "must contain only alphanumeric characters, dashes, underscores, and dots",
+        ),
+    ];
+
+    let mut err_msgs = vec![];
+    for (valid, msg) in validations.iter() {
+        if !valid {
+            err_msgs.push(*msg);
+        }
+    }
+
+    if err_msgs.is_empty() {
+        Ok(())
+    } else {
+        Err(format!(
+            "label key invalid - {} - found key : \"{}\"",
+            err_msgs.join(", "),
+            key
+        ))
+    }
+}
+
+pub fn validate_label_value(value: &str) -> Result<(), String> {
+    // empty string is ok
+    if value.is_empty() {
+        return Ok(());
+    }
+    let validations = [
+        (value.is_ascii(), "must be ASCII"),
+        (value.len() <= 63, "must be 63 characters or less"),
+        (
+            value
+                .chars()
+                .next()
+                .map_or(false, |c| c.is_ascii_alphanumeric()),
+            "must begin with an alphanumeric character",
+        ),
+        (
+            value
+                .chars()
+                .last()
+                .map_or(false, |c| c.is_ascii_alphanumeric()),
+            "must end with an alphanumeric character",
+        ),
+        (
+            value
+                .chars()
+                .all(|c| c.is_ascii_alphanumeric() || ['-', '_', '.'].contains(&c)),
+            "must contain only alphanumeric characters, dashes, underscores, and dots",
+        ),
+    ];
+
+    let mut err_msgs = vec![];
+    for (valid, msg) in validations.iter() {
+        if !valid {
+            err_msgs.push(*msg);
+        }
+    }
+
+    if err_msgs.is_empty() {
+        Ok(())
+    } else {
+        Err(format!(
+            "label value invalid - {} - found value : \"{}\"",
+            err_msgs.join(", "),
+            value
+        ))
+    }
+}
+
+pub fn parse_validate_label_raw(raw: &str) -> Result<(String, String), String> {
+    let mut split = raw.split(':');
+
+    let mut err_msgs = vec![];
+    let validations = [
+        (split.clone().count() > 1, "must have a ':' character"),
+        (
+            split.clone().count() < 3,
+            "must have only one ':' character",
+        ),
+    ];
+
+    for (valid, msg) in validations.iter() {
+        if !valid {
+            err_msgs.push(*msg);
+        }
+    }
+
+    if err_msgs.is_empty() {
+        let key = split.next().unwrap_or("").to_string();
+        let value = split.next().unwrap_or("").to_string();
+        Ok((key, value))
+    } else {
+        Err(format!(
+            "query invalid - {} - raw : \"{}\"",
+            err_msgs.join(", "),
+            raw
+        ))
+    }
+}
+
+#[cfg(test)]
+mod test_label_validation {
+    use super::*;
+
+    #[test]
+    fn test_parse_validate_label_raw() {
+        let invalid_raw_labels = vec!["", "key", "key:value:value2", "key:value:value2:value3"];
+
+        let valid_raw_labels = vec![
+            ("key:value", ("key".to_string(), "value".to_string())),
+            ("key:", ("key".to_string(), "".to_string())),
+            (":value", ("".to_string(), "value".to_string())),
+        ];
+
+        for label in invalid_raw_labels {
+            let result = parse_validate_label_raw(label);
+            assert!(result.is_err(), "should be invalid: {}", label);
+        }
+
+        for (label, expected) in valid_raw_labels {
+            let result = parse_validate_label_raw(label);
+            assert!(
+                result.is_ok(),
+                "should be valid: {} - {}",
+                label,
+                result.unwrap_err()
+            );
+            assert_eq!(result.unwrap(), expected);
+        }
+    }
+    #[test]
+    fn test_validate_label_key() {
+        let too_long_string = "a".repeat(64);
+        let good_length_string = "a".repeat(63);
+        let invalid_keys = vec![
+            "",
+            "thumbs_up_emoji_👍",
+            "& ^ % $ # @ !",
+            " ",
+            "_",
+            "_-_.",
+            too_long_string.as_str(),
+        ];
+
+        let valid_keys = vec![
+            "key",
+            "key1",
+            "key-1",
+            "key_1",
+            "key.1",
+            good_length_string.as_str(),
+        ];
+
+        for key in invalid_keys {
+            let result = validate_label_key(key);
+            assert!(result.is_err(), "should be invalid: {}", key);
+        }
+
+        for key in valid_keys {
+            let result = validate_label_key(key);
+            assert!(result.is_ok(), "should be valid: {}", key);
+        }
+    }
+
+    #[test]
+    fn test_validate_label_value() {
+        let too_long_string = "a".repeat(64);
+        let good_length_string = "a".repeat(63);
+        let invalid_values = vec![
+            "thumbs_up_emoji_👍",
+            "& ^ % $ # @ !",
+            " ",
+            "_",
+            "_-_.",
+            too_long_string.as_str(),
+        ];
+
+        let valid_values = vec![
+            "",
+            "value",
+            "value1",
+            "value-1",
+            "value_1",
+            "value.1",
+            good_length_string.as_str(),
+        ];
+
+        for value in invalid_values {
+            let result = validate_label_value(value);
+            assert!(result.is_err(), "should be invalid: {}", value);
+        }
+
+        for value in valid_values {
+            let result = validate_label_value(value);
+            assert!(result.is_ok(), "should be valid: {}", value);
+        }
+    }
+}
+
+pub fn deserialize_none_to_empty_string<'de, D>(deserializer: D) -> Result<String, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let s: Option<String> = serde::Deserialize::deserialize(deserializer)?;
+    Ok(s.unwrap_or("".to_string()))
+}
+
+pub fn deserialize_labels_eq_filter<'de, D>(
+    deserializer: D,
+) -> Result<Option<HashMap<String, String>>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let err_formatter = |msg: String, e: String| -> D::Error {
+        serde::de::Error::custom(format!("invalid labels_eq filter - {}: {}", msg, e))
+    };
+
+    // labels_eq is in the form labels_eq=key1:value1,key2:value2
+    // split on comma
+    let labels = String::deserialize(deserializer)?;
+    let labels: Vec<&str> = labels.split(',').collect();
+
+    // if there's one label and it's an empty string, then it's an empty filter -
+    // return an empty HashMap
+    if labels.len() == 1 && labels[0].is_empty() {
+        return Ok(Some(HashMap::new()));
+    }
+
+    // if there are labels, then parse them
+    let mut labels_eq = HashMap::new();
+    for label in labels {
+        let (key, value) = parse_validate_label_raw(label)
+            .map_err(|e| err_formatter("query invalid".to_string(), e))?;
+
+        // if the key already exists, then it's a duplicate
+        if labels_eq.contains_key(&key) {
+            return Err(err_formatter(
+                "query has duplicate key".to_string(),
+                label.to_string(),
+            ));
+        }
+        validate_label_key(key.as_str())
+            .map_err(|e| err_formatter("key invalid".to_string(), e))?;
+        validate_label_value(value.as_str())
+            .map_err(|e| err_formatter("value invalid".to_string(), e))?;
+
+        labels_eq.insert(key, value);
+    }
+
+    for (key, value) in labels_eq.clone() {
+        // if the first part is empty, then it's invalid
+        if key.is_empty() {
+            return Err(serde::de::Error::custom(format!(
+                "invalid labels_eq filter - must be in the form 'key:value' or 'key:' or ''"
+            )));
+        }
+        // if the second part is empty, then it's an empty string value filter
+        if value.is_empty() {
+            continue;
+        }
+    }
+
+    Ok(Some(labels_eq))
+}
+
+#[cfg(test)]
+mod test_deserialize_labels_eq_filter {
+    use axum::extract::Query;
+    use hyper::Uri;
+
+    use super::*;
+    use crate::api::ListContentParams;
+
+    /// 1. ?source=foo&labels_eq=key:value
+    #[test]
+    fn test_key_value() {
+        let expected_query: Query<ListContentParams> = Query(ListContentParams {
+            source: "foo".to_string(),
+            parent_id: "".to_string(),
+            labels_eq: Some({
+                let mut labels_eq = HashMap::new();
+                labels_eq.insert("key".to_string(), "value".to_string());
+                labels_eq
+            }),
+        });
+
+        let query_str: Uri = "http://example.com/path?source=foo&labels_eq=key:value"
+            .parse()
+            .unwrap();
+        let query: Query<ListContentParams> = Query::try_from_uri(&query_str).unwrap();
+        assert_eq!(query.0, expected_query.0);
+    }
+
+    /// 2. ?source=foo&labels_eq=key:
+    #[test]
+    fn test_key_empty_value() {
+        let expected_query: Query<ListContentParams> = Query(ListContentParams {
+            source: "foo".to_string(),
+            parent_id: "".to_string(),
+            labels_eq: Some({
+                let mut labels_eq = HashMap::new();
+                labels_eq.insert("key".to_string(), "".to_string());
+                labels_eq
+            }),
+        });
+
+        let query_str: Uri = "http://example.com/path?source=foo&labels_eq=key:"
+            .parse()
+            .unwrap();
+        let query: Query<ListContentParams> = Query::try_from_uri(&query_str).unwrap();
+        assert_eq!(query.0, expected_query.0);
+    }
+
+    /// 3. ?source=foo&labels_eq=
+    /// ?source=foo&labels_eq= without a key or value matches on no labels
+    #[test]
+    fn test_empty() {
+        let expected_query: Query<ListContentParams> = Query(ListContentParams {
+            source: "foo".to_string(),
+            parent_id: "".to_string(),
+            labels_eq: Some(HashMap::new()),
+        });
+
+        let query_str: Uri = "http://example.com/path?source=foo&labels_eq="
+            .parse()
+            .unwrap();
+        let query: Query<ListContentParams> = Query::try_from_uri(&query_str).unwrap();
+        assert_eq!(query.0, expected_query.0);
+    }
+
+    /// 4. ?source=foo&labels_eq=key:value&labels_eq=key2:value2
+    #[test]
+    fn test_multiple_key_value() {
+        let expected_query: Query<ListContentParams> = Query(ListContentParams {
+            source: "foo".to_string(),
+            parent_id: "".to_string(),
+            labels_eq: Some({
+                let mut labels_eq = HashMap::new();
+                labels_eq.insert("key".to_string(), "value".to_string());
+                labels_eq.insert("key2".to_string(), "value2".to_string());
+                labels_eq
+            }),
+        });
+
+        let query_str: Uri = "http://example.com/path?source=foo&labels_eq=key:value,key2:value2"
+            .parse()
+            .unwrap();
+        let query: Query<ListContentParams> = Query::try_from_uri(&query_str).unwrap();
+        assert_eq!(query.0, expected_query.0);
+    }
+
+    /// 5. ?source=foo&labels_eq=key:value&labels_eq=key2:
+    #[test]
+    fn test_multiple_key_value_key_empty_value() {
+        let expected_query: Query<ListContentParams> = Query(ListContentParams {
+            source: "foo".to_string(),
+            parent_id: "".to_string(),
+            labels_eq: Some({
+                let mut labels_eq = HashMap::new();
+                labels_eq.insert("key".to_string(), "value".to_string());
+                labels_eq.insert("key2".to_string(), "".to_string());
+                labels_eq
+            }),
+        });
+
+        let query_str: Uri = "http://example.com/path?source=foo&labels_eq=key:value,key2:"
+            .parse()
+            .unwrap();
+        let query: Query<ListContentParams> = Query::try_from_uri(&query_str).unwrap();
+        assert_eq!(query.0, expected_query.0);
+    }
+
+    /// INVALID - each of these throws error
+    #[test]
+    fn test_invalid() {
+        let invalid_query_params: Vec<Uri> = vec![
+            "labels_eq=key:value:key2:value2",
+            "labels_eq=key:value:key2",
+            "labels_eq=:value",
+            "labels_eq=key",
+            "labels_eq=:",
+            "labels_eq=key:value&labels_eq=key2:value2",
+        ]
+        .into_iter()
+        .map(|s| format!("http://example.com/path?source=foo&{}", s))
+        .map(|s| s.parse().unwrap())
+        .collect();
+
+        for query_str in invalid_query_params {
+            let query: Result<Query<ListContentParams>, _> = Query::try_from_uri(&query_str);
+            assert!(query.is_err(), "query should be invalid: {}", query_str);
+        }
+    }
+}

--- a/src/coordinator.rs
+++ b/src/coordinator.rs
@@ -143,15 +143,17 @@ impl Coordinator {
         &self,
         repository: &str,
         source: &str,
+        parent_id: &str,
+        labels: Option<&HashMap<String, String>>,
     ) -> Result<Vec<internal_api::ContentMetadata>> {
-        let content = self.shared_state.list_content(repository).await?;
-        if source.is_empty() {
-            return Ok(content);
-        }
-        Ok(content
-            .into_iter()
-            .filter(|c| c.source == source)
-            .collect::<Vec<internal_api::ContentMetadata>>())
+        let content = self
+            .shared_state
+            .list_content(repository)
+            .await?
+            .into_iter();
+        list_content_filter(content, source, parent_id, labels)
+            .map(|c| Ok(c))
+            .collect::<Result<Vec<internal_api::ContentMetadata>>>()
     }
 
     pub async fn list_bindings(

--- a/src/coordinator.rs
+++ b/src/coordinator.rs
@@ -11,6 +11,7 @@ use tokio::sync::watch::Receiver;
 use tracing::info;
 
 use crate::{
+    coordinator_filters::*,
     internal_api::{
         self,
         ContentMetadata,
@@ -144,14 +145,14 @@ impl Coordinator {
         repository: &str,
         source: &str,
         parent_id: &str,
-        labels: Option<&HashMap<String, String>>,
+        labels_eq: &HashMap<String, String>,
     ) -> Result<Vec<internal_api::ContentMetadata>> {
         let content = self
             .shared_state
             .list_content(repository)
             .await?
             .into_iter();
-        list_content_filter(content, source, parent_id, labels)
+        list_content_filter(content, source, parent_id, labels_eq)
             .map(|c| Ok(c))
             .collect::<Result<Vec<internal_api::ContentMetadata>>>()
     }

--- a/src/coordinator_filters.rs
+++ b/src/coordinator_filters.rs
@@ -116,14 +116,10 @@ mod test_list_content_filter {
         assert_eq!(filtered_content[1].id, "3");
 
         // labels filter - empty - only matches if there are no labels
-        let filtered_content = list_content_filter(
-            content.clone().into_iter(),
-            "",
-            "",
-            Some(&HashMap::new()),
-        )
-        .into_iter()
-        .collect::<Vec<_>>();
+        let filtered_content =
+            list_content_filter(content.clone().into_iter(), "", "", Some(&HashMap::new()))
+                .into_iter()
+                .collect::<Vec<_>>();
         assert_eq!(filtered_content.len(), 2);
         assert_eq!(filtered_content[0].id, "2");
         assert_eq!(filtered_content[1].id, "4");

--- a/src/coordinator_filters.rs
+++ b/src/coordinator_filters.rs
@@ -1,0 +1,158 @@
+use std::collections::HashMap;
+
+use crate::internal_api::ContentMetadata;
+
+/// filter for content metadata
+pub fn list_content_filter<'a>(
+    content: impl IntoIterator<Item = ContentMetadata> + 'a,
+    source: &'a str,
+    parent_id: &'a str,
+    labels_eq: Option<&'a HashMap<String, String>>,
+) -> impl Iterator<Item = ContentMetadata> + 'a {
+    content
+        .into_iter()
+        .filter(move |c| source.is_empty() || c.source == source)
+        .filter(move |c| parent_id.is_empty() || c.parent_id == parent_id)
+        // c.labels HashMap<String, String> must exactly match labels_eq { ("key", "value") }
+        // and not have any other labels
+        .filter(move |c| {
+            // if there's no labels_eq, then all labels are ok
+            if labels_eq.is_none() {
+                return true;
+            }
+            let labels_eq = labels_eq.unwrap();
+            // if there are labels_eq, then all labels must match
+            if c.labels != *labels_eq {
+                return false;
+            }
+            true
+        })
+}
+
+#[cfg(test)]
+mod test_list_content_filter {
+    use std::collections::HashMap;
+
+    use super::*;
+    use crate::state::store::SledStorableTestFactory;
+
+    #[test]
+    fn test_list_content_filter() {
+        let default = ContentMetadata::spawn_instance_for_store_test();
+        let content = vec![
+            ContentMetadata {
+                id: "1".to_string(),
+                source: "source1".to_string(),
+                parent_id: "parent1".to_string(),
+                labels: {
+                    let mut labels = HashMap::new();
+                    labels.insert("key1".to_string(), "value1".to_string());
+                    labels
+                },
+                ..default.clone()
+            },
+            ContentMetadata {
+                id: "2".to_string(),
+                source: "source2".to_string(),
+                parent_id: "parent2".to_string(),
+                labels: HashMap::new(),
+                ..default.clone()
+            },
+            ContentMetadata {
+                id: "3".to_string(),
+                source: "source1".to_string(),
+                parent_id: "parent2".to_string(),
+                labels: {
+                    let mut labels = HashMap::new();
+                    labels.insert("key1".to_string(), "value1".to_string());
+                    labels.insert("key2".to_string(), "value2".to_string());
+                    labels
+                },
+                ..default.clone()
+            },
+            ContentMetadata {
+                id: "4".to_string(),
+                source: "source4".to_string(),
+                parent_id: "parent4".to_string(),
+                labels: HashMap::new(),
+                ..default.clone()
+            },
+        ];
+
+        // no filters
+        let filtered_content = list_content_filter(content.clone().into_iter(), "", "", None)
+            .into_iter()
+            .collect::<Vec<_>>();
+        assert_eq!(filtered_content.len(), 4);
+        assert_eq!(filtered_content[0].id, "1");
+        assert_eq!(filtered_content[1].id, "2");
+        assert_eq!(filtered_content[2].id, "3");
+        assert_eq!(filtered_content[3].id, "4");
+
+        // source filter
+        let filtered_content =
+            list_content_filter(content.clone().into_iter(), "source1", "", None)
+                .into_iter()
+                .collect::<Vec<_>>();
+        assert_eq!(filtered_content.len(), 2);
+        assert_eq!(filtered_content[0].id, "1");
+        assert_eq!(filtered_content[1].id, "3");
+
+        // parent_id and source filter
+        let filtered_content =
+            list_content_filter(content.clone().into_iter(), "source1", "parent2", None)
+                .into_iter()
+                .collect::<Vec<_>>();
+        assert_eq!(filtered_content.len(), 1);
+        assert_eq!(filtered_content[0].id, "3");
+
+        // parent_id filter
+        let filtered_content =
+            list_content_filter(content.clone().into_iter(), "", "parent2", None)
+                .into_iter()
+                .collect::<Vec<_>>();
+        assert_eq!(filtered_content.len(), 2);
+        assert_eq!(filtered_content[0].id, "2");
+        assert_eq!(filtered_content[1].id, "3");
+
+        // labels filter - empty - only matches if there are no labels
+        let filtered_content = list_content_filter(
+            content.clone().into_iter(),
+            "",
+            "",
+            Some(&HashMap::new()),
+        )
+        .into_iter()
+        .collect::<Vec<_>>();
+        assert_eq!(filtered_content.len(), 2);
+        assert_eq!(filtered_content[0].id, "2");
+        assert_eq!(filtered_content[1].id, "4");
+
+        // labels filter - exact match
+        let labels_eq = {
+            let mut labels = HashMap::new();
+            labels.insert("key1".to_string(), "value1".to_string());
+            labels
+        };
+        let filtered_content =
+            list_content_filter(content.clone().into_iter(), "", "", Some(&labels_eq))
+                .into_iter()
+                .collect::<Vec<_>>();
+        assert_eq!(filtered_content.len(), 1);
+        assert_eq!(filtered_content[0].id, "1");
+
+        // labels filter - exact match multiple labels
+        let labels_eq = {
+            let mut labels = HashMap::new();
+            labels.insert("key1".to_string(), "value1".to_string());
+            labels.insert("key2".to_string(), "value2".to_string());
+            labels
+        };
+        let filtered_content =
+            list_content_filter(content.clone().into_iter(), "", "", Some(&labels_eq))
+                .into_iter()
+                .collect::<Vec<_>>();
+        assert_eq!(filtered_content.len(), 1);
+        assert_eq!(filtered_content[0].id, "3");
+    }
+}

--- a/src/coordinator_filters.rs
+++ b/src/coordinator_filters.rs
@@ -7,7 +7,7 @@ pub fn list_content_filter<'a>(
     content: impl IntoIterator<Item = ContentMetadata> + 'a,
     source: &'a str,
     parent_id: &'a str,
-    labels_eq: Option<&'a HashMap<String, String>>,
+    labels_eq: &'a HashMap<String, String>,
 ) -> impl Iterator<Item = ContentMetadata> + 'a {
     content
         .into_iter()
@@ -16,11 +16,10 @@ pub fn list_content_filter<'a>(
         // c.labels HashMap<String, String> must exactly match labels_eq { ("key", "value") }
         // and not have any other labels
         .filter(move |c| {
-            // if there's no labels_eq, then all labels are ok
-            if labels_eq.is_none() {
+            // if labels_eq is an empty hash map, skip the filter
+            if labels_eq.is_empty() {
                 return true;
             }
-            let labels_eq = labels_eq.unwrap();
             // if there are labels_eq, then all labels must match
             if c.labels != *labels_eq {
                 return false;
@@ -39,6 +38,7 @@ mod test_list_content_filter {
     #[test]
     fn test_list_content_filter() {
         let default = ContentMetadata::spawn_instance_for_store_test();
+        let no_labels_filter = HashMap::new();
         let content = vec![
             ContentMetadata {
                 id: "1".to_string(),
@@ -80,9 +80,10 @@ mod test_list_content_filter {
         ];
 
         // no filters
-        let filtered_content = list_content_filter(content.clone().into_iter(), "", "", None)
-            .into_iter()
-            .collect::<Vec<_>>();
+        let filtered_content =
+            list_content_filter(content.clone().into_iter(), "", "", &no_labels_filter)
+                .into_iter()
+                .collect::<Vec<_>>();
         assert_eq!(filtered_content.len(), 4);
         assert_eq!(filtered_content[0].id, "1");
         assert_eq!(filtered_content[1].id, "2");
@@ -90,39 +91,49 @@ mod test_list_content_filter {
         assert_eq!(filtered_content[3].id, "4");
 
         // source filter
-        let filtered_content =
-            list_content_filter(content.clone().into_iter(), "source1", "", None)
-                .into_iter()
-                .collect::<Vec<_>>();
+        let filtered_content = list_content_filter(
+            content.clone().into_iter(),
+            "source1",
+            "",
+            &no_labels_filter,
+        )
+        .into_iter()
+        .collect::<Vec<_>>();
         assert_eq!(filtered_content.len(), 2);
         assert_eq!(filtered_content[0].id, "1");
         assert_eq!(filtered_content[1].id, "3");
 
         // parent_id and source filter
-        let filtered_content =
-            list_content_filter(content.clone().into_iter(), "source1", "parent2", None)
-                .into_iter()
-                .collect::<Vec<_>>();
+        let filtered_content = list_content_filter(
+            content.clone().into_iter(),
+            "source1",
+            "parent2",
+            &no_labels_filter,
+        )
+        .into_iter()
+        .collect::<Vec<_>>();
         assert_eq!(filtered_content.len(), 1);
         assert_eq!(filtered_content[0].id, "3");
 
         // parent_id filter
-        let filtered_content =
-            list_content_filter(content.clone().into_iter(), "", "parent2", None)
-                .into_iter()
-                .collect::<Vec<_>>();
+        let filtered_content = list_content_filter(
+            content.clone().into_iter(),
+            "",
+            "parent2",
+            &no_labels_filter,
+        )
+        .into_iter()
+        .collect::<Vec<_>>();
         assert_eq!(filtered_content.len(), 2);
         assert_eq!(filtered_content[0].id, "2");
         assert_eq!(filtered_content[1].id, "3");
 
-        // labels filter - empty - only matches if there are no labels
+        // labels filter - empty - skips the labels filter
         let filtered_content =
-            list_content_filter(content.clone().into_iter(), "", "", Some(&HashMap::new()))
+            list_content_filter(content.clone().into_iter(), "", "", &no_labels_filter)
                 .into_iter()
                 .collect::<Vec<_>>();
-        assert_eq!(filtered_content.len(), 2);
-        assert_eq!(filtered_content[0].id, "2");
-        assert_eq!(filtered_content[1].id, "4");
+        assert_eq!(filtered_content.len(), 4);
 
         // labels filter - exact match
         let labels_eq = {
@@ -130,10 +141,9 @@ mod test_list_content_filter {
             labels.insert("key1".to_string(), "value1".to_string());
             labels
         };
-        let filtered_content =
-            list_content_filter(content.clone().into_iter(), "", "", Some(&labels_eq))
-                .into_iter()
-                .collect::<Vec<_>>();
+        let filtered_content = list_content_filter(content.clone().into_iter(), "", "", &labels_eq)
+            .into_iter()
+            .collect::<Vec<_>>();
         assert_eq!(filtered_content.len(), 1);
         assert_eq!(filtered_content[0].id, "1");
 
@@ -144,10 +154,9 @@ mod test_list_content_filter {
             labels.insert("key2".to_string(), "value2".to_string());
             labels
         };
-        let filtered_content =
-            list_content_filter(content.clone().into_iter(), "", "", Some(&labels_eq))
-                .into_iter()
-                .collect::<Vec<_>>();
+        let filtered_content = list_content_filter(content.clone().into_iter(), "", "", &labels_eq)
+            .into_iter()
+            .collect::<Vec<_>>();
         assert_eq!(filtered_content.len(), 1);
         assert_eq!(filtered_content[0].id, "3");
     }

--- a/src/coordinator_service.rs
+++ b/src/coordinator_service.rs
@@ -100,9 +100,13 @@ impl CoordinatorService for CoordinatorServiceServer {
         request: tonic::Request<ListContentRequest>,
     ) -> Result<tonic::Response<ListContentResponse>, tonic::Status> {
         let req = request.into_inner();
+        let labels_eq = match req.has_labels_eq_filter {
+            true => Some(&req.labels_eq_filter),
+            false => None,
+        };
         let content_list = self
             .coordinator
-            .list_content(&req.repository, &req.source)
+            .list_content(&req.repository, &req.source, &req.parent_id, labels_eq)
             .await
             .map_err(|e| tonic::Status::aborted(e.to_string()))?;
         Ok(tonic::Response::new(ListContentResponse {

--- a/src/coordinator_service.rs
+++ b/src/coordinator_service.rs
@@ -100,13 +100,9 @@ impl CoordinatorService for CoordinatorServiceServer {
         request: tonic::Request<ListContentRequest>,
     ) -> Result<tonic::Response<ListContentResponse>, tonic::Status> {
         let req = request.into_inner();
-        let labels_eq = match req.has_labels_eq_filter {
-            true => Some(&req.labels_eq_filter),
-            false => None,
-        };
         let content_list = self
             .coordinator
-            .list_content(&req.repository, &req.source, &req.parent_id, labels_eq)
+            .list_content(&req.repository, &req.source, &req.parent_id, &req.labels_eq)
             .await
             .map_err(|e| tonic::Status::aborted(e.to_string()))?;
         Ok(tonic::Response::new(ListContentResponse {

--- a/src/data_repository_manager.rs
+++ b/src/data_repository_manager.rs
@@ -217,17 +217,13 @@ impl DataRepositoryManager {
         repository: &str,
         source_filter: &str,
         parent_id_filter: &str,
-        labels_eq: Option<&HashMap<String, String>>,
+        labels_eq_filter: Option<&HashMap<String, String>>,
     ) -> Result<Vec<api::ContentMetadata>> {
         let req = indexify_coordinator::ListContentRequest {
             repository: repository.to_string(),
             source: source_filter.to_string(),
             parent_id: parent_id_filter.to_string(),
-            has_labels_eq_filter: labels_eq.is_some(),
-            labels_eq_filter: match labels_eq {
-                Some(labels) => labels.clone().to_owned(),
-                None => HashMap::new(),
-            },
+            labels_eq: labels_eq_filter.unwrap_or(&HashMap::new()).clone(),
         };
         let response = self
             .coordinator_client

--- a/src/data_repository_manager.rs
+++ b/src/data_repository_manager.rs
@@ -216,10 +216,18 @@ impl DataRepositoryManager {
         &self,
         repository: &str,
         source_filter: &str,
+        parent_id_filter: &str,
+        labels_eq: Option<&HashMap<String, String>>,
     ) -> Result<Vec<api::ContentMetadata>> {
         let req = indexify_coordinator::ListContentRequest {
             repository: repository.to_string(),
             source: source_filter.to_string(),
+            parent_id: parent_id_filter.to_string(),
+            has_labels_eq_filter: labels_eq.is_some(),
+            labels_eq_filter: match labels_eq {
+                Some(labels) => labels.clone().to_owned(),
+                None => HashMap::new(),
+            },
         };
         let response = self
             .coordinator_client

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ use tracing_subscriber::{
     Layer,
 };
 
+pub mod coordinator_filters;
 pub mod coordinator_service;
 pub mod executor_server;
 pub mod extractor;
@@ -15,6 +16,7 @@ pub mod server_config;
 pub mod state;
 
 mod api;
+mod api_utils;
 mod attribute_index;
 mod blob_storage;
 mod caching;

--- a/src/server.rs
+++ b/src/server.rs
@@ -503,7 +503,7 @@ async fn add_texts(
 async fn list_content(
     Path(repository_name): Path<String>,
     State(state): State<RepositoryEndpointState>,
-    filter: Query<super::api::ListContentParams>,
+    filter: Query<super::api::ListContentFilters>,
 ) -> Result<Json<ListContentResponse>, IndexifyAPIError> {
     let content_list = state
         .repository_manager

--- a/src/server.rs
+++ b/src/server.rs
@@ -503,12 +503,16 @@ async fn add_texts(
 async fn list_content(
     Path(repository_name): Path<String>,
     State(state): State<RepositoryEndpointState>,
-    filter: Option<Query<ContentSourceFilter>>,
+    filter: Query<super::api::ListContentParams>,
 ) -> Result<Json<ListContentResponse>, IndexifyAPIError> {
-    let source_filter = filter.map(|f| f.source.clone()).unwrap_or("".to_string());
     let content_list = state
         .repository_manager
-        .list_content(&repository_name, &source_filter)
+        .list_content(
+            &repository_name,
+            &filter.source,
+            &filter.parent_id,
+            filter.labels_eq.as_ref(),
+        )
         .await
         .map_err(|e| IndexifyAPIError::new(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
     Ok(Json(ListContentResponse { content_list }))

--- a/src/state/store/mod.rs
+++ b/src/state/store/mod.rs
@@ -15,6 +15,7 @@ use std::{
 use anyerror::AnyError;
 use error::*;
 use impl_sled_storable::SledStorable;
+pub use impl_sled_storable::SledStorableTestFactory;
 use openraft::{
     async_trait::async_trait,
     storage::{LogState, Snapshot},


### PR DESCRIPTION
Enhanced the ListContent API to support advanced filtering options. This extension allows users to filter content based on multiple criteria such as `parent_id`, and a new `labels_eq_filter`. The update includes:

- Added `parent_id` and `labels_eq_filter` fields in `ListContentRequest`.
- Implemented new utility functions in `api_utils.rs` for label validation and deserialization.
- Updated `ListContentParams` struct to include `parent_id` and `labels_eq`.
- Created `coordinator_filters.rs` for filtering logic in the content listing.
- Modified `CoordinatorService` to utilize new filters in the `list_content` method.
- Adjusted `DataRepositoryManager` and `server.rs` to accommodate new filter parameters.
- Added to Getting Started docs

This update significantly improves the flexibility of the content querying process, allowing for more precise and efficient data retrieval.

Tests:
- All unit tests and integration tests pass (`cargo test -- --test-threads 1`).
- Thoroughly validated new filters and utility functions for robustness and edge cases.