### PR TITLE
Removing the need to provide indexify.yaml

### DIFF
--- a/crates/indexify_proto/src/indexify_coordinator.rs
+++ b/crates/indexify_proto/src/indexify_coordinator.rs
@@ -166,10 +166,8 @@ pub struct Task {
     #[prost(string, tag = "6")]
     pub extractor_binding: ::prost::alloc::string::String,
     #[prost(map = "string, string", tag = "7")]
-    pub output_index_mapping: ::std::collections::HashMap<
-        ::prost::alloc::string::String,
-        ::prost::alloc::string::String,
-    >,
+    pub output_index_mapping:
+        ::std::collections::HashMap<::prost::alloc::string::String, ::prost::alloc::string::String>,
     #[prost(enumeration = "TaskOutcome", tag = "8")]
     pub outcome: i32,
 }
@@ -192,10 +190,8 @@ pub struct Extractor {
     #[prost(string, tag = "3")]
     pub input_params: ::prost::alloc::string::String,
     #[prost(map = "string, string", tag = "4")]
-    pub outputs: ::std::collections::HashMap<
-        ::prost::alloc::string::String,
-        ::prost::alloc::string::String,
-    >,
+    pub outputs:
+        ::std::collections::HashMap<::prost::alloc::string::String, ::prost::alloc::string::String>,
     #[prost(string, repeated, tag = "5")]
     pub input_mime_types: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
 }
@@ -280,10 +276,8 @@ pub struct ExtractorBinding {
     #[prost(string, tag = "4")]
     pub input_params: ::prost::alloc::string::String,
     #[prost(map = "string, string", tag = "5")]
-    pub filters: ::std::collections::HashMap<
-        ::prost::alloc::string::String,
-        ::prost::alloc::string::String,
-    >,
+    pub filters:
+        ::std::collections::HashMap<::prost::alloc::string::String, ::prost::alloc::string::String>,
     #[prost(string, tag = "6")]
     pub content_source: ::prost::alloc::string::String,
 }
@@ -305,15 +299,11 @@ pub struct ExtractorBindResponse {
     #[prost(message, optional, tag = "2")]
     pub extractor: ::core::option::Option<Extractor>,
     #[prost(map = "string, string", tag = "4")]
-    pub index_name_table_mapping: ::std::collections::HashMap<
-        ::prost::alloc::string::String,
-        ::prost::alloc::string::String,
-    >,
+    pub index_name_table_mapping:
+        ::std::collections::HashMap<::prost::alloc::string::String, ::prost::alloc::string::String>,
     #[prost(map = "string, string", tag = "5")]
-    pub output_index_name_mapping: ::std::collections::HashMap<
-        ::prost::alloc::string::String,
-        ::prost::alloc::string::String,
-    >,
+    pub output_index_name_mapping:
+        ::std::collections::HashMap<::prost::alloc::string::String, ::prost::alloc::string::String>,
 }
 #[derive(serde::Deserialize, serde::Serialize)]
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -328,10 +318,8 @@ pub struct ContentMetadata {
     #[prost(string, tag = "4")]
     pub mime: ::prost::alloc::string::String,
     #[prost(map = "string, string", tag = "5")]
-    pub labels: ::std::collections::HashMap<
-        ::prost::alloc::string::String,
-        ::prost::alloc::string::String,
-    >,
+    pub labels:
+        ::std::collections::HashMap<::prost::alloc::string::String, ::prost::alloc::string::String>,
     #[prost(string, tag = "6")]
     pub storage_url: ::prost::alloc::string::String,
     #[prost(int64, tag = "7")]
@@ -373,7 +361,8 @@ impl TaskOutcome {
     /// String value of the enum field names used in the ProtoBuf definition.
     ///
     /// The values are not transformed in any way and thus are considered stable
-    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    /// (if the ProtoBuf definition does not change) and safe for programmatic
+    /// use.
     pub fn as_str_name(&self) -> &'static str {
         match self {
             TaskOutcome::Unknown => "UNKNOWN",
@@ -381,6 +370,7 @@ impl TaskOutcome {
             TaskOutcome::Success => "SUCCESS",
         }
     }
+
     /// Creates an enum from field names used in the ProtoBuf definition.
     pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
         match value {
@@ -394,8 +384,7 @@ impl TaskOutcome {
 /// Generated client implementations.
 pub mod coordinator_service_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
-    use tonic::codegen::*;
-    use tonic::codegen::http::Uri;
+    use tonic::codegen::{http::Uri, *};
     #[derive(Debug, Clone)]
     pub struct CoordinatorServiceClient<T> {
         inner: tonic::client::Grpc<T>,
@@ -422,10 +411,12 @@ pub mod coordinator_service_client {
             let inner = tonic::client::Grpc::new(inner);
             Self { inner }
         }
+
         pub fn with_origin(inner: T, origin: Uri) -> Self {
             let inner = tonic::client::Grpc::with_origin(inner, origin);
             Self { inner }
         }
+
         pub fn with_interceptor<F>(
             inner: T,
             interceptor: F,
@@ -439,27 +430,29 @@ pub mod coordinator_service_client {
                     <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
                 >,
             >,
-            <T as tonic::codegen::Service<
-                http::Request<tonic::body::BoxBody>,
-            >>::Error: Into<StdError> + Send + Sync,
+            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
+                Into<StdError> + Send + Sync,
         {
             CoordinatorServiceClient::new(InterceptedService::new(inner, interceptor))
         }
+
         /// Compress requests with the given encoding.
         ///
-        /// This requires the server to support it otherwise it might respond with an
-        /// error.
+        /// This requires the server to support it otherwise it might respond
+        /// with an error.
         #[must_use]
         pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
             self.inner = self.inner.send_compressed(encoding);
             self
         }
+
         /// Enable decompressing responses.
         #[must_use]
         pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
             self.inner = self.inner.accept_compressed(encoding);
             self
         }
+
         /// Limits the maximum size of a decoded message.
         ///
         /// Default: `4MB`
@@ -468,6 +461,7 @@ pub mod coordinator_service_client {
             self.inner = self.inner.max_decoding_message_size(limit);
             self
         }
+
         /// Limits the maximum size of an encoded message.
         ///
         /// Default: `usize::MAX`
@@ -476,306 +470,237 @@ pub mod coordinator_service_client {
             self.inner = self.inner.max_encoding_message_size(limit);
             self
         }
+
         pub async fn create_content(
             &mut self,
             request: impl tonic::IntoRequest<super::CreateContentRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::CreateContentResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::CreateContentResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/indexify_coordinator.CoordinatorService/CreateContent",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new(
-                        "indexify_coordinator.CoordinatorService",
-                        "CreateContent",
-                    ),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "indexify_coordinator.CoordinatorService",
+                "CreateContent",
+            ));
             self.inner.unary(req, path, codec).await
         }
+
         pub async fn get_content_metadata(
             &mut self,
             request: impl tonic::IntoRequest<super::GetContentMetadataRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::GetContentMetadataResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::GetContentMetadataResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/indexify_coordinator.CoordinatorService/GetContentMetadata",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new(
-                        "indexify_coordinator.CoordinatorService",
-                        "GetContentMetadata",
-                    ),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "indexify_coordinator.CoordinatorService",
+                "GetContentMetadata",
+            ));
             self.inner.unary(req, path, codec).await
         }
+
         pub async fn list_content(
             &mut self,
             request: impl tonic::IntoRequest<super::ListContentRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::ListContentResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::ListContentResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/indexify_coordinator.CoordinatorService/ListContent",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new(
-                        "indexify_coordinator.CoordinatorService",
-                        "ListContent",
-                    ),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "indexify_coordinator.CoordinatorService",
+                "ListContent",
+            ));
             self.inner.unary(req, path, codec).await
         }
+
         pub async fn create_binding(
             &mut self,
             request: impl tonic::IntoRequest<super::ExtractorBindRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::ExtractorBindResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::ExtractorBindResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/indexify_coordinator.CoordinatorService/CreateBinding",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new(
-                        "indexify_coordinator.CoordinatorService",
-                        "CreateBinding",
-                    ),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "indexify_coordinator.CoordinatorService",
+                "CreateBinding",
+            ));
             self.inner.unary(req, path, codec).await
         }
+
         pub async fn list_bindings(
             &mut self,
             request: impl tonic::IntoRequest<super::ListBindingsRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::ListBindingsResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::ListBindingsResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/indexify_coordinator.CoordinatorService/ListBindings",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new(
-                        "indexify_coordinator.CoordinatorService",
-                        "ListBindings",
-                    ),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "indexify_coordinator.CoordinatorService",
+                "ListBindings",
+            ));
             self.inner.unary(req, path, codec).await
         }
+
         pub async fn create_repository(
             &mut self,
             request: impl tonic::IntoRequest<super::CreateRepositoryRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::CreateRepositoryResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::CreateRepositoryResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/indexify_coordinator.CoordinatorService/CreateRepository",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new(
-                        "indexify_coordinator.CoordinatorService",
-                        "CreateRepository",
-                    ),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "indexify_coordinator.CoordinatorService",
+                "CreateRepository",
+            ));
             self.inner.unary(req, path, codec).await
         }
+
         pub async fn list_repositories(
             &mut self,
             request: impl tonic::IntoRequest<super::ListRepositoriesRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::ListRepositoriesResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::ListRepositoriesResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/indexify_coordinator.CoordinatorService/ListRepositories",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new(
-                        "indexify_coordinator.CoordinatorService",
-                        "ListRepositories",
-                    ),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "indexify_coordinator.CoordinatorService",
+                "ListRepositories",
+            ));
             self.inner.unary(req, path, codec).await
         }
+
         pub async fn get_repository(
             &mut self,
             request: impl tonic::IntoRequest<super::GetRepositoryRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::GetRepositoryResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::GetRepositoryResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/indexify_coordinator.CoordinatorService/GetRepository",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new(
-                        "indexify_coordinator.CoordinatorService",
-                        "GetRepository",
-                    ),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "indexify_coordinator.CoordinatorService",
+                "GetRepository",
+            ));
             self.inner.unary(req, path, codec).await
         }
+
         pub async fn list_extractors(
             &mut self,
             request: impl tonic::IntoRequest<super::ListExtractorsRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::ListExtractorsResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::ListExtractorsResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/indexify_coordinator.CoordinatorService/ListExtractors",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new(
-                        "indexify_coordinator.CoordinatorService",
-                        "ListExtractors",
-                    ),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "indexify_coordinator.CoordinatorService",
+                "ListExtractors",
+            ));
             self.inner.unary(req, path, codec).await
         }
+
         pub async fn register_executor(
             &mut self,
             request: impl tonic::IntoRequest<super::RegisterExecutorRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::RegisterExecutorResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::RegisterExecutorResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/indexify_coordinator.CoordinatorService/RegisterExecutor",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new(
-                        "indexify_coordinator.CoordinatorService",
-                        "RegisterExecutor",
-                    ),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "indexify_coordinator.CoordinatorService",
+                "RegisterExecutor",
+            ));
             self.inner.unary(req, path, codec).await
         }
+
         pub async fn heartbeat(
             &mut self,
             request: impl tonic::IntoStreamingRequest<Message = super::HeartbeatRequest>,
@@ -783,119 +708,92 @@ pub mod coordinator_service_client {
             tonic::Response<tonic::codec::Streaming<super::HeartbeatResponse>>,
             tonic::Status,
         > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/indexify_coordinator.CoordinatorService/Heartbeat",
             );
             let mut req = request.into_streaming_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new(
-                        "indexify_coordinator.CoordinatorService",
-                        "Heartbeat",
-                    ),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "indexify_coordinator.CoordinatorService",
+                "Heartbeat",
+            ));
             self.inner.streaming(req, path, codec).await
         }
+
         pub async fn list_indexes(
             &mut self,
             request: impl tonic::IntoRequest<super::ListIndexesRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::ListIndexesResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::ListIndexesResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/indexify_coordinator.CoordinatorService/ListIndexes",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new(
-                        "indexify_coordinator.CoordinatorService",
-                        "ListIndexes",
-                    ),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "indexify_coordinator.CoordinatorService",
+                "ListIndexes",
+            ));
             self.inner.unary(req, path, codec).await
         }
+
         pub async fn get_index(
             &mut self,
             request: impl tonic::IntoRequest<super::GetIndexRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::GetIndexResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::GetIndexResponse>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/indexify_coordinator.CoordinatorService/GetIndex",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new(
-                        "indexify_coordinator.CoordinatorService",
-                        "GetIndex",
-                    ),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "indexify_coordinator.CoordinatorService",
+                "GetIndex",
+            ));
             self.inner.unary(req, path, codec).await
         }
+
         pub async fn create_index(
             &mut self,
             request: impl tonic::IntoRequest<super::CreateIndexRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::CreateIndexResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::CreateIndexResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/indexify_coordinator.CoordinatorService/CreateIndex",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new(
-                        "indexify_coordinator.CoordinatorService",
-                        "CreateIndex",
-                    ),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "indexify_coordinator.CoordinatorService",
+                "CreateIndex",
+            ));
             self.inner.unary(req, path, codec).await
         }
+
         pub async fn get_extractor_coordinates(
             &mut self,
             request: impl tonic::IntoRequest<super::GetExtractorCoordinatesRequest>,
@@ -903,57 +801,44 @@ pub mod coordinator_service_client {
             tonic::Response<super::GetExtractorCoordinatesResponse>,
             tonic::Status,
         > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/indexify_coordinator.CoordinatorService/GetExtractorCoordinates",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new(
-                        "indexify_coordinator.CoordinatorService",
-                        "GetExtractorCoordinates",
-                    ),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "indexify_coordinator.CoordinatorService",
+                "GetExtractorCoordinates",
+            ));
             self.inner.unary(req, path, codec).await
         }
+
         pub async fn update_task(
             &mut self,
             request: impl tonic::IntoRequest<super::UpdateTaskRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::UpdateTaskResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::UpdateTaskResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static(
                 "/indexify_coordinator.CoordinatorService/UpdateTask",
             );
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(
-                    GrpcMethod::new(
-                        "indexify_coordinator.CoordinatorService",
-                        "UpdateTask",
-                    ),
-                );
+            req.extensions_mut().insert(GrpcMethod::new(
+                "indexify_coordinator.CoordinatorService",
+                "UpdateTask",
+            ));
             self.inner.unary(req, path, codec).await
         }
     }
@@ -962,84 +847,54 @@ pub mod coordinator_service_client {
 pub mod coordinator_service_server {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
-    /// Generated trait containing gRPC methods that should be implemented for use with CoordinatorServiceServer.
+    /// Generated trait containing gRPC methods that should be implemented for
+    /// use with CoordinatorServiceServer.
     #[async_trait]
     pub trait CoordinatorService: Send + Sync + 'static {
         async fn create_content(
             &self,
             request: tonic::Request<super::CreateContentRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::CreateContentResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::CreateContentResponse>, tonic::Status>;
         async fn get_content_metadata(
             &self,
             request: tonic::Request<super::GetContentMetadataRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::GetContentMetadataResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::GetContentMetadataResponse>, tonic::Status>;
         async fn list_content(
             &self,
             request: tonic::Request<super::ListContentRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::ListContentResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::ListContentResponse>, tonic::Status>;
         async fn create_binding(
             &self,
             request: tonic::Request<super::ExtractorBindRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::ExtractorBindResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::ExtractorBindResponse>, tonic::Status>;
         async fn list_bindings(
             &self,
             request: tonic::Request<super::ListBindingsRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::ListBindingsResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::ListBindingsResponse>, tonic::Status>;
         async fn create_repository(
             &self,
             request: tonic::Request<super::CreateRepositoryRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::CreateRepositoryResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::CreateRepositoryResponse>, tonic::Status>;
         async fn list_repositories(
             &self,
             request: tonic::Request<super::ListRepositoriesRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::ListRepositoriesResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::ListRepositoriesResponse>, tonic::Status>;
         async fn get_repository(
             &self,
             request: tonic::Request<super::GetRepositoryRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::GetRepositoryResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::GetRepositoryResponse>, tonic::Status>;
         async fn list_extractors(
             &self,
             request: tonic::Request<super::ListExtractorsRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::ListExtractorsResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::ListExtractorsResponse>, tonic::Status>;
         async fn register_executor(
             &self,
             request: tonic::Request<super::RegisterExecutorRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::RegisterExecutorResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::RegisterExecutorResponse>, tonic::Status>;
         /// Server streaming response type for the Heartbeat method.
         type HeartbeatStream: tonic::codegen::tokio_stream::Stream<
                 Item = std::result::Result<super::HeartbeatResponse, tonic::Status>,
-            >
-            + Send
+            > + Send
             + 'static;
         async fn heartbeat(
             &self,
@@ -1048,24 +903,15 @@ pub mod coordinator_service_server {
         async fn list_indexes(
             &self,
             request: tonic::Request<super::ListIndexesRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::ListIndexesResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::ListIndexesResponse>, tonic::Status>;
         async fn get_index(
             &self,
             request: tonic::Request<super::GetIndexRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::GetIndexResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::GetIndexResponse>, tonic::Status>;
         async fn create_index(
             &self,
             request: tonic::Request<super::CreateIndexRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::CreateIndexResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::CreateIndexResponse>, tonic::Status>;
         async fn get_extractor_coordinates(
             &self,
             request: tonic::Request<super::GetExtractorCoordinatesRequest>,
@@ -1076,10 +922,7 @@ pub mod coordinator_service_server {
         async fn update_task(
             &self,
             request: tonic::Request<super::UpdateTaskRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::UpdateTaskResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::UpdateTaskResponse>, tonic::Status>;
     }
     #[derive(Debug)]
     pub struct CoordinatorServiceServer<T: CoordinatorService> {
@@ -1094,6 +937,7 @@ pub mod coordinator_service_server {
         pub fn new(inner: T) -> Self {
             Self::from_arc(Arc::new(inner))
         }
+
         pub fn from_arc(inner: Arc<T>) -> Self {
             let inner = _Inner(inner);
             Self {
@@ -1104,27 +948,29 @@ pub mod coordinator_service_server {
                 max_encoding_message_size: None,
             }
         }
-        pub fn with_interceptor<F>(
-            inner: T,
-            interceptor: F,
-        ) -> InterceptedService<Self, F>
+
+        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
         where
             F: tonic::service::Interceptor,
         {
             InterceptedService::new(Self::new(inner), interceptor)
         }
+
         /// Enable decompressing requests with the given encoding.
         #[must_use]
         pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
             self.accept_compression_encodings.enable(encoding);
             self
         }
-        /// Compress responses with the given encoding, if the client supports it.
+
+        /// Compress responses with the given encoding, if the client supports
+        /// it.
         #[must_use]
         pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
             self.send_compression_encodings.enable(encoding);
             self
         }
+
         /// Limits the maximum size of a decoded message.
         ///
         /// Default: `4MB`
@@ -1133,6 +979,7 @@ pub mod coordinator_service_server {
             self.max_decoding_message_size = Some(limit);
             self
         }
+
         /// Limits the maximum size of an encoded message.
         ///
         /// Default: `usize::MAX`
@@ -1148,38 +995,37 @@ pub mod coordinator_service_server {
         B: Body + Send + 'static,
         B::Error: Into<StdError> + Send + 'static,
     {
-        type Response = http::Response<tonic::body::BoxBody>;
         type Error = std::convert::Infallible;
         type Future = BoxFuture<Self::Response, Self::Error>;
+        type Response = http::Response<tonic::body::BoxBody>;
+
         fn poll_ready(
             &mut self,
             _cx: &mut Context<'_>,
         ) -> Poll<std::result::Result<(), Self::Error>> {
             Poll::Ready(Ok(()))
         }
+
         fn call(&mut self, req: http::Request<B>) -> Self::Future {
             let inner = self.inner.clone();
             match req.uri().path() {
                 "/indexify_coordinator.CoordinatorService/CreateContent" => {
                     #[allow(non_camel_case_types)]
                     struct CreateContentSvc<T: CoordinatorService>(pub Arc<T>);
-                    impl<
-                        T: CoordinatorService,
-                    > tonic::server::UnaryService<super::CreateContentRequest>
-                    for CreateContentSvc<T> {
+                    impl<T: CoordinatorService>
+                        tonic::server::UnaryService<super::CreateContentRequest>
+                        for CreateContentSvc<T>
+                    {
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         type Response = super::CreateContentResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+
                         fn call(
                             &mut self,
                             request: tonic::Request<super::CreateContentRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as CoordinatorService>::create_content(&inner, request)
-                                    .await
+                                <T as CoordinatorService>::create_content(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -1210,25 +1056,20 @@ pub mod coordinator_service_server {
                 "/indexify_coordinator.CoordinatorService/GetContentMetadata" => {
                     #[allow(non_camel_case_types)]
                     struct GetContentMetadataSvc<T: CoordinatorService>(pub Arc<T>);
-                    impl<
-                        T: CoordinatorService,
-                    > tonic::server::UnaryService<super::GetContentMetadataRequest>
-                    for GetContentMetadataSvc<T> {
+                    impl<T: CoordinatorService>
+                        tonic::server::UnaryService<super::GetContentMetadataRequest>
+                        for GetContentMetadataSvc<T>
+                    {
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         type Response = super::GetContentMetadataResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetContentMetadataRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as CoordinatorService>::get_content_metadata(
-                                        &inner,
-                                        request,
-                                    )
+                                <T as CoordinatorService>::get_content_metadata(&inner, request)
                                     .await
                             };
                             Box::pin(fut)
@@ -1260,23 +1101,20 @@ pub mod coordinator_service_server {
                 "/indexify_coordinator.CoordinatorService/ListContent" => {
                     #[allow(non_camel_case_types)]
                     struct ListContentSvc<T: CoordinatorService>(pub Arc<T>);
-                    impl<
-                        T: CoordinatorService,
-                    > tonic::server::UnaryService<super::ListContentRequest>
-                    for ListContentSvc<T> {
+                    impl<T: CoordinatorService>
+                        tonic::server::UnaryService<super::ListContentRequest>
+                        for ListContentSvc<T>
+                    {
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         type Response = super::ListContentResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+
                         fn call(
                             &mut self,
                             request: tonic::Request<super::ListContentRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as CoordinatorService>::list_content(&inner, request)
-                                    .await
+                                <T as CoordinatorService>::list_content(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -1307,23 +1145,20 @@ pub mod coordinator_service_server {
                 "/indexify_coordinator.CoordinatorService/CreateBinding" => {
                     #[allow(non_camel_case_types)]
                     struct CreateBindingSvc<T: CoordinatorService>(pub Arc<T>);
-                    impl<
-                        T: CoordinatorService,
-                    > tonic::server::UnaryService<super::ExtractorBindRequest>
-                    for CreateBindingSvc<T> {
+                    impl<T: CoordinatorService>
+                        tonic::server::UnaryService<super::ExtractorBindRequest>
+                        for CreateBindingSvc<T>
+                    {
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         type Response = super::ExtractorBindResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+
                         fn call(
                             &mut self,
                             request: tonic::Request<super::ExtractorBindRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as CoordinatorService>::create_binding(&inner, request)
-                                    .await
+                                <T as CoordinatorService>::create_binding(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -1354,23 +1189,20 @@ pub mod coordinator_service_server {
                 "/indexify_coordinator.CoordinatorService/ListBindings" => {
                     #[allow(non_camel_case_types)]
                     struct ListBindingsSvc<T: CoordinatorService>(pub Arc<T>);
-                    impl<
-                        T: CoordinatorService,
-                    > tonic::server::UnaryService<super::ListBindingsRequest>
-                    for ListBindingsSvc<T> {
+                    impl<T: CoordinatorService>
+                        tonic::server::UnaryService<super::ListBindingsRequest>
+                        for ListBindingsSvc<T>
+                    {
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         type Response = super::ListBindingsResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+
                         fn call(
                             &mut self,
                             request: tonic::Request<super::ListBindingsRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as CoordinatorService>::list_bindings(&inner, request)
-                                    .await
+                                <T as CoordinatorService>::list_bindings(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -1401,26 +1233,20 @@ pub mod coordinator_service_server {
                 "/indexify_coordinator.CoordinatorService/CreateRepository" => {
                     #[allow(non_camel_case_types)]
                     struct CreateRepositorySvc<T: CoordinatorService>(pub Arc<T>);
-                    impl<
-                        T: CoordinatorService,
-                    > tonic::server::UnaryService<super::CreateRepositoryRequest>
-                    for CreateRepositorySvc<T> {
+                    impl<T: CoordinatorService>
+                        tonic::server::UnaryService<super::CreateRepositoryRequest>
+                        for CreateRepositorySvc<T>
+                    {
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         type Response = super::CreateRepositoryResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+
                         fn call(
                             &mut self,
                             request: tonic::Request<super::CreateRepositoryRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as CoordinatorService>::create_repository(
-                                        &inner,
-                                        request,
-                                    )
-                                    .await
+                                <T as CoordinatorService>::create_repository(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -1451,26 +1277,20 @@ pub mod coordinator_service_server {
                 "/indexify_coordinator.CoordinatorService/ListRepositories" => {
                     #[allow(non_camel_case_types)]
                     struct ListRepositoriesSvc<T: CoordinatorService>(pub Arc<T>);
-                    impl<
-                        T: CoordinatorService,
-                    > tonic::server::UnaryService<super::ListRepositoriesRequest>
-                    for ListRepositoriesSvc<T> {
+                    impl<T: CoordinatorService>
+                        tonic::server::UnaryService<super::ListRepositoriesRequest>
+                        for ListRepositoriesSvc<T>
+                    {
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         type Response = super::ListRepositoriesResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+
                         fn call(
                             &mut self,
                             request: tonic::Request<super::ListRepositoriesRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as CoordinatorService>::list_repositories(
-                                        &inner,
-                                        request,
-                                    )
-                                    .await
+                                <T as CoordinatorService>::list_repositories(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -1501,23 +1321,20 @@ pub mod coordinator_service_server {
                 "/indexify_coordinator.CoordinatorService/GetRepository" => {
                     #[allow(non_camel_case_types)]
                     struct GetRepositorySvc<T: CoordinatorService>(pub Arc<T>);
-                    impl<
-                        T: CoordinatorService,
-                    > tonic::server::UnaryService<super::GetRepositoryRequest>
-                    for GetRepositorySvc<T> {
+                    impl<T: CoordinatorService>
+                        tonic::server::UnaryService<super::GetRepositoryRequest>
+                        for GetRepositorySvc<T>
+                    {
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         type Response = super::GetRepositoryResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetRepositoryRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as CoordinatorService>::get_repository(&inner, request)
-                                    .await
+                                <T as CoordinatorService>::get_repository(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -1548,23 +1365,20 @@ pub mod coordinator_service_server {
                 "/indexify_coordinator.CoordinatorService/ListExtractors" => {
                     #[allow(non_camel_case_types)]
                     struct ListExtractorsSvc<T: CoordinatorService>(pub Arc<T>);
-                    impl<
-                        T: CoordinatorService,
-                    > tonic::server::UnaryService<super::ListExtractorsRequest>
-                    for ListExtractorsSvc<T> {
+                    impl<T: CoordinatorService>
+                        tonic::server::UnaryService<super::ListExtractorsRequest>
+                        for ListExtractorsSvc<T>
+                    {
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         type Response = super::ListExtractorsResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+
                         fn call(
                             &mut self,
                             request: tonic::Request<super::ListExtractorsRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as CoordinatorService>::list_extractors(&inner, request)
-                                    .await
+                                <T as CoordinatorService>::list_extractors(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -1595,26 +1409,20 @@ pub mod coordinator_service_server {
                 "/indexify_coordinator.CoordinatorService/RegisterExecutor" => {
                     #[allow(non_camel_case_types)]
                     struct RegisterExecutorSvc<T: CoordinatorService>(pub Arc<T>);
-                    impl<
-                        T: CoordinatorService,
-                    > tonic::server::UnaryService<super::RegisterExecutorRequest>
-                    for RegisterExecutorSvc<T> {
+                    impl<T: CoordinatorService>
+                        tonic::server::UnaryService<super::RegisterExecutorRequest>
+                        for RegisterExecutorSvc<T>
+                    {
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         type Response = super::RegisterExecutorResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+
                         fn call(
                             &mut self,
                             request: tonic::Request<super::RegisterExecutorRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as CoordinatorService>::register_executor(
-                                        &inner,
-                                        request,
-                                    )
-                                    .await
+                                <T as CoordinatorService>::register_executor(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -1645,21 +1453,18 @@ pub mod coordinator_service_server {
                 "/indexify_coordinator.CoordinatorService/Heartbeat" => {
                     #[allow(non_camel_case_types)]
                     struct HeartbeatSvc<T: CoordinatorService>(pub Arc<T>);
-                    impl<
-                        T: CoordinatorService,
-                    > tonic::server::StreamingService<super::HeartbeatRequest>
-                    for HeartbeatSvc<T> {
+                    impl<T: CoordinatorService>
+                        tonic::server::StreamingService<super::HeartbeatRequest>
+                        for HeartbeatSvc<T>
+                    {
+                        type Future =
+                            BoxFuture<tonic::Response<Self::ResponseStream>, tonic::Status>;
                         type Response = super::HeartbeatResponse;
                         type ResponseStream = T::HeartbeatStream;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::ResponseStream>,
-                            tonic::Status,
-                        >;
+
                         fn call(
                             &mut self,
-                            request: tonic::Request<
-                                tonic::Streaming<super::HeartbeatRequest>,
-                            >,
+                            request: tonic::Request<tonic::Streaming<super::HeartbeatRequest>>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
@@ -1694,23 +1499,20 @@ pub mod coordinator_service_server {
                 "/indexify_coordinator.CoordinatorService/ListIndexes" => {
                     #[allow(non_camel_case_types)]
                     struct ListIndexesSvc<T: CoordinatorService>(pub Arc<T>);
-                    impl<
-                        T: CoordinatorService,
-                    > tonic::server::UnaryService<super::ListIndexesRequest>
-                    for ListIndexesSvc<T> {
+                    impl<T: CoordinatorService>
+                        tonic::server::UnaryService<super::ListIndexesRequest>
+                        for ListIndexesSvc<T>
+                    {
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         type Response = super::ListIndexesResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+
                         fn call(
                             &mut self,
                             request: tonic::Request<super::ListIndexesRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as CoordinatorService>::list_indexes(&inner, request)
-                                    .await
+                                <T as CoordinatorService>::list_indexes(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -1741,15 +1543,10 @@ pub mod coordinator_service_server {
                 "/indexify_coordinator.CoordinatorService/GetIndex" => {
                     #[allow(non_camel_case_types)]
                     struct GetIndexSvc<T: CoordinatorService>(pub Arc<T>);
-                    impl<
-                        T: CoordinatorService,
-                    > tonic::server::UnaryService<super::GetIndexRequest>
-                    for GetIndexSvc<T> {
+                    impl<T: CoordinatorService> tonic::server::UnaryService<super::GetIndexRequest> for GetIndexSvc<T> {
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         type Response = super::GetIndexResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GetIndexRequest>,
@@ -1787,23 +1584,20 @@ pub mod coordinator_service_server {
                 "/indexify_coordinator.CoordinatorService/CreateIndex" => {
                     #[allow(non_camel_case_types)]
                     struct CreateIndexSvc<T: CoordinatorService>(pub Arc<T>);
-                    impl<
-                        T: CoordinatorService,
-                    > tonic::server::UnaryService<super::CreateIndexRequest>
-                    for CreateIndexSvc<T> {
+                    impl<T: CoordinatorService>
+                        tonic::server::UnaryService<super::CreateIndexRequest>
+                        for CreateIndexSvc<T>
+                    {
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         type Response = super::CreateIndexResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+
                         fn call(
                             &mut self,
                             request: tonic::Request<super::CreateIndexRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as CoordinatorService>::create_index(&inner, request)
-                                    .await
+                                <T as CoordinatorService>::create_index(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -1834,28 +1628,23 @@ pub mod coordinator_service_server {
                 "/indexify_coordinator.CoordinatorService/GetExtractorCoordinates" => {
                     #[allow(non_camel_case_types)]
                     struct GetExtractorCoordinatesSvc<T: CoordinatorService>(pub Arc<T>);
-                    impl<
-                        T: CoordinatorService,
-                    > tonic::server::UnaryService<super::GetExtractorCoordinatesRequest>
-                    for GetExtractorCoordinatesSvc<T> {
+                    impl<T: CoordinatorService>
+                        tonic::server::UnaryService<super::GetExtractorCoordinatesRequest>
+                        for GetExtractorCoordinatesSvc<T>
+                    {
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         type Response = super::GetExtractorCoordinatesResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+
                         fn call(
                             &mut self,
-                            request: tonic::Request<
-                                super::GetExtractorCoordinatesRequest,
-                            >,
+                            request: tonic::Request<super::GetExtractorCoordinatesRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
                                 <T as CoordinatorService>::get_extractor_coordinates(
-                                        &inner,
-                                        request,
-                                    )
-                                    .await
+                                    &inner, request,
+                                )
+                                .await
                             };
                             Box::pin(fut)
                         }
@@ -1886,23 +1675,19 @@ pub mod coordinator_service_server {
                 "/indexify_coordinator.CoordinatorService/UpdateTask" => {
                     #[allow(non_camel_case_types)]
                     struct UpdateTaskSvc<T: CoordinatorService>(pub Arc<T>);
-                    impl<
-                        T: CoordinatorService,
-                    > tonic::server::UnaryService<super::UpdateTaskRequest>
-                    for UpdateTaskSvc<T> {
+                    impl<T: CoordinatorService>
+                        tonic::server::UnaryService<super::UpdateTaskRequest> for UpdateTaskSvc<T>
+                    {
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         type Response = super::UpdateTaskResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+
                         fn call(
                             &mut self,
                             request: tonic::Request<super::UpdateTaskRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as CoordinatorService>::update_task(&inner, request)
-                                    .await
+                                <T as CoordinatorService>::update_task(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -1930,18 +1715,14 @@ pub mod coordinator_service_server {
                     };
                     Box::pin(fut)
                 }
-                _ => {
-                    Box::pin(async move {
-                        Ok(
-                            http::Response::builder()
-                                .status(200)
-                                .header("grpc-status", "12")
-                                .header("content-type", "application/grpc")
-                                .body(empty_body())
-                                .unwrap(),
-                        )
-                    })
-                }
+                _ => Box::pin(async move {
+                    Ok(http::Response::builder()
+                        .status(200)
+                        .header("grpc-status", "12")
+                        .header("content-type", "application/grpc")
+                        .body(empty_body())
+                        .unwrap())
+                }),
             }
         }
     }
@@ -1967,8 +1748,7 @@ pub mod coordinator_service_server {
             write!(f, "{:?}", self.0)
         }
     }
-    impl<T: CoordinatorService> tonic::server::NamedService
-    for CoordinatorServiceServer<T> {
+    impl<T: CoordinatorService> tonic::server::NamedService for CoordinatorServiceServer<T> {
         const NAME: &'static str = "indexify_coordinator.CoordinatorService";
     }
 }

--- a/crates/indexify_proto/src/indexify_raft.rs
+++ b/crates/indexify_proto/src/indexify_raft.rs
@@ -15,8 +15,7 @@ pub struct RaftReply {
 /// Generated client implementations.
 pub mod raft_api_client {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
-    use tonic::codegen::*;
-    use tonic::codegen::http::Uri;
+    use tonic::codegen::{http::Uri, *};
     #[derive(Debug, Clone)]
     pub struct RaftApiClient<T> {
         inner: tonic::client::Grpc<T>,
@@ -43,10 +42,12 @@ pub mod raft_api_client {
             let inner = tonic::client::Grpc::new(inner);
             Self { inner }
         }
+
         pub fn with_origin(inner: T, origin: Uri) -> Self {
             let inner = tonic::client::Grpc::with_origin(inner, origin);
             Self { inner }
         }
+
         pub fn with_interceptor<F>(
             inner: T,
             interceptor: F,
@@ -60,27 +61,29 @@ pub mod raft_api_client {
                     <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
                 >,
             >,
-            <T as tonic::codegen::Service<
-                http::Request<tonic::body::BoxBody>,
-            >>::Error: Into<StdError> + Send + Sync,
+            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
+                Into<StdError> + Send + Sync,
         {
             RaftApiClient::new(InterceptedService::new(inner, interceptor))
         }
+
         /// Compress requests with the given encoding.
         ///
-        /// This requires the server to support it otherwise it might respond with an
-        /// error.
+        /// This requires the server to support it otherwise it might respond
+        /// with an error.
         #[must_use]
         pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
             self.inner = self.inner.send_compressed(encoding);
             self
         }
+
         /// Enable decompressing responses.
         #[must_use]
         pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
             self.inner = self.inner.accept_compressed(encoding);
             self
         }
+
         /// Limits the maximum size of a decoded message.
         ///
         /// Default: `4MB`
@@ -89,6 +92,7 @@ pub mod raft_api_client {
             self.inner = self.inner.max_decoding_message_size(limit);
             self
         }
+
         /// Limits the maximum size of an encoded message.
         ///
         /// Default: `usize::MAX`
@@ -97,89 +101,74 @@ pub mod raft_api_client {
             self.inner = self.inner.max_encoding_message_size(limit);
             self
         }
+
         pub async fn forward(
             &mut self,
             request: impl tonic::IntoRequest<super::RaftRequest>,
         ) -> std::result::Result<tonic::Response<super::RaftReply>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/indexify_raft.RaftApi/Forward",
-            );
+            let path = http::uri::PathAndQuery::from_static("/indexify_raft.RaftApi/Forward");
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("indexify_raft.RaftApi", "Forward"));
             self.inner.unary(req, path, codec).await
         }
+
         pub async fn append_entries(
             &mut self,
             request: impl tonic::IntoRequest<super::RaftRequest>,
         ) -> std::result::Result<tonic::Response<super::RaftReply>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/indexify_raft.RaftApi/AppendEntries",
-            );
+            let path = http::uri::PathAndQuery::from_static("/indexify_raft.RaftApi/AppendEntries");
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("indexify_raft.RaftApi", "AppendEntries"));
             self.inner.unary(req, path, codec).await
         }
+
         pub async fn install_snapshot(
             &mut self,
             request: impl tonic::IntoRequest<super::RaftRequest>,
         ) -> std::result::Result<tonic::Response<super::RaftReply>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/indexify_raft.RaftApi/InstallSnapshot",
-            );
+            let path =
+                http::uri::PathAndQuery::from_static("/indexify_raft.RaftApi/InstallSnapshot");
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("indexify_raft.RaftApi", "InstallSnapshot"));
             self.inner.unary(req, path, codec).await
         }
+
         pub async fn vote(
             &mut self,
             request: impl tonic::IntoRequest<super::RaftRequest>,
         ) -> std::result::Result<tonic::Response<super::RaftReply>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::new(
-                        tonic::Code::Unknown,
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::new(
+                    tonic::Code::Unknown,
+                    format!("Service was not ready: {}", e.into()),
+                )
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/indexify_raft.RaftApi/Vote",
-            );
+            let path = http::uri::PathAndQuery::from_static("/indexify_raft.RaftApi/Vote");
             let mut req = request.into_request();
             req.extensions_mut()
                 .insert(GrpcMethod::new("indexify_raft.RaftApi", "Vote"));
@@ -191,7 +180,8 @@ pub mod raft_api_client {
 pub mod raft_api_server {
     #![allow(unused_variables, dead_code, missing_docs, clippy::let_unit_value)]
     use tonic::codegen::*;
-    /// Generated trait containing gRPC methods that should be implemented for use with RaftApiServer.
+    /// Generated trait containing gRPC methods that should be implemented for
+    /// use with RaftApiServer.
     #[async_trait]
     pub trait RaftApi: Send + Sync + 'static {
         async fn forward(
@@ -224,6 +214,7 @@ pub mod raft_api_server {
         pub fn new(inner: T) -> Self {
             Self::from_arc(Arc::new(inner))
         }
+
         pub fn from_arc(inner: Arc<T>) -> Self {
             let inner = _Inner(inner);
             Self {
@@ -234,27 +225,29 @@ pub mod raft_api_server {
                 max_encoding_message_size: None,
             }
         }
-        pub fn with_interceptor<F>(
-            inner: T,
-            interceptor: F,
-        ) -> InterceptedService<Self, F>
+
+        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
         where
             F: tonic::service::Interceptor,
         {
             InterceptedService::new(Self::new(inner), interceptor)
         }
+
         /// Enable decompressing requests with the given encoding.
         #[must_use]
         pub fn accept_compressed(mut self, encoding: CompressionEncoding) -> Self {
             self.accept_compression_encodings.enable(encoding);
             self
         }
-        /// Compress responses with the given encoding, if the client supports it.
+
+        /// Compress responses with the given encoding, if the client supports
+        /// it.
         #[must_use]
         pub fn send_compressed(mut self, encoding: CompressionEncoding) -> Self {
             self.send_compression_encodings.enable(encoding);
             self
         }
+
         /// Limits the maximum size of a decoded message.
         ///
         /// Default: `4MB`
@@ -263,6 +256,7 @@ pub mod raft_api_server {
             self.max_decoding_message_size = Some(limit);
             self
         }
+
         /// Limits the maximum size of an encoded message.
         ///
         /// Default: `usize::MAX`
@@ -278,36 +272,33 @@ pub mod raft_api_server {
         B: Body + Send + 'static,
         B::Error: Into<StdError> + Send + 'static,
     {
-        type Response = http::Response<tonic::body::BoxBody>;
         type Error = std::convert::Infallible;
         type Future = BoxFuture<Self::Response, Self::Error>;
+        type Response = http::Response<tonic::body::BoxBody>;
+
         fn poll_ready(
             &mut self,
             _cx: &mut Context<'_>,
         ) -> Poll<std::result::Result<(), Self::Error>> {
             Poll::Ready(Ok(()))
         }
+
         fn call(&mut self, req: http::Request<B>) -> Self::Future {
             let inner = self.inner.clone();
             match req.uri().path() {
                 "/indexify_raft.RaftApi/Forward" => {
                     #[allow(non_camel_case_types)]
                     struct ForwardSvc<T: RaftApi>(pub Arc<T>);
-                    impl<T: RaftApi> tonic::server::UnaryService<super::RaftRequest>
-                    for ForwardSvc<T> {
+                    impl<T: RaftApi> tonic::server::UnaryService<super::RaftRequest> for ForwardSvc<T> {
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         type Response = super::RaftReply;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+
                         fn call(
                             &mut self,
                             request: tonic::Request<super::RaftRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move {
-                                <T as RaftApi>::forward(&inner, request).await
-                            };
+                            let fut = async move { <T as RaftApi>::forward(&inner, request).await };
                             Box::pin(fut)
                         }
                     }
@@ -337,13 +328,10 @@ pub mod raft_api_server {
                 "/indexify_raft.RaftApi/AppendEntries" => {
                     #[allow(non_camel_case_types)]
                     struct AppendEntriesSvc<T: RaftApi>(pub Arc<T>);
-                    impl<T: RaftApi> tonic::server::UnaryService<super::RaftRequest>
-                    for AppendEntriesSvc<T> {
+                    impl<T: RaftApi> tonic::server::UnaryService<super::RaftRequest> for AppendEntriesSvc<T> {
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         type Response = super::RaftReply;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+
                         fn call(
                             &mut self,
                             request: tonic::Request<super::RaftRequest>,
@@ -381,13 +369,10 @@ pub mod raft_api_server {
                 "/indexify_raft.RaftApi/InstallSnapshot" => {
                     #[allow(non_camel_case_types)]
                     struct InstallSnapshotSvc<T: RaftApi>(pub Arc<T>);
-                    impl<T: RaftApi> tonic::server::UnaryService<super::RaftRequest>
-                    for InstallSnapshotSvc<T> {
+                    impl<T: RaftApi> tonic::server::UnaryService<super::RaftRequest> for InstallSnapshotSvc<T> {
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         type Response = super::RaftReply;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+
                         fn call(
                             &mut self,
                             request: tonic::Request<super::RaftRequest>,
@@ -425,21 +410,16 @@ pub mod raft_api_server {
                 "/indexify_raft.RaftApi/Vote" => {
                     #[allow(non_camel_case_types)]
                     struct VoteSvc<T: RaftApi>(pub Arc<T>);
-                    impl<T: RaftApi> tonic::server::UnaryService<super::RaftRequest>
-                    for VoteSvc<T> {
+                    impl<T: RaftApi> tonic::server::UnaryService<super::RaftRequest> for VoteSvc<T> {
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         type Response = super::RaftReply;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+
                         fn call(
                             &mut self,
                             request: tonic::Request<super::RaftRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move {
-                                <T as RaftApi>::vote(&inner, request).await
-                            };
+                            let fut = async move { <T as RaftApi>::vote(&inner, request).await };
                             Box::pin(fut)
                         }
                     }
@@ -466,18 +446,14 @@ pub mod raft_api_server {
                     };
                     Box::pin(fut)
                 }
-                _ => {
-                    Box::pin(async move {
-                        Ok(
-                            http::Response::builder()
-                                .status(200)
-                                .header("grpc-status", "12")
-                                .header("content-type", "application/grpc")
-                                .body(empty_body())
-                                .unwrap(),
-                        )
-                    })
-                }
+                _ => Box::pin(async move {
+                    Ok(http::Response::builder()
+                        .status(200)
+                        .header("grpc-status", "12")
+                        .header("content-type", "application/grpc")
+                        .body(empty_body())
+                        .unwrap())
+                }),
             }
         }
     }

--- a/indexify_extractor_sdk/base_extractor.py
+++ b/indexify_extractor_sdk/base_extractor.py
@@ -6,18 +6,27 @@ from typing import get_type_hints
 
 from pydantic import BaseModel, Json
 
+
 class EmbeddingSchema(BaseModel):
     dim: int
     distance: str
+
 
 class Embedding(BaseModel):
     values: List[float]
     distance: str
 
-class InternalExtractorSchema(BaseModel):
+
+class ExtractorDescription(BaseModel):
+    name: str
+    version: str
+    description: str
+    python_dependencies: List[str]
+    system_dependencies: List[str]
     embedding_schemas: dict[str, EmbeddingSchema]
     input_params: Optional[str]
     input_mime_types: List[str]
+
 
 class Feature(BaseModel):
     feature_type: str
@@ -25,13 +34,16 @@ class Feature(BaseModel):
     value: str
 
     @classmethod
-    def embedding(cls, values: List[float], name: str="embedding", distance="cosine"):
+    def embedding(cls, values: List[float], name: str = "embedding", distance="cosine"):
         embedding = Embedding(values=values, distance=distance)
-        return cls(feature_type="embedding", name=name, value=embedding.model_dump_json())
-    
+        return cls(
+            feature_type="embedding", name=name, value=embedding.model_dump_json()
+        )
+
     @classmethod
-    def metadata(cls, value: Json, name: str="metadata"):
+    def metadata(cls, value: Json, name: str = "metadata"):
         return cls(feature_type="metadata", name=name, value=json.dumps(value))
+
 
 class Content(BaseModel):
     content_type: Optional[str]
@@ -43,24 +55,26 @@ class Content(BaseModel):
     def from_text(
         cls, text: str, feature: Feature = None, labels: Dict[str, str] = None
     ):
-
         return cls(
             content_type="text/plain",
             data=bytes(text, "utf-8"),
             feature=feature,
             labels=labels,
         )
-    
 
     @classmethod
     def from_file(cls, path: str):
         import mimetypes
+
         m = mimetypes.guess_extension(path)
         with open(path, "rb") as f:
             return cls(content_type=m, data=f.read())
 
-    
+
 class Extractor(ABC):
+    name: str = ""
+
+    version: str = "0.0.0"
 
     system_dependencies: List[str] = []
 
@@ -72,7 +86,8 @@ class Extractor(ABC):
 
     @abstractmethod
     def extract(
-        self, content: Content, params: Type[BaseModel]=None) -> List[Content]:
+        self, content: Content, params: Type[BaseModel] = None
+    ) -> List[Content]:
         """
         Extracts information from the content.
         """
@@ -81,12 +96,12 @@ class Extractor(ABC):
     @abstractmethod
     def sample_input(self) -> Content:
         pass
-    
+
     def run_sample_input(self) -> List[Content]:
         return self.extract(self.sample_input())
 
-class ExtractorWrapper:
 
+class ExtractorWrapper:
     def __init__(self, module_name: str, class_name: str):
         self._module = import_module(module_name)
         self._cls = getattr(self._module, class_name)
@@ -95,18 +110,21 @@ class ExtractorWrapper:
 
     def extract(self, content: List[Content], params: Json) -> List[List[Content]]:
         params_dict = json.loads(params)
-        param_instance = self._param_cls.model_validate(params_dict) if self._param_cls else None
+        param_instance = (
+            self._param_cls.model_validate(params_dict) if self._param_cls else None
+        )
 
-        # This is because the rust side does batching and on python we don't batch 
+        # This is because the rust side does batching and on python we don't batch
         out = []
         for c in content:
-            extracted_data = self._instance.extract(Content(content_type=c.content_type, data=bytes(c.data)), param_instance)
+            extracted_data = self._instance.extract(
+                Content(content_type=c.content_type, data=bytes(c.data)), param_instance
+            )
             out.append(extracted_data)
         return out
-    
-    def schema(self, input_params: Type[BaseModel] = None) -> InternalExtractorSchema:
+
+    def describe(self, input_params: Type[BaseModel] = None) -> ExtractorDescription:
         s_input = self._instance.sample_input()
-        input_mime_types = self._instance.input_mime_types
         # Come back to this when we can support schemas based on user defined input params
         if input_params is None:
             input_params = self._param_cls() if self._param_cls else None
@@ -114,14 +132,30 @@ class ExtractorWrapper:
         embedding_schemas = {}
         metadata_schemas = {}
         json_schema = self._param_cls.model_json_schema() if self._param_cls else {}
-        json_schema['additionalProperties'] = False
+        json_schema["additionalProperties"] = False
         for content in out_c:
             if content.feature is not None:
                 if content.feature.feature_type == "embedding":
-                    embedding_value: Embedding = Embedding.parse_raw(content.feature.value)
-                    embedding_schema = EmbeddingSchema(dim=len(embedding_value.values), distance=embedding_value.distance)
+                    embedding_value: Embedding = Embedding.parse_raw(
+                        content.feature.value
+                    )
+                    embedding_schema = EmbeddingSchema(
+                        dim=len(embedding_value.values),
+                        distance=embedding_value.distance,
+                    )
                     embedding_schemas[content.feature.name] = embedding_schema
                 elif content.feature.feature_type == "metadata":
-                    metadata_schemas[content.feature.name] = json.loads(content.feature.value)
+                    metadata_schemas[content.feature.name] = json.loads(
+                        content.feature.value
+                    )
 
-        return InternalExtractorSchema(embedding_schemas=embedding_schemas, input_mime_types=input_mime_types, input_params=json.dumps(json_schema))
+        return ExtractorDescription(
+            name=self._instance.name,
+            version=self._instance.version,
+            description=self._instance.description,
+            python_dependencies=self._instance.python_dependencies,
+            system_dependencies=self._instance.system_dependencies,
+            embedding_schemas=embedding_schemas,
+            input_mime_types=self._instance.input_mime_types,
+            input_params=json.dumps(json_schema),
+        )

--- a/src/cmd/extractor/extract.rs
+++ b/src/cmd/extractor/extract.rs
@@ -30,7 +30,7 @@ pub struct Args {
 }
 
 impl Args {
-    pub async fn run(self, _extractor_config_path: String, _: GlobalArgs) {
+    pub async fn run(self, _: GlobalArgs) {
         let Self {
             extractor_path,
             cache_dir,

--- a/src/cmd/extractor/info.rs
+++ b/src/cmd/extractor/info.rs
@@ -21,7 +21,7 @@ pub struct Args {
 }
 
 impl Args {
-    pub async fn run(self, _extractor_config_path: String, _: GlobalArgs) {
+    pub async fn run(self, _: GlobalArgs) {
         let Self {
             config_path: _,
             cache_dir: _,

--- a/src/cmd/extractor/info.rs
+++ b/src/cmd/extractor/info.rs
@@ -32,9 +32,8 @@ impl Args {
         python_path::set_python_path(&extractor_config_path).unwrap();
 
         let extractor_config = ExtractorConfig::from_path(&extractor_config_path).unwrap();
-        let extractor = PythonExtractor::new_from_extractor_path(&extractor_config.module).unwrap();
-        let extractor_runner =
-            extractor_runner::ExtractorRunner::new(Arc::new(extractor), extractor_config);
+        let extractor = PythonExtractor::new_from_extractor_path(&extractor_config.path).unwrap();
+        let extractor_runner = extractor_runner::ExtractorRunner::new(Arc::new(extractor));
         let info = extractor_runner.info().unwrap();
         println!("{}", serde_json::to_string_pretty(&info).unwrap());
     }

--- a/src/cmd/extractor/mod.rs
+++ b/src/cmd/extractor/mod.rs
@@ -1,7 +1,6 @@
 use clap::{Args as ClapArgs, Subcommand};
 
 use super::GlobalArgs;
-use crate::prelude::*;
 
 mod extract;
 mod info;
@@ -17,9 +16,7 @@ pub struct Args {
 
 impl Args {
     pub async fn run(self, global_args: GlobalArgs) {
-        let Self {
-            command,
-        } = self;
+        let Self { command } = self;
 
         match command {
             Command::Extract(args) => args.run(global_args).await,

--- a/src/cmd/extractor/mod.rs
+++ b/src/cmd/extractor/mod.rs
@@ -11,10 +11,6 @@ mod start;
 
 #[derive(Debug, ClapArgs)]
 pub struct Args {
-    /// path to the extractor config file
-    #[arg(global = true, short = 'c', long, default_value = "indexify.yaml")]
-    config_path: String,
-
     #[command(subcommand)]
     command: Command,
 }
@@ -22,18 +18,15 @@ pub struct Args {
 impl Args {
     pub async fn run(self, global_args: GlobalArgs) {
         let Self {
-            config_path,
             command,
         } = self;
 
-        let extractor_config_path = config_path;
-        info!("using config file: {}", &extractor_config_path);
         match command {
-            Command::Extract(args) => args.run(extractor_config_path, global_args).await,
-            Command::New(args) => args.run(extractor_config_path, global_args).await,
-            Command::Package(args) => args.run(extractor_config_path, global_args).await,
-            Command::Start(args) => args.run(extractor_config_path, global_args).await,
-            Command::Info(args) => args.run(extractor_config_path, global_args).await,
+            Command::Extract(args) => args.run(global_args).await,
+            Command::New(args) => args.run(global_args).await,
+            Command::Package(args) => args.run(global_args).await,
+            Command::Start(args) => args.run(global_args).await,
+            Command::Info(args) => args.run(global_args).await,
         }
     }
 }

--- a/src/cmd/extractor/new.rs
+++ b/src/cmd/extractor/new.rs
@@ -14,7 +14,7 @@ pub struct Args {
 }
 
 impl Args {
-    pub async fn run(self, _extractor_config_path: String, _: GlobalArgs) {
+    pub async fn run(self, _: GlobalArgs) {
         let Self { path, name } = self;
 
         let current_dir = std::env::current_dir().expect("cannot get current directory");

--- a/src/cmd/extractor/package.rs
+++ b/src/cmd/extractor/package.rs
@@ -1,21 +1,44 @@
+use std::sync::Arc;
+
 use clap::Args as ClapArgs;
 
-use crate::{cmd::GlobalArgs, prelude::*};
+use tracing_unwrap::ResultExt;
+
+use crate::{
+    cmd::GlobalArgs,
+    extractor::{py_extractors::PythonExtractor, python_path, ExtractorTS},
+    prelude::*,
+};
 
 #[derive(Debug, ClapArgs)]
 pub struct Args {
     #[arg(long)]
     dev: bool,
+
+    #[arg(long)]
+    extractor_path: String,
+
+    #[arg(long)]
+    gpu: bool,
 }
 
 impl Args {
-    pub async fn run(self, extractor_config_path: String, global_args: GlobalArgs) {
-        let Self { dev } = self;
+    pub async fn run(self, _: String, global_args: GlobalArgs) {
+        let Self {
+            dev,
+            extractor_path,
+            gpu,
+        } = self;
 
         let verbose = global_args.verbosity > 1;
 
+        python_path::set_python_path(&extractor_path).unwrap();
+        let extractor = PythonExtractor::new_from_extractor_path(&extractor_path).unwrap_or_log();
+        let extractor: ExtractorTS = Arc::new(extractor);
+        let description = extractor.schemas().unwrap_or_log();
+
         info!("starting indexify packager, version: {}", crate::VERSION);
-        crate::package::Packager::new(extractor_config_path, dev)
+        crate::package::Packager::new(description, dev, extractor_path, gpu)
             .expect("failed to create packager")
             .package(verbose)
             .await

--- a/src/cmd/extractor/package.rs
+++ b/src/cmd/extractor/package.rs
@@ -23,7 +23,7 @@ pub struct Args {
 }
 
 impl Args {
-    pub async fn run(self, _: String, global_args: GlobalArgs) {
+    pub async fn run(self, global_args: GlobalArgs) {
         let Self {
             dev,
             extractor_path,

--- a/src/cmd/extractor/package.rs
+++ b/src/cmd/extractor/package.rs
@@ -1,7 +1,6 @@
 use std::sync::Arc;
 
 use clap::Args as ClapArgs;
-
 use tracing_unwrap::ResultExt;
 
 use crate::{

--- a/src/cmd/extractor/start.rs
+++ b/src/cmd/extractor/start.rs
@@ -6,7 +6,7 @@ use crate::{
     cmd::GlobalArgs,
     executor_server::ExecutorServer,
     prelude::*,
-    server_config::ExecutorConfig,
+    server_config::{ExecutorConfig, ExtractorConfig},
 };
 
 #[derive(Debug, ClapArgs)]
@@ -21,6 +21,9 @@ pub struct Args {
 
     #[arg(long)]
     ingestion_addr: String,
+
+    #[arg(long)]
+    extractor_path: Option<String>,
 }
 
 impl Args {
@@ -29,15 +32,25 @@ impl Args {
             advertise_addr,
             coordinator_addr,
             ingestion_addr,
+            extractor_path,
         } = self;
 
         info!("starting indexify executor, version: {}", crate::VERSION);
+        let extractor_path = match extractor_path {
+            Some(path) => path,
+            None => {
+                ExtractorConfig::from_path("indexify.yaml")
+                    .unwrap_or_else(|_| panic!("unable to load extractor config from indexify.yaml, and extractor path is not provided explicitly via --extractor-path"))
+                    .path
+            }
+        };
         let executor_config = Arc::new(
             ExecutorConfig::default()
                 .with_advertise_addr(advertise_addr)
                 .expect("unable to use the provided advertise address")
                 .with_coordinator_addr(coordinator_addr)
-                .with_ingestion_addr(ingestion_addr),
+                .with_ingestion_addr(ingestion_addr)
+                .with_extractor_path(extractor_path),
         );
         ExecutorServer::new(executor_config)
             .await

--- a/src/cmd/extractor/start.rs
+++ b/src/cmd/extractor/start.rs
@@ -24,7 +24,7 @@ pub struct Args {
 }
 
 impl Args {
-    pub async fn run(self, extractor_config_path: String, _: GlobalArgs) {
+    pub async fn run(self, _: GlobalArgs) {
         let Self {
             advertise_addr,
             coordinator_addr,
@@ -39,7 +39,7 @@ impl Args {
                 .with_coordinator_addr(coordinator_addr)
                 .with_ingestion_addr(ingestion_addr),
         );
-        ExecutorServer::new(&extractor_config_path, executor_config)
+        ExecutorServer::new(executor_config)
             .await
             .expect("failed to create executor server")
             .run()

--- a/src/executor_server.rs
+++ b/src/executor_server.rs
@@ -69,9 +69,8 @@ impl ExecutorServer {
         let advertise_addr = format!("{}:{}", self.executor_config.advertise_if, listen_port);
         let extractor_config = ExtractorConfig::from_path(&self.extractor_config_path)?;
         let extractor =
-            py_extractors::PythonExtractor::new_from_extractor_path(&extractor_config.module)?;
-        let extractor_runner =
-            extractor_runner::ExtractorRunner::new(Arc::new(extractor), extractor_config);
+            py_extractors::PythonExtractor::new_from_extractor_path(&extractor_config.path)?;
+        let extractor_runner = extractor_runner::ExtractorRunner::new(Arc::new(extractor));
         let task_store = Arc::new(TaskStore::new());
         let executor = Arc::new(
             ExtractorExecutor::new(

--- a/src/executor_server.rs
+++ b/src/executor_server.rs
@@ -28,7 +28,7 @@ use crate::{
     executor::{heartbeat, ExtractorExecutor},
     extractor::{extractor_runner, py_extractors, python_path},
     internal_api::{Content, ExtractRequest, ExtractResponse},
-    server_config::{ExecutorConfig, ExtractorConfig},
+    server_config::ExecutorConfig,
     task_store::TaskStore,
 };
 
@@ -44,11 +44,7 @@ pub struct ApiEndpointState {
 }
 
 impl ExecutorServer {
-    pub async fn new(
-        executor_config: Arc<ExecutorConfig>,
-    ) -> Result<Self> {
-        // Set Python Path
-        python_path::set_python_path(".")?;
+    pub async fn new(executor_config: Arc<ExecutorConfig>) -> Result<Self> {
         let coordinator_client =
             Arc::new(CoordinatorClient::new(&executor_config.coordinator_addr));
 
@@ -64,11 +60,11 @@ impl ExecutorServer {
         let listen_addr = listener.local_addr()?.to_string();
         let listen_port = listener.local_addr()?.port();
         let advertise_addr = format!("{}:{}", self.executor_config.advertise_if, listen_port);
-        let extractor_config = ExtractorConfig::from_path("indexify.yaml")?;
-        let extractor =
-            py_extractors::PythonExtractor::new_from_extractor_path(&extractor_config.path)?;
-        let extractor_runner =
-            extractor_runner::ExtractorRunner::new(Arc::new(extractor));
+        python_path::set_python_path(&self.executor_config.extractor_path)?;
+        let extractor = py_extractors::PythonExtractor::new_from_extractor_path(
+            &self.executor_config.extractor_path,
+        )?;
+        let extractor_runner = extractor_runner::ExtractorRunner::new(Arc::new(extractor));
         let task_store = Arc::new(TaskStore::new());
         let executor = Arc::new(
             ExtractorExecutor::new(

--- a/src/extractor/extractor_runner.rs
+++ b/src/extractor/extractor_runner.rs
@@ -7,18 +7,16 @@ use crate::{
     api,
     api::{ExtractorDescription, IndexDistance},
     internal_api::Content,
-    server_config::ExtractorConfig,
 };
 
 #[derive(Debug)]
 pub struct ExtractorRunner {
     extractor: ExtractorTS,
-    config: ExtractorConfig,
 }
 
 impl ExtractorRunner {
-    pub fn new(extractor: ExtractorTS, config: ExtractorConfig) -> Self {
-        Self { extractor, config }
+    pub fn new(extractor: ExtractorTS) -> Self {
+        Self { extractor }
     }
 
     pub fn extract(
@@ -64,8 +62,8 @@ impl ExtractorRunner {
             })
             .collect();
         let extractor_description = ExtractorDescription {
-            name: self.config.name.clone(),
-            description: self.config.description.clone(),
+            name: extractor_schema.name.clone(),
+            description: extractor_schema.description.clone(),
             input_params: extractor_schema.input_params,
             outputs,
             input_mime_types: extractor_schema.input_mimes,

--- a/src/extractor/mod.rs
+++ b/src/extractor/mod.rs
@@ -13,7 +13,7 @@ use tokio_stream::StreamExt;
 pub mod extractor_runner;
 pub mod py_extractors;
 
-use crate::{api::ExtractorDescription, internal_api::Content};
+use crate::{api, internal_api::Content};
 
 pub mod python_path;
 mod scaffold;
@@ -41,11 +41,16 @@ pub trait ExtractorCli {
         input_params: serde_json::Value,
     ) -> Result<Vec<Vec<Content>>>;
     fn extract_from_data(&self, data: Vec<u8>, mime: &str) -> Result<Vec<Content>>;
-    fn info(&self) -> Result<ExtractorDescription>;
+    fn info(&self) -> Result<api::ExtractorDescription>;
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Default, Debug, Clone, Serialize, Deserialize)]
 pub struct ExtractorSchema {
+    pub name: String,
+    pub version: String,
+    pub description: String,
+    pub python_dependencies: Vec<String>,
+    pub system_dependencies: Vec<String>,
     pub embedding_schemas: HashMap<String, EmbeddingSchema>,
     pub metadata_schemas: HashMap<String, serde_json::Value>,
     pub input_params: serde_json::Value,

--- a/src/server_config.rs
+++ b/src/server_config.rs
@@ -194,6 +194,8 @@ pub struct ExecutorConfig {
     pub coordinator_addr: String,
     #[serde(default)]
     pub ingestion_api_addr: String,
+    #[serde(default)]
+    pub extractor_path: String,
 }
 
 impl Default for ExecutorConfig {
@@ -204,6 +206,7 @@ impl Default for ExecutorConfig {
             listen_port: default_executor_port(),
             coordinator_addr: format!("localhost:{}", default_coordinator_port()),
             ingestion_api_addr: format!("localhost:{}", default_server_port()),
+            extractor_path: "".into(),
         }
     }
 }
@@ -248,6 +251,11 @@ impl ExecutorConfig {
 
     pub fn with_ingestion_addr(mut self, addr: String) -> Self {
         self.ingestion_api_addr = addr;
+        self
+    }
+
+    pub fn with_extractor_path(mut self, path: String) -> Self {
+        self.extractor_path = path;
         self
     }
 }

--- a/src/server_config.rs
+++ b/src/server_config.rs
@@ -130,13 +130,7 @@ impl Default for VectorIndexConfig {
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ExtractorConfig {
-    pub name: String,
-    pub version: String,
-    pub description: String,
-    pub module: String,
-    pub gpu: bool,
-    pub system_dependencies: Vec<String>,
-    pub python_dependencies: Vec<String>,
+    pub path: String,
 }
 
 impl ExtractorConfig {


### PR DESCRIPTION
Developers no longer have to provide indexify.yaml to describe the dependencies of an extractor