### PR TITLE
Reintroduce confidence score in search result

### DIFF
--- a/docs/docs/getting_started.md
+++ b/docs/docs/getting_started.md
@@ -227,7 +227,7 @@ Now let's rerun our query for documents related to "sports":
     curl -v -X POST http://localhost:8900/repositories/default/search \
     -H "Content-Type: application/json" \
     -d '{
-            "index": "minil6-embedding",
+            "index": "minil6.embedding",
             "query": "sports", 
             "k": 3
         }'

--- a/src/vectordbs/qdrant.rs
+++ b/src/vectordbs/qdrant.rs
@@ -155,7 +155,7 @@ impl VectorDb for QdrantDb {
                 .map_err(|e| anyhow!("unable to read embedding: {}", e.to_string()))?;
             // TODO similarity score
             documents.push(SearchResult {
-                confidence_score: 0.0,
+                confidence_score: point.score,
                 content_id: qdrant_payload.chunk_id,
             });
         }


### PR DESCRIPTION
Going through the Getting Started guide, I noticed calling the /search
endpoint returned results with `0.0` for the `confidence_score`, which
didn't match the guide contents. It looks like a static value was
introduced [here in #213](https://github.com/tensorlakeai/indexify/pull/213/files#diff-d47fe5859b6ddc1776a6bd7fe57d643c01370723b0761e734dc332f0a3a08e37R158).

I'm not sure why it would be intentional, but in case it's not, this PR
re-introduces `point.score` to the output.

I also updated the guide to fix what I believe is a typo usage of `-` instead of `.` when referencing an index. 