### PR TITLE
Refactor internal_api.rs into its own crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2028,6 +2028,7 @@ dependencies = [
  "hostname",
  "hyper 1.1.0",
  "hyper-util",
+ "indexify_internal_api",
  "indexify_proto",
  "insta",
  "itertools 0.12.0",
@@ -2089,6 +2090,20 @@ dependencies = [
  "utoipa-swagger-ui",
  "vergen",
  "walkdir",
+]
+
+[[package]]
+name = "indexify_internal_api"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "indexify_proto",
+ "mime",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "smart-default",
+ "strum",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ build = "build.rs"
 resolver = "2"
 
 [workspace]
-members = [".", "crates/indexify_proto"] 
+members = [".", "crates/indexify_internal_api", "crates/indexify_proto"] 
 
 [workspace.dependencies]
 anyerror = "*"
@@ -31,6 +31,7 @@ hostname = { version = "0.3" }
 hyper = { version = "1", features = ["full"] }
 hyper-util = { version = "0.1", features = ["service"] }
 itertools = "0.12"
+indexify_internal_api = { path = "crates/indexify_internal_api" }
 indexify_proto = { path = "crates/indexify_proto" }
 jsonschema = "0.17"
 mime = { version = "0.3" }
@@ -116,6 +117,7 @@ hostname = { workspace = true }
 hyper = { workspace = true }
 hyper-util = { workspace = true }
 indexify_proto = { workspace = true }
+indexify_internal_api = { workspace = true }
 itertools = { workspace = true }
 jsonschema = { workspace = true }
 mime = { workspace = true }

--- a/crates/indexify_internal_api/Cargo.toml
+++ b/crates/indexify_internal_api/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "indexify_internal_api"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[lib]
+crate-type = ["rlib"]
+
+[dependencies]
+anyhow = { workspace = true }
+indexify_proto = { workspace = true }
+mime = { workspace = true }
+serde = { workspace = true }
+serde_with = { workspace = true }
+serde_json = { workspace = true }
+smart-default = { workspace = true }
+strum = { workspace = true }

--- a/crates/indexify_internal_api/src/lib.rs
+++ b/crates/indexify_internal_api/src/lib.rs
@@ -128,36 +128,6 @@ impl From<indexify_coordinator::Extractor> for ExtractorDescription {
     }
 }
 
-// impl From<api::ExtractorDescription> for ExtractorDescription {
-//     fn from(extractor: api::ExtractorDescription) -> ExtractorDescription {
-//         let mut output_schema = HashMap::new();
-//         for (output_name, embedding_schema) in extractor.outputs {
-//             match embedding_schema {
-//                 api::ExtractorOutputSchema::Embedding(embedding_schema) => {
-//                     let distance = embedding_schema.distance.to_string();
-//                     output_schema.insert(
-//                         output_name,
-//                         OutputSchema::Embedding(EmbeddingSchema {
-//                             dim: embedding_schema.dim,
-//                             distance,
-//                         }),
-//                     );
-//                 }
-//                 api::ExtractorOutputSchema::Metadata(schema) => {
-//                     output_schema.insert(output_name,
-// OutputSchema::Attributes(schema));                 }
-//             }
-//         }
-//         Self {
-//             name: extractor.name,
-//             description: extractor.description,
-//             input_params: extractor.input_params,
-//             outputs: output_schema,
-//             input_mime_types: extractor.input_mime_types,
-//         }
-//     }
-// }
-
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ExecutorInfo {
     pub id: String,
@@ -206,16 +176,6 @@ pub enum FeatureType {
     #[strum(serialize = "unknown")]
     Unknown,
 }
-
-// impl From<FeatureType> for api::FeatureType {
-//     fn from(feature_type: FeatureType) -> Self {
-//         match feature_type {
-//             FeatureType::Embedding => api::FeatureType::Embedding,
-//             FeatureType::Metadata => api::FeatureType::Metadata,
-//             FeatureType::Unknown => api::FeatureType::Unknown,
-//         }
-//     }
-// }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Feature {

--- a/crates/indexify_internal_api/src/lib.rs
+++ b/crates/indexify_internal_api/src/lib.rs
@@ -11,8 +11,6 @@ use serde_with::{serde_as, BytesOrString};
 use smart_default::SmartDefault;
 use strum::{Display, EnumString};
 
-use crate::api;
-
 #[derive(Debug, Clone, Serialize, PartialEq, Eq, Deserialize)]
 pub struct Index {
     pub repository: String,
@@ -130,35 +128,35 @@ impl From<indexify_coordinator::Extractor> for ExtractorDescription {
     }
 }
 
-impl From<api::ExtractorDescription> for ExtractorDescription {
-    fn from(extractor: api::ExtractorDescription) -> ExtractorDescription {
-        let mut output_schema = HashMap::new();
-        for (output_name, embedding_schema) in extractor.outputs {
-            match embedding_schema {
-                api::ExtractorOutputSchema::Embedding(embedding_schema) => {
-                    let distance = embedding_schema.distance.to_string();
-                    output_schema.insert(
-                        output_name,
-                        OutputSchema::Embedding(EmbeddingSchema {
-                            dim: embedding_schema.dim,
-                            distance,
-                        }),
-                    );
-                }
-                api::ExtractorOutputSchema::Metadata(schema) => {
-                    output_schema.insert(output_name, OutputSchema::Attributes(schema));
-                }
-            }
-        }
-        Self {
-            name: extractor.name,
-            description: extractor.description,
-            input_params: extractor.input_params,
-            outputs: output_schema,
-            input_mime_types: extractor.input_mime_types,
-        }
-    }
-}
+// impl From<api::ExtractorDescription> for ExtractorDescription {
+//     fn from(extractor: api::ExtractorDescription) -> ExtractorDescription {
+//         let mut output_schema = HashMap::new();
+//         for (output_name, embedding_schema) in extractor.outputs {
+//             match embedding_schema {
+//                 api::ExtractorOutputSchema::Embedding(embedding_schema) => {
+//                     let distance = embedding_schema.distance.to_string();
+//                     output_schema.insert(
+//                         output_name,
+//                         OutputSchema::Embedding(EmbeddingSchema {
+//                             dim: embedding_schema.dim,
+//                             distance,
+//                         }),
+//                     );
+//                 }
+//                 api::ExtractorOutputSchema::Metadata(schema) => {
+//                     output_schema.insert(output_name,
+// OutputSchema::Attributes(schema));                 }
+//             }
+//         }
+//         Self {
+//             name: extractor.name,
+//             description: extractor.description,
+//             input_params: extractor.input_params,
+//             outputs: output_schema,
+//             input_mime_types: extractor.input_mime_types,
+//         }
+//     }
+// }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ExecutorInfo {
@@ -209,15 +207,15 @@ pub enum FeatureType {
     Unknown,
 }
 
-impl From<FeatureType> for api::FeatureType {
-    fn from(feature_type: FeatureType) -> Self {
-        match feature_type {
-            FeatureType::Embedding => api::FeatureType::Embedding,
-            FeatureType::Metadata => api::FeatureType::Metadata,
-            FeatureType::Unknown => api::FeatureType::Unknown,
-        }
-    }
-}
+// impl From<FeatureType> for api::FeatureType {
+//     fn from(feature_type: FeatureType) -> Self {
+//         match feature_type {
+//             FeatureType::Embedding => api::FeatureType::Embedding,
+//             FeatureType::Metadata => api::FeatureType::Metadata,
+//             FeatureType::Unknown => api::FeatureType::Unknown,
+//         }
+//     }
+// }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Feature {
@@ -245,21 +243,6 @@ impl Content {
             }
         }
         None
-    }
-}
-
-impl From<Content> for api::Content {
-    fn from(content: Content) -> Self {
-        Self {
-            content_type: content.mime,
-            bytes: content.bytes,
-            feature: content.feature.map(|f| api::Feature {
-                feature_type: f.feature_type.into(),
-                name: f.name,
-                data: f.data,
-            }),
-            labels: content.labels,
-        }
     }
 }
 

--- a/src/cmd/extractor/extract.rs
+++ b/src/cmd/extractor/extract.rs
@@ -2,13 +2,13 @@ use std::{collections::HashMap, sync::Arc};
 
 use anyhow::anyhow;
 use clap::Args as ClapArgs;
+use indexify_internal_api as internal_api;
 use serde_json::json;
 use tracing_unwrap::ResultExt;
 
 use crate::{
     cmd::GlobalArgs,
     extractor::{py_extractors::PythonExtractor, python_path, ExtractorTS},
-    internal_api::Content,
 };
 
 #[derive(Debug, ClapArgs)]
@@ -53,7 +53,7 @@ impl Args {
                 PythonExtractor::new_from_extractor_path(&extractor_path).unwrap_or_log();
             let extractor: ExtractorTS = Arc::new(extractor);
             let content = match (text, file) {
-                (Some(text), None) => Ok(Content {
+                (Some(text), None) => Ok(internal_api::Content {
                     mime: "text/plain".to_string(),
                     bytes: text.as_bytes().to_vec(),
                     feature: None,
@@ -66,7 +66,7 @@ impl Args {
                         })
                         .unwrap_or_log();
                     let mime_type = mime_guess::from_path(&file_path).first_or_octet_stream();
-                    Ok(Content {
+                    Ok(internal_api::Content {
                         mime: mime_type.to_string(),
                         bytes: data,
                         feature: None,

--- a/src/coordinator_filters.rs
+++ b/src/coordinator_filters.rs
@@ -1,14 +1,14 @@
 use std::collections::HashMap;
 
-use crate::internal_api::ContentMetadata;
+use indexify_internal_api as internal_api;
 
 /// filter for content metadata
 pub fn list_content_filter<'a>(
-    content: impl IntoIterator<Item = ContentMetadata> + 'a,
+    content: impl IntoIterator<Item = internal_api::ContentMetadata> + 'a,
     source: &'a str,
     parent_id: &'a str,
     labels_eq: &'a HashMap<String, String>,
-) -> impl Iterator<Item = ContentMetadata> + 'a {
+) -> impl Iterator<Item = internal_api::ContentMetadata> + 'a {
     content
         .into_iter()
         .filter(move |c| source.is_empty() || c.source == source)
@@ -37,10 +37,10 @@ mod test_list_content_filter {
 
     #[test]
     fn test_list_content_filter() {
-        let default = ContentMetadata::spawn_instance_for_store_test();
+        let default = internal_api::ContentMetadata::spawn_instance_for_store_test();
         let no_labels_filter = HashMap::new();
         let content = vec![
-            ContentMetadata {
+            internal_api::ContentMetadata {
                 id: "1".to_string(),
                 source: "source1".to_string(),
                 parent_id: "parent1".to_string(),
@@ -51,14 +51,14 @@ mod test_list_content_filter {
                 },
                 ..default.clone()
             },
-            ContentMetadata {
+            internal_api::ContentMetadata {
                 id: "2".to_string(),
                 source: "source2".to_string(),
                 parent_id: "parent2".to_string(),
                 labels: HashMap::new(),
                 ..default.clone()
             },
-            ContentMetadata {
+            internal_api::ContentMetadata {
                 id: "3".to_string(),
                 source: "source1".to_string(),
                 parent_id: "parent2".to_string(),
@@ -70,7 +70,7 @@ mod test_list_content_filter {
                 },
                 ..default.clone()
             },
-            ContentMetadata {
+            internal_api::ContentMetadata {
                 id: "4".to_string(),
                 source: "source4".to_string(),
                 parent_id: "parent4".to_string(),

--- a/src/coordinator_service.rs
+++ b/src/coordinator_service.rs
@@ -10,6 +10,7 @@ use std::{
 };
 
 use anyhow::{anyhow, Result};
+use indexify_internal_api as internal_api;
 use indexify_proto::indexify_coordinator::{
     self,
     coordinator_service_server::CoordinatorService,
@@ -59,7 +60,6 @@ use tracing::{error, info};
 
 use crate::{
     coordinator::Coordinator,
-    internal_api,
     server_config::ServerConfig,
     state::{self, store::StateChange},
     tonic_streamer::DropReceiver,

--- a/src/data_repository_manager.rs
+++ b/src/data_repository_manager.rs
@@ -9,6 +9,7 @@ use std::{
 
 use anyhow::{anyhow, Result};
 use bytes::Bytes;
+use indexify_internal_api as internal_api;
 use indexify_proto::indexify_coordinator::{
     self,
     ContentMetadata,
@@ -29,7 +30,6 @@ use crate::{
     coordinator_client::CoordinatorClient,
     extractor::ExtractedEmbeddings,
     grpc_helper::GrpcHelper,
-    internal_api::{self, Embedding, OutputSchema},
     vector_index::{ScoredText, VectorIndexManager},
 };
 
@@ -145,7 +145,7 @@ impl DataRepositoryManager {
         let mut index_names = Vec::new();
         let extractor = response.extractor.ok_or(anyhow!("extractor not found"))?;
         for (name, output_schema) in &extractor.outputs {
-            let output_schema: OutputSchema = serde_json::from_str(output_schema)?;
+            let output_schema: internal_api::OutputSchema = serde_json::from_str(output_schema)?;
             let index_name = response.output_index_name_mapping.get(name).unwrap();
             let table_name = response.index_name_table_mapping.get(index_name).unwrap();
             index_names.push(index_name.clone());
@@ -413,8 +413,8 @@ impl DataRepositoryManager {
             if let Some(feature) = content.feature.clone() {
                 match feature.feature_type {
                     api::FeatureType::Embedding => {
-                        let embedding_payload: Embedding = serde_json::from_value(feature.data)
-                            .map_err(|e| {
+                        let embedding_payload: internal_api::Embedding =
+                            serde_json::from_value(feature.data).map_err(|e| {
                                 anyhow!("unable to get embedding from extracted data {}", e)
                             })?;
                         let embeddings = ExtractedEmbeddings {

--- a/src/extractor/extractor_runner.rs
+++ b/src/extractor/extractor_runner.rs
@@ -1,12 +1,12 @@
 use std::{collections::HashMap, str::FromStr};
 
 use anyhow::{anyhow, Ok, Result};
+use indexify_internal_api as internal_api;
 
 use super::ExtractorTS;
 use crate::{
     api,
     api::{ExtractorDescription, IndexDistance},
-    internal_api::Content,
 };
 
 #[derive(Debug)]
@@ -21,15 +21,19 @@ impl ExtractorRunner {
 
     pub fn extract(
         &self,
-        content: Vec<Content>,
+        content: Vec<internal_api::Content>,
         input_params: serde_json::Value,
-    ) -> Result<Vec<Vec<Content>>> {
+    ) -> Result<Vec<Vec<internal_api::Content>>> {
         let extracted_content = self.extractor.extract(content, input_params)?;
         Ok(extracted_content)
     }
 
-    pub fn extract_from_data(&self, data: Vec<u8>, mime: &str) -> Result<Vec<Content>> {
-        let content = Content {
+    pub fn extract_from_data(
+        &self,
+        data: Vec<u8>,
+        mime: &str,
+    ) -> Result<Vec<internal_api::Content>> {
+        let content = internal_api::Content {
             bytes: data,
             mime: mime.to_string(),
             feature: None,

--- a/src/extractor/mod.rs
+++ b/src/extractor/mod.rs
@@ -13,7 +13,9 @@ use tokio_stream::StreamExt;
 pub mod extractor_runner;
 pub mod py_extractors;
 
-use crate::{api, internal_api::Content};
+use indexify_internal_api as internal_api;
+
+use crate::api;
 
 pub mod python_path;
 mod scaffold;
@@ -29,18 +31,18 @@ pub trait Extractor: Debug {
 
     fn extract(
         &self,
-        content: Vec<Content>,
+        content: Vec<internal_api::Content>,
         input_params: serde_json::Value,
-    ) -> Result<Vec<Vec<Content>>, anyhow::Error>;
+    ) -> Result<Vec<Vec<internal_api::Content>>, anyhow::Error>;
 }
 
 pub trait ExtractorCli {
     fn extract(
         &self,
-        content: Vec<Content>,
+        content: Vec<internal_api::Content>,
         input_params: serde_json::Value,
-    ) -> Result<Vec<Vec<Content>>>;
-    fn extract_from_data(&self, data: Vec<u8>, mime: &str) -> Result<Vec<Content>>;
+    ) -> Result<Vec<Vec<internal_api::Content>>>;
+    fn extract_from_data(&self, data: Vec<u8>, mime: &str) -> Result<Vec<internal_api::Content>>;
     fn info(&self) -> Result<api::ExtractorDescription>;
 }
 
@@ -69,7 +71,7 @@ pub async fn run_docker_extractor(
     cache_dir: Option<String>,
     text: Option<String>,
     file_path: Option<String>,
-) -> Result<Vec<Content>, anyhow::Error> {
+) -> Result<Vec<internal_api::Content>, anyhow::Error> {
     let docker = Docker::connect_with_socket_defaults().unwrap();
     let options = Some(CreateContainerOptions {
         name: name.clone().replace('/', "."),

--- a/src/extractor/py_extractors.rs
+++ b/src/extractor/py_extractors.rs
@@ -1,13 +1,13 @@
 use std::{collections::HashMap, path::Path, str::FromStr};
 
 use anyhow::{anyhow, Ok, Result};
+use indexify_internal_api as internal_api;
 use pyo3::{
     prelude::*,
     types::{PyList, PyString},
 };
 
 use super::{EmbeddingSchema, Extractor, ExtractorSchema};
-use crate::internal_api::{self, Content};
 
 const EXTRACT_METHOD: &str = "extract";
 
@@ -190,9 +190,9 @@ impl Extractor for PythonExtractor {
 
     fn extract(
         &self,
-        content: Vec<Content>,
+        content: Vec<internal_api::Content>,
         input_params: serde_json::Value,
-    ) -> Result<Vec<Vec<Content>>, anyhow::Error> {
+    ) -> Result<Vec<Vec<internal_api::Content>>, anyhow::Error> {
         let extracted_content = Python::with_gil(|py| {
             let json_string = serde_json::to_string(&input_params)?.into_py(py);
             let content: Vec<PyContent> = content
@@ -236,7 +236,7 @@ impl Extractor for PythonExtractor {
                         }
                         None => None,
                     };
-                    temp.push(Content {
+                    temp.push(internal_api::Content {
                         mime,
                         bytes: data,
                         feature,

--- a/src/extractor_router.rs
+++ b/src/extractor_router.rs
@@ -1,6 +1,7 @@
 use std::{collections::HashMap, sync::Arc};
 
 use anyhow::{anyhow, Result};
+use indexify_internal_api as internal_api;
 use indexify_proto::indexify_coordinator::GetExtractorCoordinatesRequest;
 use serde::{Deserialize, Serialize};
 use tokio::sync::RwLock;
@@ -10,7 +11,6 @@ use crate::{
     api::Content,
     caching::{Cache, NoOpCache},
     coordinator_client::CoordinatorClient,
-    internal_api::{self, ExtractResponse},
 };
 
 const CONNECT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
@@ -126,8 +126,9 @@ impl ExtractorRouter {
             .await
             .map_err(|e| anyhow!("unable to get response body: {}", e))?;
 
-        let extractor_response: ExtractResponse = serde_json::from_str(&response_body)
-            .map_err(|e| anyhow!("unable to extract response from json: {}", e))?;
+        let extractor_response: internal_api::ExtractResponse =
+            serde_json::from_str(&response_body)
+                .map_err(|e| anyhow!("unable to extract response from json: {}", e))?;
 
         let content_list: Vec<Content> = extractor_response
             .content

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,7 +27,6 @@ mod data_repository_manager;
 mod executor;
 mod extractor_router;
 mod grpc_helper;
-mod internal_api;
 mod task_store;
 mod test_util;
 mod tls;

--- a/src/state/store/impl_sled_storable.rs
+++ b/src/state/store/impl_sled_storable.rs
@@ -5,6 +5,7 @@ use std::{
     string::ToString,
 };
 
+use indexify_internal_api as internal_api;
 use openraft::{
     BasicNode,
     Entry,
@@ -19,17 +20,6 @@ use serde::{Deserialize, Serialize};
 use sled::IVec;
 
 use super::{NodeId, TypeConfig, *};
-use crate::internal_api::{
-    ContentMetadata,
-    ExecutorMetadata,
-    ExtractionEvent,
-    ExtractionEventPayload,
-    ExtractorBinding,
-    ExtractorDescription,
-    Index,
-    OutputSchema,
-    Task,
-};
 
 pub trait SledStorable: Serialize + for<'de> Deserialize<'de> + SledStorableTestFactory {
     fn to_saveable_value(&self) -> Result<IVec, Box<dyn Error>> {
@@ -73,17 +63,17 @@ impl SledStorable for LogId<NodeId> {}
 impl SledStorable for StoredMembership<NodeId, BasicNode> {}
 impl SledStorable for SnapshotIndex {}
 impl SledStorable for HashMap<ExecutorId, u64> {}
-impl SledStorable for HashMap<ExecutorId, ExecutorMetadata> {}
-impl SledStorable for HashMap<TaskId, Task> {}
-impl SledStorable for HashMap<ExtractionEventId, ExtractionEvent> {}
-impl SledStorable for HashMap<ContentId, ContentMetadata> {}
+impl SledStorable for HashMap<ExecutorId, internal_api::ExecutorMetadata> {}
+impl SledStorable for HashMap<TaskId, internal_api::Task> {}
+impl SledStorable for HashMap<ExtractionEventId, internal_api::ExtractionEvent> {}
+impl SledStorable for HashMap<ContentId, internal_api::ContentMetadata> {}
 impl SledStorable for HashMap<String, HashSet<String>> {}
-impl SledStorable for HashMap<RepositoryId, HashSet<ExtractorBinding>> {}
+impl SledStorable for HashMap<RepositoryId, HashSet<internal_api::ExtractorBinding>> {}
 impl SledStorable for HashMap<ExtractorName, Vec<ExecutorId>> {}
-impl SledStorable for HashMap<ExtractorName, ExtractorDescription> {}
+impl SledStorable for HashMap<ExtractorName, internal_api::ExtractorDescription> {}
 impl SledStorable for HashSet<String> {}
-impl SledStorable for HashMap<RepositoryId, HashSet<Index>> {}
-impl SledStorable for HashMap<String, Index> {}
+impl SledStorable for HashMap<RepositoryId, HashSet<internal_api::Index>> {}
+impl SledStorable for HashMap<String, internal_api::Index> {}
 impl SledStorable for StateMachine {}
 impl SledStorable for SnapshotMeta<u64, BasicNode> {}
 
@@ -93,28 +83,28 @@ impl SledStorableTestFactory for StateMachine {
         StateMachine {
             last_applied_log: Some(LogId::spawn_instance_for_store_test()),
             last_membership: StoredMembership::spawn_instance_for_store_test(),
-            executors: HashMap::<ExecutorId, ExecutorMetadata>::spawn_instance_for_store_test(),
-            tasks: HashMap::<TaskId, Task>::spawn_instance_for_store_test(),
+            executors: HashMap::<ExecutorId, internal_api::ExecutorMetadata>::spawn_instance_for_store_test(),
+            tasks: HashMap::<TaskId, internal_api::Task>::spawn_instance_for_store_test(),
             unassigned_tasks: HashSet::<TaskId>::spawn_instance_for_store_test(),
             task_assignments: HashMap::<ExecutorId, HashSet<TaskId>>::spawn_instance_for_store_test(
             ),
             extraction_events:
-                HashMap::<ExtractionEventId, ExtractionEvent>::spawn_instance_for_store_test(),
+                HashMap::<ExtractionEventId, internal_api::ExtractionEvent>::spawn_instance_for_store_test(),
             unprocessed_extraction_events:
                 HashSet::<ExtractionEventId>::spawn_instance_for_store_test(),
-            content_table: HashMap::<ContentId, ContentMetadata>::spawn_instance_for_store_test(),
+            content_table: HashMap::<ContentId, internal_api::ContentMetadata>::spawn_instance_for_store_test(),
             content_repository_table:
                 HashMap::<RepositoryId, HashSet<ContentId>>::spawn_instance_for_store_test(),
             bindings_table:
-                HashMap::<RepositoryId, HashSet<ExtractorBinding>>::spawn_instance_for_store_test(),
+                HashMap::<RepositoryId, HashSet<internal_api::ExtractorBinding>>::spawn_instance_for_store_test(),
             extractor_executors_table:
                 HashMap::<ExtractorName, HashSet<ExecutorId>>::spawn_instance_for_store_test(),
             extractors:
-                HashMap::<ExtractorName, ExtractorDescription>::spawn_instance_for_store_test(),
+                HashMap::<ExtractorName, internal_api::ExtractorDescription>::spawn_instance_for_store_test(),
             repositories: HashSet::<String>::spawn_instance_for_store_test(),
             repository_extractors:
-                HashMap::<RepositoryId, HashSet<Index>>::spawn_instance_for_store_test(),
-            index_table: HashMap::<String, Index>::spawn_instance_for_store_test(),
+                HashMap::<RepositoryId, HashSet<internal_api::Index>>::spawn_instance_for_store_test(),
+            index_table: HashMap::<String, internal_api::Index>::spawn_instance_for_store_test(),
         }
     }
 }
@@ -205,21 +195,24 @@ impl SledStorableTestFactory for HashMap<ExecutorId, u64> {
     }
 }
 
-impl SledStorableTestFactory for HashMap<ExecutorId, ExecutorMetadata> {
+impl SledStorableTestFactory for HashMap<ExecutorId, internal_api::ExecutorMetadata> {
     fn spawn_instance_for_store_test() -> Self {
         let mut hm = HashMap::new();
         hm.insert(
             "test".to_string(),
-            ExecutorMetadata::spawn_instance_for_store_test(),
+            internal_api::ExecutorMetadata::spawn_instance_for_store_test(),
         );
         hm
     }
 }
 
-impl SledStorableTestFactory for HashMap<TaskId, Task> {
+impl SledStorableTestFactory for HashMap<TaskId, internal_api::Task> {
     fn spawn_instance_for_store_test() -> Self {
         let mut hm = HashMap::new();
-        hm.insert("test".to_string(), Task::spawn_instance_for_store_test());
+        hm.insert(
+            "test".to_string(),
+            internal_api::Task::spawn_instance_for_store_test(),
+        );
         hm
     }
 }
@@ -232,23 +225,23 @@ impl SledStorableTestFactory for HashSet<String> {
     }
 }
 
-impl SledStorableTestFactory for HashMap<ExtractionEventId, ExtractionEvent> {
+impl SledStorableTestFactory for HashMap<ExtractionEventId, internal_api::ExtractionEvent> {
     fn spawn_instance_for_store_test() -> Self {
         let mut hm = HashMap::new();
         hm.insert(
             "test".to_string(),
-            ExtractionEvent::spawn_instance_for_store_test(),
+            internal_api::ExtractionEvent::spawn_instance_for_store_test(),
         );
         hm
     }
 }
 
-impl SledStorableTestFactory for HashMap<ContentId, ContentMetadata> {
+impl SledStorableTestFactory for HashMap<ContentId, internal_api::ContentMetadata> {
     fn spawn_instance_for_store_test() -> Self {
         let mut hm = HashMap::new();
         hm.insert(
             "test".to_string(),
-            ContentMetadata::spawn_instance_for_store_test(),
+            internal_api::ContentMetadata::spawn_instance_for_store_test(),
         );
         hm
     }
@@ -268,9 +261,9 @@ fn test_json_value() -> serde_json::Value {
     .unwrap()
 }
 
-impl SledStorableTestFactory for ExtractorDescription {
+impl SledStorableTestFactory for internal_api::ExtractorDescription {
     fn spawn_instance_for_store_test() -> Self {
-        ExtractorDescription {
+        internal_api::ExtractorDescription {
             name: "test".to_string(),
             description: "test".to_string(),
             input_params: test_json_value(),
@@ -278,7 +271,7 @@ impl SledStorableTestFactory for ExtractorDescription {
                 let mut outputs = HashMap::new();
                 outputs.insert(
                     "test".to_string(),
-                    OutputSchema::Attributes(test_json_value()),
+                    internal_api::OutputSchema::Attributes(test_json_value()),
                 );
                 outputs
             },
@@ -287,35 +280,35 @@ impl SledStorableTestFactory for ExtractorDescription {
     }
 }
 
-impl SledStorableTestFactory for ExecutorMetadata {
+impl SledStorableTestFactory for internal_api::ExecutorMetadata {
     fn spawn_instance_for_store_test() -> Self {
-        ExecutorMetadata {
+        internal_api::ExecutorMetadata {
             id: "test".to_string(),
             last_seen: 0,
             addr: "localhost:8080".to_string(),
-            extractor: ExtractorDescription::spawn_instance_for_store_test(),
+            extractor: internal_api::ExtractorDescription::spawn_instance_for_store_test(),
         }
     }
 }
 
-impl SledStorableTestFactory for Task {
+impl SledStorableTestFactory for internal_api::Task {
     fn spawn_instance_for_store_test() -> Self {
-        Task {
+        internal_api::Task {
             id: "test".to_string(),
             extractor: "test".to_string(),
             extractor_binding: "test".to_string(),
             output_index_table_mapping: HashMap::new(),
             repository: "test".to_string(),
-            content_metadata: ContentMetadata::spawn_instance_for_store_test(),
+            content_metadata: internal_api::ContentMetadata::spawn_instance_for_store_test(),
             input_params: test_json_value(),
-            outcome: crate::internal_api::TaskOutcome::Success,
+            outcome: internal_api::TaskOutcome::Success,
         }
     }
 }
 
-impl SledStorableTestFactory for ContentMetadata {
+impl SledStorableTestFactory for internal_api::ContentMetadata {
     fn spawn_instance_for_store_test() -> Self {
-        ContentMetadata {
+        internal_api::ContentMetadata {
             id: "test_id".to_string(),
             parent_id: "test_parent_id".to_string(),
             repository: "test_repository".to_string(),
@@ -334,13 +327,13 @@ impl SledStorableTestFactory for ContentMetadata {
     }
 }
 
-impl SledStorableTestFactory for ExtractionEvent {
+impl SledStorableTestFactory for internal_api::ExtractionEvent {
     fn spawn_instance_for_store_test() -> Self {
-        ExtractionEvent {
+        internal_api::ExtractionEvent {
             id: "test_id".to_string(),
             repository: "test_repository".to_string(),
-            payload: ExtractionEventPayload::CreateContent {
-                content: ContentMetadata::spawn_instance_for_store_test(),
+            payload: internal_api::ExtractionEventPayload::CreateContent {
+                content: internal_api::ContentMetadata::spawn_instance_for_store_test(),
             },
             created_at: 1234567890,
             processed_at: Some(1234567890),
@@ -348,9 +341,9 @@ impl SledStorableTestFactory for ExtractionEvent {
     }
 }
 
-impl SledStorableTestFactory for ExtractorBinding {
+impl SledStorableTestFactory for internal_api::ExtractorBinding {
     fn spawn_instance_for_store_test() -> Self {
-        ExtractorBinding {
+        internal_api::ExtractorBinding {
             id: "test_id".to_string(),
             name: "test_name".to_string(),
             repository: "test_repository".to_string(),
@@ -369,9 +362,9 @@ impl SledStorableTestFactory for ExtractorBinding {
     }
 }
 
-impl SledStorableTestFactory for Index {
+impl SledStorableTestFactory for internal_api::Index {
     fn spawn_instance_for_store_test() -> Self {
-        Index {
+        internal_api::Index {
             repository: "test_repository".to_string(),
             name: "test_name".to_string(),
             table_name: "test_table_name".to_string(),
@@ -382,20 +375,23 @@ impl SledStorableTestFactory for Index {
     }
 }
 
-impl SledStorableTestFactory for HashMap<String, Index> {
-    fn spawn_instance_for_store_test() -> Self {
-        let mut hm = HashMap::new();
-        hm.insert("test".to_string(), Index::spawn_instance_for_store_test());
-        hm
-    }
-}
-
-impl SledStorableTestFactory for HashMap<ExtractorName, ExtractorDescription> {
+impl SledStorableTestFactory for HashMap<String, internal_api::Index> {
     fn spawn_instance_for_store_test() -> Self {
         let mut hm = HashMap::new();
         hm.insert(
             "test".to_string(),
-            ExtractorDescription::spawn_instance_for_store_test(),
+            internal_api::Index::spawn_instance_for_store_test(),
+        );
+        hm
+    }
+}
+
+impl SledStorableTestFactory for HashMap<ExtractorName, internal_api::ExtractorDescription> {
+    fn spawn_instance_for_store_test() -> Self {
+        let mut hm = HashMap::new();
+        hm.insert(
+            "test".to_string(),
+            internal_api::ExtractorDescription::spawn_instance_for_store_test(),
         );
         hm
     }
@@ -409,24 +405,24 @@ impl SledStorableTestFactory for HashMap<ExtractorName, Vec<ExecutorId>> {
     }
 }
 
-impl SledStorableTestFactory for HashMap<RepositoryId, HashSet<ExtractorBinding>> {
+impl SledStorableTestFactory for HashMap<RepositoryId, HashSet<internal_api::ExtractorBinding>> {
     fn spawn_instance_for_store_test() -> Self {
         let mut hm = HashMap::new();
         hm.insert("test".to_string(), {
             let mut hs = HashSet::new();
-            hs.insert(ExtractorBinding::spawn_instance_for_store_test());
+            hs.insert(internal_api::ExtractorBinding::spawn_instance_for_store_test());
             hs
         });
         hm
     }
 }
 
-impl SledStorableTestFactory for HashMap<RepositoryId, HashSet<Index>> {
+impl SledStorableTestFactory for HashMap<RepositoryId, HashSet<internal_api::Index>> {
     fn spawn_instance_for_store_test() -> Self {
         let mut hm = HashMap::new();
         hm.insert("test".to_string(), {
             let mut hs = HashSet::new();
-            hs.insert(Index::spawn_instance_for_store_test());
+            hs.insert(internal_api::Index::spawn_instance_for_store_test());
             hs
         });
         hm
@@ -482,20 +478,20 @@ mod sled_tests {
     type TestLogId = LogId<NodeId>;
     type TestStoredMembership = StoredMembership<NodeId, BasicNode>;
     type TestExecutorHealthChecks = HashMap<ExecutorId, u64>;
-    type TestExecutors = HashMap<ExecutorId, ExecutorMetadata>;
-    type TestTasks = HashMap<TaskId, Task>;
+    type TestExecutors = HashMap<ExecutorId, internal_api::ExecutorMetadata>;
+    type TestTasks = HashMap<TaskId, internal_api::Task>;
     type TestUnassignedTasks = HashSet<TaskId>;
     type TestTaskAssignments = HashMap<ExecutorId, HashSet<TaskId>>;
-    type TestExtractionEvents = HashMap<ExtractionEventId, ExtractionEvent>;
+    type TestExtractionEvents = HashMap<ExtractionEventId, internal_api::ExtractionEvent>;
     type TestUnprocessedExtractionEvents = HashSet<ExtractionEventId>;
-    type TestContentTable = HashMap<ContentId, ContentMetadata>;
+    type TestContentTable = HashMap<ContentId, internal_api::ContentMetadata>;
     type TestContentRepositoryTable = HashMap<RepositoryId, HashSet<ContentId>>;
-    type TestBindingsTable = HashMap<RepositoryId, HashSet<ExtractorBinding>>;
+    type TestBindingsTable = HashMap<RepositoryId, HashSet<internal_api::ExtractorBinding>>;
     type TestExtractorExecutorsTable = HashMap<ExtractorName, Vec<ExecutorId>>;
-    type TestExtractors = HashMap<ExtractorName, ExtractorDescription>;
+    type TestExtractors = HashMap<ExtractorName, internal_api::ExtractorDescription>;
     type TestRepositories = HashSet<String>;
-    type TestRepositoryExtractors = HashMap<RepositoryId, HashSet<Index>>;
-    type TestIndexTable = HashMap<String, Index>;
+    type TestRepositoryExtractors = HashMap<RepositoryId, HashSet<internal_api::Index>>;
+    type TestIndexTable = HashMap<String, internal_api::Index>;
     type TestStateMachine = StateMachine;
     type TestVoteNodeId = Vote<NodeId>;
     type TestStoredSnapshot = StoredSnapshot;

--- a/src/task_store.rs
+++ b/src/task_store.rs
@@ -3,16 +3,15 @@ use std::{
     sync::{Arc, RwLock},
 };
 
+use indexify_internal_api as internal_api;
 use tokio::sync::watch;
 use tracing::info;
 
-use crate::internal_api::{Task, TaskResult};
-
 #[derive(Debug)]
 pub struct TaskStore {
-    tasks: Arc<RwLock<HashMap<String, Task>>>,
+    tasks: Arc<RwLock<HashMap<String, internal_api::Task>>>,
     pending: Arc<RwLock<HashSet<String>>>,
-    finished: Arc<RwLock<HashMap<String, TaskResult>>>,
+    finished: Arc<RwLock<HashMap<String, internal_api::TaskResult>>>,
     tx: watch::Sender<()>,
     rx: watch::Receiver<()>,
 }
@@ -34,7 +33,7 @@ impl TaskStore {
         self.tasks.write().unwrap().remove(task_id);
     }
 
-    pub fn add(&self, tasks: Vec<Task>) {
+    pub fn add(&self, tasks: Vec<internal_api::Task>) {
         info!("Adding {} tasks to task store", tasks.len());
         let mut pending = self.pending.write().unwrap();
         let mut tasks_store = self.tasks.write().unwrap();
@@ -45,7 +44,7 @@ impl TaskStore {
         self.tx.send(()).unwrap();
     }
 
-    pub fn update(&self, task_results: Vec<TaskResult>) {
+    pub fn update(&self, task_results: Vec<internal_api::TaskResult>) {
         let mut pending = self.pending.write().unwrap();
         let mut finished = self.finished.write().unwrap();
         for task_result in task_results {
@@ -54,7 +53,7 @@ impl TaskStore {
         }
     }
 
-    pub fn pending_tasks(&self) -> Vec<Task> {
+    pub fn pending_tasks(&self) -> Vec<internal_api::Task> {
         let pending = self.pending.read().unwrap();
         let tasks = self.tasks.read().unwrap();
         pending
@@ -63,7 +62,7 @@ impl TaskStore {
             .collect()
     }
 
-    pub fn finished_tasks(&self) -> Vec<TaskResult> {
+    pub fn finished_tasks(&self) -> Vec<internal_api::TaskResult> {
         let finished = self.finished.read().unwrap();
         finished.values().cloned().collect()
     }
@@ -77,7 +76,7 @@ impl TaskStore {
         self.rx.clone()
     }
 
-    pub fn get_task(&self, task_id: &str) -> Option<Task> {
+    pub fn get_task(&self, task_id: &str) -> Option<internal_api::Task> {
         let tasks = self.tasks.read().unwrap();
         tasks.get(task_id).cloned()
     }

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -2,24 +2,23 @@
 pub mod db_utils {
     use std::collections::HashMap;
 
+    use indexify_internal_api as internal_api;
     use serde_json::json;
-
-    use crate::internal_api::{EmbeddingSchema, ExtractorDescription, OutputSchema};
 
     pub const DEFAULT_TEST_REPOSITORY: &str = "test_repository";
 
     pub const DEFAULT_TEST_EXTRACTOR: &str = "MockExtractor";
 
-    pub fn mock_extractor() -> ExtractorDescription {
+    pub fn mock_extractor() -> internal_api::ExtractorDescription {
         let mut outputs = HashMap::new();
         outputs.insert(
             "test_output".to_string(),
-            OutputSchema::Embedding(EmbeddingSchema {
+            internal_api::OutputSchema::Embedding(internal_api::EmbeddingSchema {
                 dim: 384,
                 distance: "cosine".to_string(),
             }),
         );
-        ExtractorDescription {
+        internal_api::ExtractorDescription {
             name: DEFAULT_TEST_EXTRACTOR.to_string(),
             description: "test_description".to_string(),
             input_params: json!({}),

--- a/src/vector_index.rs
+++ b/src/vector_index.rs
@@ -2,6 +2,7 @@ use std::{collections::HashMap, fmt, str::FromStr, sync::Arc};
 
 use anyhow::{anyhow, Result};
 use base64::{engine::general_purpose, Engine as _};
+use indexify_internal_api as internal_api;
 use indexify_proto::indexify_coordinator::{self, Index};
 use itertools::Itertools;
 use tracing::info;
@@ -12,7 +13,6 @@ use crate::{
     coordinator_client::CoordinatorClient,
     extractor::ExtractedEmbeddings,
     extractor_router::ExtractorRouter,
-    internal_api::{Embedding, EmbeddingSchema},
     vectordbs::{CreateIndexParams, IndexDistance, VectorChunk, VectorDBTS},
 };
 
@@ -45,7 +45,11 @@ impl VectorIndexManager {
         })
     }
 
-    pub async fn create_index(&self, index_name: &str, schema: EmbeddingSchema) -> Result<String> {
+    pub async fn create_index(
+        &self,
+        index_name: &str,
+        schema: internal_api::EmbeddingSchema,
+    ) -> Result<String> {
         let create_index_params = CreateIndexParams {
             vectordb_index_name: index_name.to_string(),
             vector_dim: schema.dim as u64,
@@ -94,7 +98,7 @@ impl VectorIndexManager {
             .feature
             .as_ref()
             .ok_or(anyhow!("No features were extracted"))?;
-        let embedding: Embedding =
+        let embedding: internal_api::Embedding =
             serde_json::from_value(features.data.clone()).map_err(|e| anyhow!(e.to_string()))?;
         let search_result = self
             .vector_db


### PR DESCRIPTION
Factored out `internal_api.rs` into its own crate. Integrated the `indexify_internal_api` into various modules of the project. This change enhances the project's capability to handle internal API structures more effectively.

Key Changes:

- Replaced existing internal API structures with `indexify_internal_api` equivalents in various files such as `executor.rs`, `state/store/mod.rs`, and `task_store.rs`.
- Updated function signatures and implementations to align with the new internal API structures.
- Removed the old `internal_api.rs` file as its responsibilities are now covered by `indexify_internal_api`.

Testing:

- Conducted unit tests to ensure the integration works as expected without breaking existing functionalities.

This integration streamlines the project's internal structure and sets a foundation for future enhancements involving internal API usage.