### PR TITLE
Output extractor name in error

### DIFF
--- a/src/data_repository_manager.rs
+++ b/src/data_repository_manager.rs
@@ -143,7 +143,7 @@ impl DataRepositoryManager {
             .await?
             .into_inner();
         let mut index_names = Vec::new();
-        let extractor = response.extractor.ok_or(anyhow!("extractor {:?} not found", extractor_binding.name))?;
+        let extractor = response.extractor.ok_or(anyhow!("extractor {:?} not found", extractor_binding.extractor))?;
         for (name, output_schema) in &extractor.outputs {
             let output_schema: OutputSchema = serde_json::from_str(output_schema)?;
             let index_name = response.output_index_name_mapping.get(name).unwrap();

--- a/src/data_repository_manager.rs
+++ b/src/data_repository_manager.rs
@@ -143,7 +143,7 @@ impl DataRepositoryManager {
             .await?
             .into_inner();
         let mut index_names = Vec::new();
-        let extractor = response.extractor.ok_or(anyhow!("extractor not found"))?;
+        let extractor = response.extractor.ok_or(anyhow!("extractor {:?} not found", extractor_binding.name))?;
         for (name, output_schema) in &extractor.outputs {
             let output_schema: OutputSchema = serde_json::from_str(output_schema)?;
             let index_name = response.output_index_name_mapping.get(name).unwrap();

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -424,7 +424,7 @@ impl App {
         let binding = store
             .extractors
             .get(extractor)
-            .ok_or(anyhow!("extractor not found"))?;
+            .ok_or(anyhow!("extractor {:?} not found", extractor))?;
         Ok(binding.clone())
     }
 


### PR DESCRIPTION
This PR is an attempt to fix https://github.com/tensorlakeai/indexify/issues/189 , though I'm not entirely sure if I hit all of the correct areas, or any of them actually... I made the change in the 2 places I found the `"extractor not found"` message mentioned in #189 although I was only able to actually trigger the one in `src/state/mod.rs` due to still being not to familiar with Indexify. 

This PR changes the output when calling _at least_ the `/repositories/default/extractor_binding` endpoint, adding in the name and escaping the quotes as needed(?). I wasn't sure about the formatting using `{:?}` here, I'm happy to make any changes if there's a better way. 

Example output:

```
➜ curl -s -X POST http://localhost:8900/repositories/default/extractor_bindings \
 -H "Content-Type: application/json" \
 -d '{
         "extractor": "nothing",
         "name": "nothing"
     }'
failed to bind extractor: status: Aborted, message: "extractor \"nothing\" not found", details: [], metadata: MetadataMap { headers: {"content-type": "application/grpc", "date": "Thu, 25 Jan 2024 14:49:37 GMT", "content-length": "0"} }
```

Alternatively I could change it to be `'{}'` instead of `{:?}` if you prefer:

```
failed to bind extractor: status: Aborted, message: "extractor 'nothing' not found", details: [], metadata: MetadataMap { headers: {"content-type": "application/grpc", "date": "Thu, 25 Jan 2024 14:53:56 GMT", "content-length": "0"} }%
```