### PR TITLE
Make build a PHONY target in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ BINDIR = $(PREFIX)/bin
 # Target executable
 TARGET = ./target/release/$(APPLICATION_NAME)
 
+.PHONY: build
 build: ## Build rust application
 	cargo build
 


### PR DESCRIPTION
The `build` step in the [Makefile](https://github.com/tensorlakeai/indexify/blob/239551f9eb3a1c2f890160a4fea6e1ed9aa222f7/Makefile#L13) needs to be a [PHONY target](https://www.gnu.org/software/make/manual/html_node/Phony-Targets.html) otherwise `make` confuses the target with the resulting `build` directory.

Before:

```
 ➜ make build
make: `build' is up to date.
```

After:

```
 ➜ make build
cargo build
   Compiling pyo3-build-config v0.20.2
   Compiling pyo3-ffi v0.20.2
   Compiling pyo3 v0.20.2
   Compiling indexify v0.0.1 (/Users/clint/go/github.com/tensorlakeai/indexify)
    Finished dev [unoptimized + debuginfo] target(s) in 6.21s
```

I left the other `build-release` and `clean` targets alone because they don't have this problem, but maybe for completeness(?) those should be `.PHONY` targets as well?