### PR TITLE
Add local development build option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,9 @@ build-container: ## Build container
 	docker build -f dockerfiles/Dockerfile.compose --tag ${DOCKER_USERNAME}/${APPLICATION_NAME} .
 	docker image prune
 
+build-container-dev: ## Build container for local development
+	docker build -f dockerfiles/Dockerfile.builder --tag ${DOCKER_USERNAME}/builder .
+	docker build -f dockerfiles/Dockerfile.local --tag ${DOCKER_USERNAME}/${APPLICATION_NAME} .
 
 build-base-extractor: ## Build base extractor container
 	docker build -f dockerfiles/Dockerfile.extractor_base --tag ${DOCKER_USERNAME}/${APPLICATION_NAME}-extractor-base .

--- a/dockerfiles/Dockerfile.local
+++ b/dockerfiles/Dockerfile.local
@@ -1,0 +1,20 @@
+FROM tensorlake/builder AS builder
+FROM ubuntu:22.04
+
+RUN apt update
+
+RUN apt install -y libssl-dev python3-dev ca-certificates
+
+RUN update-ca-certificates
+
+WORKDIR /indexify
+
+COPY --from=builder /indexify-build/target/release/indexify ./
+
+COPY sample_config.yaml ./config/indexify.yaml
+
+ENV PATH="/indexify:${PATH}"
+
+COPY ./scripts/docker_compose_start.sh .
+
+ENTRYPOINT [ "/indexify/indexify" ]

--- a/docs/docs/develop.md
+++ b/docs/docs/develop.md
@@ -108,3 +108,7 @@ If you're within the dev container, you can call the docker-compose-v1 from with
 
 If docker produces a EONET error, please try to build your devcontainer prior to launching it in vscode:
 ```devcontainer up --workspace-folder```
+
+To build a local container for testing, run the following command from the root of the project:
+
+```make build-container-dev```


### PR DESCRIPTION
This commit introduces a new Makefile target `build-container-dev`, enabling the building of containers specifically for local development.

Changes include:
- A new target in the Makefile, `build-container-dev`, that builds two docker images: one using `Dockerfile.builder` and another using the newly added `Dockerfile.local`.
- The `Dockerfile.local` is a new file that sets up an Ubuntu-based container with necessary dependencies and configurations for local development.
- Updated documentation in `docs/docs/develop.md` to include instructions on how to build a local container using the new Makefile target.

Tested the build process locally; containers are building as expected without any issues.