### PR TITLE
Adding parent_id to metadata

### DIFF
--- a/src/data_repository_manager.rs
+++ b/src/data_repository_manager.rs
@@ -438,6 +438,7 @@ impl DataRepositoryManager {
                     api::FeatureType::Metadata => {
                         let extracted_attributes = ExtractedMetadata::new(
                             &content_metadata.id,
+                            &content_metadata.parent_id,
                             feature.data.clone(),
                             "extractor_name",
                             &extracted_content.repository,


### PR DESCRIPTION
Adding parent content id to metadata, useful when metadata is generated for the whole input content.