### PR TITLE
Rename Document metadata to labels and update Docs

### DIFF
--- a/docs/docs/apis/data_repository.md
+++ b/docs/docs/apis/data_repository.md
@@ -7,9 +7,20 @@ Data Repositories store content either uploaded by applications or from extracto
     A default data repository, named `default` is created when Indexify is started.
 
 ## Create or Update a Data Repository
-A data repository can be created by specifying a unique name, and any additional metadata or extractor bindings.
+A data repository can be created by specifying a unique name, and any additional labels or extractor bindings.
+
+=== "python"
+
+    ```python
+    client.create_repository(
+        name="research",
+        extractor_bindings=[{"extractor": "tensorlake/minilm-l6", "name": "minilm-l6"}],
+        labels={"sensitive": True},
+    )
+    ```
 
 === "curl"
+
     ``` shell
     curl -X POST http://localhost:8900/repositories \
     -H 'Content-Type: application/json' \
@@ -18,17 +29,24 @@ A data repository can be created by specifying a unique name, and any additional
           "name": "research",
           "extractor_bindings": [
             {
-              "extractor": "MiniLML6",
-              "name": "minilm61"
+              "extractor": "tensorlake/minilm-l6",
+              "name": "minilm-l6"
             }
           ],
-          "metadata": {"sensitive": true}
+          "labels": {"sensitive": true}
         }
     '
     ```
 
 ## List Repositories
+=== "python"
+
+    ```python
+    client.repositories()
+    ```
+
 === "curl"
+
     ``` shell
     curl -X GET http://localhost:8900/repositories
     ```
@@ -59,22 +77,25 @@ A data repository can be created by specifying a unique name, and any additional
 Extractor Bindings are rules to instruct Indexify to run a particular extractor on content in a repository. Bindings are evaluated when new content is added and extractors are run automatically on new or existing content. Bindings keep indexes updated as new content is ingested.
 Additionally, filters can be added to specifically restrict the content being extracted and added to the index.
 
-For ex, the example below binds the extractor `MiniLML6` to all the content in the repository `default` which has metadata `url` as `https://www.example.com`. Anytime any text is added to the repository with metadata that matches the content they are indexed.
+For ex, the example below binds the extractor `MiniLML6` to all the content in the repository `default` which has labels `url` as `https://www.example.com`. Anytime any text is added to the repository with metadata that matches the content they are indexed.
+
+=== "python"
+    ```python
+    repo = client.get_repository("default")
+    repo.bind_extractor(
+        extractor="tensorlake/minilm-l6",
+        name="minil6",
+        filters={"url": "https://www.example.com"},
+    )
+    ```
 
 === "curl"
-    ``` shell
+    ```shell
     curl -v -X POST http://localhost:8900/repositories/default/extractor_bindings \
     -H "Content-Type: application/json" \
     -d '{
-            "repository": "default",
-            "extractor": "MiniLML6",
-            "name": "minilml6-embedding",
-            "filters": [
-                {
-                    "eq": {
-                        "url": "https://example.com/"
-                    }
-                }
-            ]
+            "extractor": "tensorlake/minilm-l6",
+            "name": "minil6",
+            "filters": {"url": "https://www.example.com"}
         }'
     ```

--- a/docs/docs/apis/data_repository.md
+++ b/docs/docs/apis/data_repository.md
@@ -15,7 +15,7 @@ A data repository can be created by specifying a unique name, and any additional
     client.create_repository(
         name="research",
         extractor_bindings=[{"extractor": "tensorlake/minilm-l6", "name": "minilm-l6"}],
-        labels={"sensitive": True},
+        labels={"sensitive": "true"},
     )
     ```
 
@@ -33,7 +33,7 @@ A data repository can be created by specifying a unique name, and any additional
               "name": "minilm-l6"
             }
           ],
-          "labels": {"sensitive": true}
+          "labels": {"sensitive": "true"}
         }
     '
     ```
@@ -66,7 +66,7 @@ A data repository can be created by specifying a unique name, and any additional
             }
           ],
           "labels": {
-            "sensitive": true
+            "sensitive": "true"
           }
         }
       ]

--- a/docs/docs/apis/data_repository.md
+++ b/docs/docs/apis/data_repository.md
@@ -65,7 +65,7 @@ A data repository can be created by specifying a unique name, and any additional
               "input_params": {}
             }
           ],
-          "metadata": {
+          "labels": {
             "sensitive": true
           }
         }
@@ -77,7 +77,7 @@ A data repository can be created by specifying a unique name, and any additional
 Extractor Bindings are rules to instruct Indexify to run a particular extractor on content in a repository. Bindings are evaluated when new content is added and extractors are run automatically on new or existing content. Bindings keep indexes updated as new content is ingested.
 Additionally, filters can be added to specifically restrict the content being extracted and added to the index.
 
-For ex, the example below binds the extractor `MiniLML6` to all the content in the repository `default` which has labels `url` as `https://www.example.com`. Anytime any text is added to the repository with metadata that matches the content they are indexed.
+For ex, the example below binds the extractor `MiniLML6` to all the content in the repository `default` which has labels `url` as `https://www.example.com`. Anytime any text is added to the repository with labels that matches the content they are indexed.
 
 === "python"
     ```python

--- a/docs/docs/getting_started.md
+++ b/docs/docs/getting_started.md
@@ -42,6 +42,16 @@ Data Repositories are logical buckets that store content. Indexify starts with a
 
 #### Add some documents
 
+=== "python"
+
+    ```python
+    repo = client.get_repository("default")
+    repo.add_documents([
+        "Indexify is amazing!",
+        "Indexify is a retrieval service for LLM agents!",
+        "Kevin Durant is the best basketball player in the world."
+    ])
+    ```
 === "curl"
 
     ```shell
@@ -53,43 +63,45 @@ Data Repositories are logical buckets that store content. Indexify starts with a
             {"text": "Kevin Durant is the best basketball player in the world."}
         ]}'
     ```
-=== "python"
-
-    ```python
-    repo = client.get_repository("default")
-    repo.add_documents([
-        "Indexify is amazing!",
-        "Indexify is a retrieval service for LLM agents!",
-        "Kevin Durant is the best basketball player in the world."
-    ])
-    ```
 
 #### You can also upload files to Indexify
 === "curl"
+
     ```
     curl -v http://localhost:8900/repositories/default/upload_file \
     -F "files=@kd.txt"
     ```
+
 === "python"
+
     ```python
     repo = client.get_repository("default")
     repo.upload_file("kd.txt")
     ```
 #### Look at the metadata of the content which has been ingested 
 Sometimes you might want to read all the metadata of the content for use in another application or debugging.
+
 === "curl"
+
     ```
     curl -v http://localhost:8900/repositories/default/content
+    ```
 
+=== "curl"
+
+    ```
+    curl -v http://localhost:8900/repositories/default/content
     ```
 
 Content can be filtered:
 
 === "curl"
+
     ```
     curl -v http://localhost:8900/repositories/default/content?source=some_source&parent_id=some_parent_id&labels_eq=key1:value1,key2:value2
     ```
 === "api spec"
+
     ```
     source: string
     parent_id: string
@@ -102,25 +114,31 @@ Extractors are used to extract information from the documents in our repository.
 
 #### Get available extractors
 
+=== "python"
+
+    ```python
+    extractors = client.extractors()
+    ```
+
 === "curl"
 
     ```shell
     curl -X GET http://localhost:8900/extractors
     ```
 
-=== "python"
-
-    ```python
-    from indexify import IndexifyClient
-
-    client = IndexifyClient()
-    extractors = client.extractors()
-    ```
 #### Bind some extractors to the repository
 
 To start extracting information from the documents, we need to bind some extractors to the repository. Let's bind a named entity extractor so that we can retrieve some data in the form of key/value pairs, and an embedding extractor so that we can run semantic search over the raw text.
 
 Every extractor we bind results in a corresponding index being created in Indexify to store the extracted information for fast retrieval. So we must also provide an index name for each extractor.
+
+=== "python"
+
+    ```python
+    repo.bind_extractor("tensorlake/minilm-l6", "minil6")
+
+    bindings = repo.extractor_bindings
+    ```
 
 === "curl"
 
@@ -132,13 +150,6 @@ Every extractor we bind results in a corresponding index being created in Indexi
             "name": "minil6"
         }'
     ```
-=== "python"
-
-    ```python
-    repo.bind_extractor("tensorlake/minilm-l6", "minil6")
-
-    bindings = repo.extractor_bindings
-    ```
 
 We now have an index with embedding extracted by MiniLML6.
 
@@ -148,6 +159,37 @@ Next let's query the index created by the embedding extractor. The index will al
 
 Let's look for documents related to "sports":
 
+=== "python"
+
+    ```python
+    search_results = repo.search_index("minil6.embedding", "sports", 3)
+    print('Search results:', *search_results, sep='\n')
+    ```
+    
+    Here are the results:
+
+    ```
+    [
+        {
+            'content_id': '8a4e86c1ed871aa5', 
+            'text': 'Kevin Durant is the best basketball player in the world.', 
+            'confidence_score': 0.22862443, 
+            'labels': {}
+        },
+        {
+            'content_id': 'cca837cf4d0654aa', 
+            'text': 'Indexify is a retrieval service for LLM agents!',
+            'confidence_score': -0.012608088, 
+            'labels': {}
+        },
+        {
+            'content_id': 'ad2540d8cf3fb9b7', 
+            'text': 'Indexify is amazing!', 
+            'confidence_score': -0.048074536, 
+            'labels': {}
+        }
+    ]
+    ```
 === "curl"
 
     ```shell
@@ -188,44 +230,18 @@ Let's look for documents related to "sports":
 
     ```
 
-=== "python"
-
-    ```python
-    search_results = repo.search_index("minil6.embedding", "sports", 3)
-    print('Search results:', *search_results, sep='\n')
-    ```
-    
-    Here are the results:
-
-    ```
-    Search results: 
-    [
-        {
-            'content_id': '8a4e86c1ed871aa5', 
-            'text': 'Kevin Durant is the best basketball player in the world.', 
-            'confidence_score': 0.22862443, 
-            'labels': {}
-        },
-        {
-            'content_id': 'cca837cf4d0654aa', 
-            'text': 'Indexify is a retrieval service for LLM agents!',
-            'confidence_score': -0.012608088, 
-            'labels': {}
-        },
-        {
-            'content_id': 'ad2540d8cf3fb9b7', 
-            'text': 'Indexify is amazing!', 
-            'confidence_score': -0.048074536, 
-            'labels': {}
-        }
-    ]
-    ```
 
 ### Automatic extraction and indexing
 
 Indexify automatically watches your data repository and runs your extractors whenever new documents are added. Let's go through an example. 
 
 #### Add a new document to the repository
+
+=== "python"
+
+    ```python
+    repo.add_documents("Steph Curry is also an amazing player!")
+    ```
 
 === "curl"
 
@@ -236,15 +252,43 @@ Indexify automatically watches your data repository and runs your extractors whe
             {"text": "Steph Curry is also an amazing player!"}
         ]}' 
     ```
-=== "python"
-
-    ```python
-    repo.add_documents("Steph Curry is also an amazing player!")
-    ```
 
 #### Query the embedding index
 
 Now let's rerun our query for documents related to "sports":
+
+=== "python"
+
+    ```python
+    search_results = repo.search_index("minil6.embedding", "sports", 3)
+    print('Updated search results:', *search_results, sep='\n')
+    ```
+
+    Here are the new search results:
+
+    ```
+    Updated search results: 
+    [
+        {
+            'content_id': '8a4e86c1ed871aa5', 
+            'text': 'Kevin Durant is the best basketball player in the world.',
+            'confidence_score': 0.22862443, 
+            'labels': {}
+        }, 
+        {
+            'content_id': 'fcb76d63e3324d9c', 
+            'text': 'Steph Curry is also an amazing player!', 
+            'confidence_score': 0.17857653, 
+            'labels': {}
+        }, 
+        {
+            'content_id': 'cca837cf4d0654aa', 
+            'text': 'Indexify is a retrieval service for LLM agents!',
+            'confidence_score': -0.012608088, 
+            'labels': {}
+        }
+    ]
+    ```
 
 === "curl"
 
@@ -286,44 +330,23 @@ Now let's rerun our query for documents related to "sports":
 
     ```
 
-=== "python"
-
-    ```python
-    search_results = repo.search_index("minil6.embedding", "sports", 3)
-    print('Updated search results:', *search_results, sep='\n')
-    ```
-
-    Here are the new search results:
-
-    ```
-    Updated search results: 
-    [
-        {
-            'content_id': '8a4e86c1ed871aa5', 
-            'text': 'Kevin Durant is the best basketball player in the world.',
-            'confidence_score': 0.22862443, 
-            'labels': {}
-        }, 
-        {
-            'content_id': 'fcb76d63e3324d9c', 
-            'text': 'Steph Curry is also an amazing player!', 
-            'confidence_score': 0.17857653, 
-            'labels': {}
-        }, 
-        {
-            'content_id': 'cca837cf4d0654aa', 
-            'text': 'Indexify is a retrieval service for LLM agents!',
-            'confidence_score': -0.012608088, 
-            'labels': {}
-        }
-    ]
-    ```
 
 We can see the new document we added about Steph Curry is now included in the search results. Indexify automatically ran our extractors when we added the new document and updated the relevant indexes. Extractors will only match content with the same mime type as the extractor. For example, the embedding extractor will only match text documents.
 
 ### Specify filters for extractor bindings
 
 Sometimes you might want to restrict the content from a data repository that's extracted and added to an index. For example, you might only want to process the documents that are downloaded from a specific URL. Indexify provides an easy way to do this using filters.
+
+=== "python"
+
+    ```python
+    repo.add_documents([
+        {"text": "The Cayuga was launched in 2245.", 
+         "metadata": 
+            {"source": "https://memory-alpha.fandom.com/wiki/USS_Cayuga"}
+        }
+    ])
+    ```
 
 === "curl"
 
@@ -337,18 +360,18 @@ Sometimes you might want to restrict the content from a data repository that's e
             }
         ]}' 
     ```
+    
+Now you can add extractor bindings with filters which match the URL and index content only from those documents.
+
 === "python"
 
     ```python
-    repo.add_documents([
-        {"text": "The Cayuga was launched in 2245.", 
-         "metadata": 
-            {"source": "https://memory-alpha.fandom.com/wiki/USS_Cayuga"}
-        }
-    ])
-    ```
+    repo.bind_extractor("tensorlake/minilm-l6", "star_trek", filters={
+        "source": "https://memory-alpha.fandom.com/wiki/USS_Cayuga"
+    })
 
-Now you can add extractor bindings with filters which match the URL and index content only from those documents.
+    print(repo.extractor_bindings)
+    ```
 
 === "curl"
 
@@ -363,12 +386,4 @@ Now you can add extractor bindings with filters which match the URL and index co
             }
         }'
     ```
-=== "python"
-
-    ```python
-    repo.bind_extractor("tensorlake/minilm-l6", "star_trek", filters={
-        "source": "https://memory-alpha.fandom.com/wiki/USS_Cayuga"
-    })
-
-    print(repo.extractor_bindings)
-    ```
+    

--- a/docs/docs/getting_started.md
+++ b/docs/docs/getting_started.md
@@ -349,7 +349,7 @@ Sometimes you might want to restrict the content from a data repository that's e
     ```python
     repo.add_documents([
         {"text": "The Cayuga was launched in 2245.", 
-         "metadata": 
+         "labels": 
             {"source": "https://memory-alpha.fandom.com/wiki/USS_Cayuga"}
         }
     ])
@@ -362,7 +362,7 @@ Sometimes you might want to restrict the content from a data repository that's e
     -H "Content-Type: application/json" \
     -d '{"documents": [ 
             {"text": "The Cayuga was launched in 2245.", 
-             "metadata": 
+             "labels": 
                 {"source": "https://memory-alpha.fandom.com/wiki/USS_Cayuga"}
             }
         ]}' 

--- a/docs/docs/getting_started.md
+++ b/docs/docs/getting_started.md
@@ -65,6 +65,13 @@ Data Repositories are logical buckets that store content. Indexify starts with a
     ```
 
 #### You can also upload files to Indexify
+=== "python"
+
+    ```python
+    repo = client.get_repository("default")
+    repo.upload_file("kd.txt")
+    ```
+    
 === "curl"
 
     ```
@@ -72,12 +79,6 @@ Data Repositories are logical buckets that store content. Indexify starts with a
     -F "files=@kd.txt"
     ```
 
-=== "python"
-
-    ```python
-    repo = client.get_repository("default")
-    repo.upload_file("kd.txt")
-    ```
 #### Look at the metadata of the content which has been ingested 
 Sometimes you might want to read all the metadata of the content for use in another application or debugging.
 

--- a/docs/docs/getting_started.md
+++ b/docs/docs/getting_started.md
@@ -81,10 +81,10 @@ Data Repositories are logical buckets that store content. Indexify starts with a
 #### Look at the metadata of the content which has been ingested 
 Sometimes you might want to read all the metadata of the content for use in another application or debugging.
 
-=== "curl"
+=== "python"
 
     ```
-    curl -v http://localhost:8900/repositories/default/content
+    repo.get_content()
     ```
 
 === "curl"
@@ -94,6 +94,12 @@ Sometimes you might want to read all the metadata of the content for use in anot
     ```
 
 Content can be filtered:
+
+=== "python"
+
+    ```
+    repo.get_content({"parent_id":"some_parent_id", "labels_eq":"key1:value1,key2:value2"})
+    ```
 
 === "curl"
 

--- a/sdk-py/examples/getting_started.py
+++ b/sdk-py/examples/getting_started.py
@@ -44,7 +44,7 @@ repo.add_documents(
     [
         {
             "text": "The Cayuga was launched in 2245.",
-            "metadata": {"url": "https://memory-alpha.fandom.com/wiki/USS_Cayuga"},
+            "labels": {"url": "https://memory-alpha.fandom.com/wiki/USS_Cayuga"},
         },
     ]
 )

--- a/sdk-py/indexify/client.py
+++ b/sdk-py/indexify/client.py
@@ -162,7 +162,10 @@ class IndexifyClient:
         return repositories
 
     def create_repository(
-        self, name: str, extractor_bindings: list = [], metadata: dict = {}
+        self,
+        name: str,
+        extractor_bindings: list = [],
+        labels: dict = {},
     ):
         """
         Create a new repository.
@@ -170,8 +173,7 @@ class IndexifyClient:
         req = {
             "name": name,
             "extractor_bindings": extractor_bindings,
-            "metadata": metadata,
-            "labels": {},
+            "labels": labels,
         }
         self.post(f"repositories", json=req)
         return self.get_repository(name)

--- a/sdk-py/indexify/repository.py
+++ b/sdk-py/indexify/repository.py
@@ -12,7 +12,7 @@ from indexify.exceptions import ApiException
 from .index import Index
 from .extractor_binding import ExtractorBinding
 
-Document = namedtuple("Document", ["text", "metadata"])
+Document = namedtuple("Document", ["text", "labels"])
 
 
 class Repository:
@@ -136,13 +136,20 @@ class Repository:
         extractor_bindings = []
         for eb in repository_json["repository"]["extractor_bindings"]:
             extractor_bindings.append(ExtractorBinding.from_dict(eb))
-        metadata = repository_json["repository"]["metadata"]
+        labels = repository_json["repository"]["labels"]
         return Repository(
             name=repository_json["repository"]["name"],
             service_url=service_url,
             extractor_bindings=extractor_bindings,
-            metadata=metadata,
+            labels=labels,
         )
+
+    def get_content(self, params: dict = {}):
+        response = httpx.get(
+            f"{self._service_url}/repositories/{self.name}/content", params=params
+        )
+        response.raise_for_status()
+        return response.json()["content_list"]
 
     def get_extractor_bindings(self):
         response = httpx.get(f"{self._service_url}/repositories/{self.name}")

--- a/sdk-py/tests/integration_test.py
+++ b/sdk-py/tests/integration_test.py
@@ -35,7 +35,7 @@ class TestIntegrationTest(unittest.TestCase):
         repository.add_documents(
             Document(
                 text="This is a test",
-                metadata={"source": "test"},
+                labels={"source": "test"},
             )
         )
 
@@ -44,11 +44,11 @@ class TestIntegrationTest(unittest.TestCase):
             [
                 Document(
                     text="This is a new test",
-                    metadata={"source": "test"},
+                    labels={"source": "test"},
                 ),
                 Document(
                     text="This is another test",
-                    metadata={"source": "test"},
+                    labels={"source": "test"},
                 ),
             ]
         )
@@ -61,6 +61,13 @@ class TestIntegrationTest(unittest.TestCase):
 
         # Add mixed
         repository.add_documents(["string", Document("document string", {})])
+
+    def test_get_content(self):
+        repository_name = str(uuid4())
+        repo = self.client.create_repository(repository_name)
+        repo.add_documents(["one", "two", "three"])
+        content = repo.get_content()
+        assert len(content) == 3
 
     def test_search(self):
         repository_name = str(uuid4())
@@ -82,7 +89,7 @@ class TestIntegrationTest(unittest.TestCase):
             [
                 Document(
                     text="Indexify is also a retrieval service for LLM agents!",
-                    metadata={"url": url},
+                    labels={"url": url},
                 )
             ]
         )


### PR DESCRIPTION
rename document metadata to labels
show python in docs first in docs
added get_content in repository sdk with document examples