### PR TITLE
Python SDK ExtractorBinding + docs for metadata updates

### DIFF
--- a/docs/docs/apis/data_repository.md
+++ b/docs/docs/apis/data_repository.md
@@ -12,9 +12,19 @@ A data repository can be created by specifying a unique name, and any additional
 === "python"
 
     ```python
+    from indexify import ExtractorBinding
+
+    minilm_binding = ExtractorBinding(
+        extractor="tensorlake/minilm-l6",
+        name="minilm-l6",
+        content_source="source",
+        filters={},
+        input_params={},
+    )
+    
     client.create_repository(
         name="research",
-        extractor_bindings=[{"extractor": "tensorlake/minilm-l6", "name": "minilm-l6"}],
+        extractor_bindings=[minilm_binding],
         labels={"sensitive": "true"},
     )
     ```

--- a/docs/docs/apis/data_repository.md
+++ b/docs/docs/apis/data_repository.md
@@ -70,7 +70,7 @@ A data repository can be created by specifying a unique name, and any additional
           "extractor_bindings": [
             {
               "extractor": "diptanu/minilm-l6-extractor",
-              "name": "minilm61",
+              "name": "minilml6",
               "filters": [],
               "input_params": {}
             }

--- a/docs/docs/apis/retrieval.md
+++ b/docs/docs/apis/retrieval.md
@@ -11,12 +11,19 @@ Vector Indexes are created by running embedding models on content. They allow do
 
 The following example searches the repository `default` for the index `embeddings` for the query `good` and returns the top `k` results.
 
+=== "python"
+
+      ```python
+      repository.search_index("minilml6.embedding","good", 3)
+      ```
+
 === "curl"
-      ``` shell
+
+      ```shell
       curl -v -X POST http://localhost:8900/repositories/default/search \
       -H "Content-Type: application/json" \
       -d '{
-            "index": "embeddings",
+            "index": "minilml6.embedding",
             "query": "good", 
             "k": 1
       }'

--- a/docs/docs/apis/retrieval.md
+++ b/docs/docs/apis/retrieval.md
@@ -41,23 +41,36 @@ The following example searches the repository `default` for the index `embedding
       ]}
 ```
 
-## Attribute Indexes
-Attribute Indexes are created by extractors powered by AI Models which produced structured data. The output of such extractors are JSON documents and stored in a document store. 
+## Metadata Indexes
+Metadata Indexes are created by extractors powered by AI Models which produced structured data. The output of such extractors are JSON documents and stored in a document store. 
 
-The schema of such indexes are defined by the extractors. The retrieval API for attribute indexes allows querying all the attributes in the index or the ones of a specific content id. 
+The schema of such indexes are defined by the extractors. The retrieval API for metadata indexes allows querying all the metadata in the index or the ones of a specific content id. 
 
 In the future we will add support for searching these indexes as well using sparse vectors, or add them to knowledge graphs.
 
-The following example queries the repository `default` for the index `entities` and returns all the attributes in the index.
+The following example queries the repository `default` for the index `entities` and returns all the metadata in the index.
 
-=== "curl"
-      ``` shell
-      curl -v -X GET http://localhost:8900/repositories/default/attributes\?index=entities
+=== "python"
+
+      ```python
+      repo.query_metadata(index_name="entities")
       ```
 
-The following example queries the repository `default` for the index `entities` and returns the attributes for the content id `foo`.
+=== "curl"
+
+      ```shell
+      curl -v -X GET http://localhost:8900/repositories/default/metadata\?index=entities
+      ```
+
+The following example queries the repository `default` for the index `entities` and returns the metadata for the content id `foo`.
+
+=== "python"
+
+      ```python
+      repo.query_metadata(index_name="entities", content_id="foo")
+      ```
 
 === "curl"
       ``` shell
-      curl -v -X GET http://localhost:8900/repositories/default/attributes\?index=entities&content_id=foo
+      curl -v -X GET http://localhost:8900/repositories/default/metadata\?index=entities&content_id=foo
       ```

--- a/docs/docs/getting_started.md
+++ b/docs/docs/getting_started.md
@@ -99,7 +99,7 @@ Content can be filtered:
 === "python"
 
     ```
-    repo.get_content({"parent_id":"some_parent_id", "labels_eq":"key1:value1,key2:value2"})
+    repo.get_content(parent_id="some_parent_id", labels_eq="key1:value1,key2:value2")
     ```
 
 === "curl"

--- a/sdk-py/indexify/client.py
+++ b/sdk-py/indexify/client.py
@@ -170,6 +170,12 @@ class IndexifyClient:
         """
         Create a new repository.
         """
+        bindings = []
+        for bd in extractor_bindings:
+            if isinstance(bd, ExtractorBinding):
+                bindings.append(bd.asdict())
+            else:
+                bindings.append(bd)
         req = {
             "name": name,
             "extractor_bindings": extractor_bindings,

--- a/sdk-py/indexify/extractor_binding.py
+++ b/sdk-py/indexify/extractor_binding.py
@@ -1,4 +1,5 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, asdict
+
 
 @dataclass
 class ExtractorBinding:
@@ -14,7 +15,10 @@ class ExtractorBinding:
     def __str__(self) -> str:
         return self.__repr__()
 
+    def to_dict(self) -> dict:
+        # This method converts the dataclass instance to a dictionary.
+        return asdict(self)
+
     @classmethod
     def from_dict(cls, json: dict):
         return ExtractorBinding(**json)
-

--- a/sdk-py/indexify/extractor_binding.py
+++ b/sdk-py/indexify/extractor_binding.py
@@ -16,7 +16,6 @@ class ExtractorBinding:
         return self.__repr__()
 
     def to_dict(self) -> dict:
-        # This method converts the dataclass instance to a dictionary.
         return asdict(self)
 
     @classmethod

--- a/sdk-py/indexify/repository.py
+++ b/sdk-py/indexify/repository.py
@@ -160,12 +160,12 @@ class Repository:
             self.extractor_bindings.append(ExtractorBinding.from_dict(eb))
         return self.extractor_bindings
 
-    def query_attribute(self, index_name: str, content_id: str = None) -> dict:
+    def query_metadata(self, index_name: str, content_id: str = None) -> dict:
         params = {"index": index_name}
         if content_id:
             params.update({"content_id": content_id})
         response = httpx.get(
-            f"{self._service_url}/repositories/{self.name}/attributes", params=params
+            f"{self._service_url}/repositories/{self.name}/metadata", params=params
         )
         response.raise_for_status()
         return response.json()["attributes"]

--- a/sdk-py/indexify/repository.py
+++ b/sdk-py/indexify/repository.py
@@ -144,7 +144,17 @@ class Repository:
             labels=labels,
         )
 
-    def get_content(self, params: dict = {}):
+    def get_content(
+        self,
+        parent_id: str = None,
+        labels_eq: str = None,
+    ):
+        params = {}
+        if parent_id:
+            params.update({"parent_id": parent_id})
+        if labels_eq:
+            params.update({"labels_eq": labels_eq})
+
         response = httpx.get(
             f"{self._service_url}/repositories/{self.name}/content", params=params
         )

--- a/sdk-py/tests/integration_test.py
+++ b/sdk-py/tests/integration_test.py
@@ -65,9 +65,19 @@ class TestIntegrationTest(unittest.TestCase):
     def test_get_content(self):
         repository_name = str(uuid4())
         repo = self.client.create_repository(repository_name)
-        repo.add_documents(["one", "two", "three"])
+        repo.add_documents(
+            [Document(text="one", labels={"l1": "test"}), "two", "three"]
+        )
         content = repo.get_content()
         assert len(content) == 3
+
+        # parent doesn't exist
+        content = repo.get_content(parent_id="idontexist")
+        assert len(content) == 0
+
+        # filter label
+        content = repo.get_content(labels_eq="l1:test")
+        assert len(content) == 1
 
     def test_search(self):
         repository_name = str(uuid4())

--- a/sdk-py/tests/integration_test.py
+++ b/sdk-py/tests/integration_test.py
@@ -117,6 +117,21 @@ class TestIntegrationTest(unittest.TestCase):
             name,
         )
 
+    def test_query_metadata(self):
+        repository_name = str(uuid4())
+        extractor_name = str(uuid4())
+        self.client.create_repository(repository_name)
+        repository = self.client.get_repository(repository_name)
+        repository.bind_extractor(
+            "tensorlake/minilm-l6",
+            extractor_name,
+        )
+
+        for index in repository.indexes():
+            index_name = index.get("name")
+            repository.query_metadata(index_name)
+            # TODO: validate response - currently broken
+
     def test_extractor_input_params(self):
         name = str(uuid4())
         repository_name = "binding-test-repository"

--- a/src/server.rs
+++ b/src/server.rs
@@ -708,7 +708,7 @@ async fn index_search(
 #[tracing::instrument]
 #[utoipa::path(
     get,
-    path = "/repository/{repository_name}/attributes",
+    path = "/repository/{repository_name}/metadata",
     tag = "indexify",
     params(MetadataRequest),
     responses(


### PR DESCRIPTION
- update sdk create_repository method to accept ExtractorBinding instances when creating repository
- update data_repository docs to use Extractor binding in example
- rename repo sdk method query_attribute to query_metadata
- added query_metadata examples in retrieval docs
- update utoipa attributes -> metadata api docs
- update get_content to no longer take dict, use separate parameters