### PR TITLE
Use sqlite for local metadata storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1295,6 +1295,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fancy-regex"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1993,6 +2005,7 @@ dependencies = [
  "regex",
  "reqwest",
  "rocksdb",
+ "rusqlite",
  "rust-embed",
  "rustls 0.22.2",
  "rustls-pemfile 2.0.0",
@@ -3665,6 +3678,20 @@ dependencies = [
  "spki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a78046161564f5e7cd9008aff3b2990b3850dc8e0349119b98e8f251e099f24d"
+dependencies = [
+ "bitflags 2.4.2",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3691,6 +3691,7 @@ dependencies = [
  "fallible-streaming-iterator",
  "hashlink",
  "libsqlite3-sys",
+ "serde_json",
  "smallvec",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,7 @@ rust-embed = { version = "8", features = [
 ] }
 rustls = { version = "0.22" }
 rustls-pemfile = { version = "2" }
-rusqlite = { version = "0.30.0", features = ["bundled"] }
+rusqlite = { version = "0.30.0", features = ["bundled", "serde_json"] }
 serde = { version = "1", features = ["derive"] }
 serde_with = { version = "3.4.0" }
 serde_yaml = { version = "0.9" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,7 @@ rust-embed = { version = "8", features = [
 ] }
 rustls = { version = "0.22" }
 rustls-pemfile = { version = "2" }
+rusqlite = { version = "0.30.0", features = ["bundled"] }
 serde = { version = "1", features = ["derive"] }
 serde_with = { version = "3.4.0" }
 serde_yaml = { version = "0.9" }
@@ -151,6 +152,7 @@ rocksdb = { workspace = true }
 rust-embed = { workspace = true }
 rustls = { workspace = true }
 rustls-pemfile = { workspace = true }
+rusqlite = { workspace = true }
 serde = { workspace = true }
 serde_with = { workspace = true }
 serde_yaml = { workspace = true }

--- a/sample_config.yaml
+++ b/sample_config.yaml
@@ -55,6 +55,10 @@ index_config:
     efconstruction: 64
     efsearch: 40
 
+metadata_storage:
+  metadata_store: sqlite
+  conn_url: /tmp/indexify-metadata-index.db
+
 # If relative path is specified, it is relative to the project root directory
 # You should replace the values with your own values
 tls:

--- a/src/api.rs
+++ b/src/api.rs
@@ -318,7 +318,7 @@ pub struct ListContentFilters {
 
 #[derive(Debug, Serialize, Deserialize, IntoParams, ToSchema)]
 pub struct MetadataRequest {
-    pub content_id: Option<String>,
+    pub content_id: String,
     pub index: String,
 }
 

--- a/src/api.rs
+++ b/src/api.rs
@@ -13,7 +13,7 @@ use smart_default::SmartDefault;
 use strum::{Display, EnumString};
 use utoipa::{IntoParams, ToSchema};
 
-use crate::{api_utils, metadata_index, vectordbs};
+use crate::{api_utils, metadata_storage, vectordbs};
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct ExtractorBinding {
@@ -289,8 +289,8 @@ pub struct ExtractedMetadata {
     pub extractor_name: String,
 }
 
-impl From<metadata_index::ExtractedMetadata> for ExtractedMetadata {
-    fn from(value: metadata_index::ExtractedMetadata) -> Self {
+impl From<metadata_storage::ExtractedMetadata> for ExtractedMetadata {
+    fn from(value: metadata_storage::ExtractedMetadata) -> Self {
         Self {
             id: value.id,
             content_id: value.content_id,

--- a/src/data_manager.rs
+++ b/src/data_manager.rs
@@ -517,7 +517,7 @@ impl DataManager {
         &self,
         namespace: &str,
         index_name: &str,
-        content_id: Option<&String>,
+        content_id: &str,
     ) -> Result<Vec<ExtractedMetadata>, anyhow::Error> {
         let req = indexify_coordinator::GetIndexRequest {
             namespace: namespace.to_string(),

--- a/src/data_manager.rs
+++ b/src/data_manager.rs
@@ -20,13 +20,13 @@ use crate::{
     coordinator_client::CoordinatorClient,
     extractor::ExtractedEmbeddings,
     grpc_helper::GrpcHelper,
-    metadata_index::{ExtractedMetadata, MetadataIndexManager},
+    metadata_storage::{ExtractedMetadata, MetadataStorageTS},
     vector_index::{ScoredText, VectorIndexManager},
 };
 
 pub struct DataManager {
     vector_index_manager: Arc<VectorIndexManager>,
-    metadata_index_manager: Arc<MetadataIndexManager>,
+    metadata_index_manager: MetadataStorageTS,
     blob_storage: BlobStorage,
     coordinator_client: Arc<CoordinatorClient>,
 }
@@ -40,14 +40,14 @@ impl fmt::Debug for DataManager {
 impl DataManager {
     pub async fn new(
         vector_index_manager: Arc<VectorIndexManager>,
-        attribute_index_manager: Arc<MetadataIndexManager>,
+        metadata_index_manager: MetadataStorageTS,
         blob_storage_config: BlobStorageConfig,
         coordinator_client: Arc<CoordinatorClient>,
     ) -> Result<Self> {
         let blob_storage = BlobStorage::new_with_config(blob_storage_config);
         Ok(Self {
             vector_index_manager,
-            metadata_index_manager: attribute_index_manager,
+            metadata_index_manager,
             blob_storage,
             coordinator_client,
         })
@@ -139,36 +139,31 @@ impl DataManager {
             let index_name = response.output_index_name_mapping.get(name).unwrap();
             let table_name = response.index_name_table_mapping.get(index_name).unwrap();
             index_names.push(index_name.clone());
-            match output_schema {
+            let index_schema = match output_schema {
                 internal_api::OutputSchema::Embedding(embedding_schema) => {
                     let _ = self
                         .vector_index_manager
                         .create_index(table_name, embedding_schema.clone())
                         .await?;
-                    self.create_index_metadata(
-                        namespace,
-                        index_name,
-                        table_name,
-                        serde_json::to_value(embedding_schema)?,
-                        &extractor_binding.name,
-                        &extractor.name,
-                    )
-                    .await?;
+                    serde_json::to_value(&embedding_schema)
                 }
                 internal_api::OutputSchema::Attributes(schema) => {
                     let _ = self
                         .metadata_index_manager
-                        .create_index(
-                            namespace,
-                            &index_name,
-                            table_name,
-                            &extractor.name,
-                            &extractor_binding.name,
-                            schema,
-                        )
+                        .create_index(&index_name, table_name)
                         .await?;
+                    Ok(schema)
                 }
-            }
+            }?;
+            self.create_index_metadata(
+                &namespace,
+                index_name,
+                table_name,
+                index_schema,
+                &extractor_binding.name,
+                &extractor.name,
+            )
+            .await?;
         }
 
         Ok(index_names)
@@ -539,7 +534,7 @@ impl DataManager {
             .ok_or(anyhow!("Index not found"))?;
 
         self.metadata_index_manager
-            .get_attributes(namespace, &index.table_name, content_id)
+            .get_metadata(namespace, &index.table_name, content_id)
             .await
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,7 +27,7 @@ mod data_manager;
 mod executor;
 mod extractor_router;
 mod grpc_helper;
-mod metadata_index;
+mod metadata_storage;
 mod task_store;
 mod test_util;
 mod tls;

--- a/src/metadata_storage/mod.rs
+++ b/src/metadata_storage/mod.rs
@@ -13,7 +13,7 @@ use crate::server_config::{MetadataStoreConfig, MetadataStoreKind};
 pub mod postgres;
 pub mod sqlite;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ExtractedMetadata {
     pub id: String,
     pub content_id: String,

--- a/src/metadata_storage/mod.rs
+++ b/src/metadata_storage/mod.rs
@@ -1,7 +1,11 @@
-use async_trait::async_trait;
-use std::{collections::hash_map::DefaultHasher, hash::{Hash, Hasher}, sync::Arc};
+use std::{
+    collections::hash_map::DefaultHasher,
+    hash::{Hash, Hasher},
+    sync::Arc,
+};
 
 use anyhow::Result;
+use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 
 use self::{postgres::PostgresIndexManager, sqlite::SqliteIndexManager};
@@ -59,7 +63,7 @@ pub trait MetadataStorage {
         &self,
         namespace: &str,
         index_table_name: &str,
-        content_id: Option<&String>,
+        content_id: &str,
     ) -> Result<Vec<ExtractedMetadata>>;
 }
 

--- a/src/metadata_storage/mod.rs
+++ b/src/metadata_storage/mod.rs
@@ -1,0 +1,71 @@
+use async_trait::async_trait;
+use std::{collections::hash_map::DefaultHasher, hash::{Hash, Hasher}, sync::Arc};
+
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+
+use self::{postgres::PostgresIndexManager, sqlite::SqliteIndexManager};
+use crate::server_config::{MetadataStoreConfig, MetadataStoreKind};
+pub mod postgres;
+pub mod sqlite;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExtractedMetadata {
+    pub id: String,
+    pub content_id: String,
+    pub parent_content_id: String,
+    pub metadata: serde_json::Value,
+    pub extractor_name: String,
+}
+
+impl ExtractedMetadata {
+    pub fn new(
+        content_id: &str,
+        parent_content_id: &str,
+        metadata: serde_json::Value,
+        extractor_name: &str,
+        repository: &str,
+    ) -> Self {
+        let mut s = DefaultHasher::new();
+        content_id.hash(&mut s);
+        extractor_name.hash(&mut s);
+        repository.hash(&mut s);
+        metadata.to_string().hash(&mut s);
+        let id = format!("{:x}", s.finish());
+        Self {
+            id,
+            content_id: content_id.into(),
+            parent_content_id: parent_content_id.into(),
+            metadata,
+            extractor_name: extractor_name.into(),
+        }
+    }
+}
+
+pub type MetadataStorageTS = Arc<dyn MetadataStorage + Sync + Send>;
+
+#[async_trait]
+pub trait MetadataStorage {
+    async fn create_index(&self, index_name: &str, table_name: &str) -> Result<String>;
+
+    async fn add_metadata(
+        &self,
+        repository: &str,
+        index_name: &str,
+        metadata: ExtractedMetadata,
+    ) -> Result<()>;
+
+    async fn get_metadata(
+        &self,
+        namespace: &str,
+        index_table_name: &str,
+        content_id: Option<&String>,
+    ) -> Result<Vec<ExtractedMetadata>>;
+}
+
+pub fn from_config(config: &MetadataStoreConfig) -> Result<MetadataStorageTS> {
+    match config.metadata_store {
+        MetadataStoreKind::Postgres => Ok(PostgresIndexManager::new(&config.conn_url)?),
+        MetadataStoreKind::Sqlite => Ok(SqliteIndexManager::new(&config.conn_url)?),
+    }
+}

--- a/src/metadata_storage/sqlite.rs
+++ b/src/metadata_storage/sqlite.rs
@@ -1,0 +1,46 @@
+use std::sync::Arc;
+
+use anyhow::{anyhow, Result};
+use async_trait::async_trait;
+use rusqlite::Connection;
+use tokio::sync::Mutex;
+
+use super::{ExtractedMetadata, MetadataStorage};
+
+pub struct SqliteIndexManager {
+    conn: Arc<Mutex<Connection>>,
+}
+
+impl SqliteIndexManager {
+    pub fn new(conn_url: &str) -> Result<Arc<Self>> {
+        let conn = Connection::open(conn_url)
+            .map_err(|e| anyhow!("unable to open sqlite connection: {}", e))?;
+        let conn = Arc::new(Mutex::new(conn));
+        Ok(Arc::new(Self { conn }))
+    }
+}
+
+#[async_trait]
+impl MetadataStorage for SqliteIndexManager {
+    async fn create_index(&self, index_name: &str, table_name: &str) -> Result<String> {
+        Ok("".to_string())
+    }
+
+    async fn add_metadata(
+        &self,
+        repository: &str,
+        index_name: &str,
+        metadata: ExtractedMetadata,
+    ) -> Result<()> {
+        Ok(())
+    }
+
+    async fn get_metadata(
+        &self,
+        namespace: &str,
+        index_table_name: &str,
+        content_id: Option<&String>,
+    ) -> Result<Vec<ExtractedMetadata>> {
+        Ok(vec![])
+    }
+}

--- a/src/metadata_storage/sqlite.rs
+++ b/src/metadata_storage/sqlite.rs
@@ -107,3 +107,65 @@ fn row_to_extracted_metadata(
         parent_content_id,
     })
 }
+
+#[cfg(test)]
+mod tests {
+    use rusqlite::params;
+
+    use super::*;
+    use crate::utils::PostgresIndexName;
+
+    #[tokio::test]
+    async fn test_create_index() {
+        let conn = Connection::open_in_memory().unwrap();
+        let conn = Arc::new(Mutex::new(conn));
+        let index_manager = SqliteIndexManager { conn };
+        let index_name = "test_index";
+        let table_name = "test_table";
+        let _ = index_manager
+            .create_index(index_name, table_name)
+            .await
+            .unwrap();
+        let table_name = PostgresIndexName::new(table_name);
+        let query =
+            format!("SELECT name FROM sqlite_master WHERE type='table' AND name='{table_name}';");
+        let conn = index_manager.conn.lock().await;
+        let mut stmt = conn.prepare(&query).unwrap();
+        let table_name_out: String = stmt.query_row(params![], |row| row.get(0)).unwrap();
+        assert_eq!(table_name_out, "test_table".to_string());
+    }
+
+    #[tokio::test]
+    async fn test_add_metadata() {
+        let conn = Connection::open_in_memory().unwrap();
+        let conn = Arc::new(Mutex::new(conn));
+        let index_manager = SqliteIndexManager { conn };
+        let index_name = "test_index";
+        let table_name = "test_table";
+        let _ = index_manager
+            .create_index(index_name, table_name)
+            .await
+            .unwrap();
+        let metadata = ExtractedMetadata {
+            id: "test_id".into(),
+            content_id: "test_content_id".into(),
+            parent_content_id: "test_parent_content_id".into(),
+            metadata: serde_json::json!({"test": "test"}),
+            extractor_name: "test_extractor".into(),
+        };
+        let namespace = "test_namespace";
+        let _ = index_manager
+            .add_metadata(namespace, table_name, metadata.clone())
+            .await
+            .unwrap();
+
+        // Retreive the metadata from the database
+        let metadata_out = index_manager
+            .get_metadata(namespace, table_name, "test_content_id")
+            .await
+            .unwrap();
+
+        assert_eq!(metadata_out.len(), 1);
+        assert_eq!(metadata_out[0], metadata);
+    }
+}

--- a/src/server.rs
+++ b/src/server.rs
@@ -124,7 +124,8 @@ impl Server {
             VectorIndexManager::new(coordinator_client.clone(), vector_db.clone())
                 .map_err(|e| anyhow!("unable to create vector index {}", e))?,
         );
-        let metadata_index_manager: MetadataStorageTS = metadata_storage::from_config(&self.config.metadata_storage)?;
+        let metadata_index_manager: MetadataStorageTS =
+            metadata_storage::from_config(&self.config.metadata_storage)?;
         let data_manager = Arc::new(
             DataManager::new(
                 vector_index_manager,
@@ -867,7 +868,7 @@ async fn metadata_lookup(
 ) -> Result<Json<MetadataResponse>, IndexifyAPIError> {
     let attributes = state
         .data_manager
-        .metadata_lookup(&namespace, &query.index, query.content_id.as_ref())
+        .metadata_lookup(&namespace, &query.index, &query.content_id)
         .await
         .map_err(|e| IndexifyAPIError::new(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -40,7 +40,7 @@ use crate::{
     coordinator_client::CoordinatorClient,
     data_manager::DataManager,
     extractor_router::ExtractorRouter,
-    metadata_index::MetadataIndexManager,
+    metadata_storage::{self, MetadataStorageTS},
     server_config::ServerConfig,
     tls::build_mtls_acceptor,
     vector_index::VectorIndexManager,
@@ -124,14 +124,11 @@ impl Server {
             VectorIndexManager::new(coordinator_client.clone(), vector_db.clone())
                 .map_err(|e| anyhow!("unable to create vector index {}", e))?,
         );
-        let attribute_index_manager = Arc::new(
-            MetadataIndexManager::new(&self.config.db_url, coordinator_client.clone()).await?,
-        );
-
+        let metadata_index_manager: MetadataStorageTS = metadata_storage::from_config(&self.config.metadata_storage)?;
         let data_manager = Arc::new(
             DataManager::new(
                 vector_index_manager,
-                attribute_index_manager,
+                metadata_index_manager,
                 self.config.blob_storage.clone(),
                 coordinator_client.clone(),
             )

--- a/src/server_config.rs
+++ b/src/server_config.rs
@@ -34,7 +34,9 @@ fn default_raft_port() -> u64 {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, strum::Display)]
 #[strum(serialize_all = "kebab-case")]
 pub enum MetadataStoreKind {
+    #[serde(alias = "postgres")]
     Postgres,
+    #[serde(alias = "sqlite")]
     Sqlite,
 }
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/src/server_config.rs
+++ b/src/server_config.rs
@@ -33,6 +33,27 @@ fn default_raft_port() -> u64 {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, strum::Display)]
 #[strum(serialize_all = "kebab-case")]
+pub enum MetadataStoreKind {
+    Postgres,
+    Sqlite,
+}
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct MetadataStoreConfig {
+    pub metadata_store: MetadataStoreKind,
+    pub conn_url: String,
+}
+
+impl Default for MetadataStoreConfig {
+    fn default() -> Self {
+        Self {
+            metadata_store: MetadataStoreKind::Sqlite,
+            conn_url: "/tmp/indexify_metadata.db".to_string(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, strum::Display)]
+#[strum(serialize_all = "kebab-case")]
 pub enum IndexStoreKind {
     Qdrant,
     PgVector,
@@ -355,6 +376,7 @@ pub struct ServerConfig {
     pub coordinator_port: u64,
     pub raft_port: u64,
     pub index_config: VectorIndexConfig,
+    pub metadata_storage: MetadataStoreConfig,
     pub db_url: String,
     #[serde(default)]
     pub coordinator_addr: String,
@@ -377,6 +399,7 @@ impl Default for ServerConfig {
             coordinator_port: default_coordinator_port(),
             raft_port: default_raft_port(),
             index_config: VectorIndexConfig::default(),
+            metadata_storage: MetadataStoreConfig::default(),
             db_url: "postgres://postgres:postgres@localhost/indexify".into(),
             coordinator_addr: format!("localhost:{}", default_coordinator_port()),
             blob_storage: BlobStorageConfig {


### PR DESCRIPTION
Making sqlite3 the default storage engine for storing structured data from unstructured data. 