### PR TITLE
Making the coordinator handle extractor instance removal

### DIFF
--- a/crates/indexify_internal_api/src/lib.rs
+++ b/crates/indexify_internal_api/src/lib.rs
@@ -473,7 +473,7 @@ impl From<Namespace> for indexify_coordinator::Namespace {
     }
 }
 
-#[derive(Clone, Serialize, Deserialize, Debug)]
+#[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
 pub enum ChangeType {
     NewContent,
     NewBinding,

--- a/src/cmd/server.rs
+++ b/src/cmd/server.rs
@@ -30,7 +30,7 @@ impl Args {
         info!("starting indexify server, version: {}", crate::VERSION);
         let config = if let Some(config_path) = config_path {
             ServerConfig::from_path(&config_path)
-                .expect(&format!("failed to load config file `{}`", config_path))
+                .unwrap_or_else(|_| panic!("failed to load config file `{}`", config_path))
         } else {
             info!("No config file provided. Using defaults");
             ServerConfig::default()

--- a/src/coordinator.rs
+++ b/src/coordinator.rs
@@ -7,143 +7,31 @@ use std::{
 use anyhow::{anyhow, Ok, Result};
 use indexify_internal_api as internal_api;
 use indexify_proto::indexify_coordinator;
-use internal_api::{StateChange, Task};
+use internal_api::StateChange;
 use jsonschema::JSONSchema;
 use tokio::sync::watch::Receiver;
 use tracing::info;
 
-use crate::{coordinator_filters::*, state::SharedState, task_allocator::TaskAllocator};
+use crate::{
+    coordinator_filters::*,
+    scheduler::Scheduler,
+    state::SharedState,
+    task_allocator::TaskAllocator,
+};
 
 pub struct Coordinator {
     shared_state: SharedState,
-    task_allocator: TaskAllocator,
+    scheduler: Scheduler,
 }
 
 impl Coordinator {
     pub fn new(shared_state: SharedState) -> Arc<Self> {
         let task_allocator = TaskAllocator::new(shared_state.clone());
+        let scheduler = Scheduler::new(shared_state.clone(), task_allocator);
         Arc::new(Self {
             shared_state,
-            task_allocator,
+            scheduler,
         })
-    }
-
-    #[tracing::instrument(skip(self, state_changes))]
-    pub async fn process_extraction_events(
-        &self,
-        state_changes: &Vec<StateChange>,
-    ) -> Result<Vec<Task>, anyhow::Error> {
-        info!("processing {} state changes", state_changes.len());
-        let mut tasks = Vec::new();
-        for change in state_changes {
-            info!(
-                "processing change event: {}, type: {}, id: {}",
-                change.id, change.change_type, change.object_id
-            );
-            match change.change_type {
-                internal_api::ChangeType::NewBinding => {
-                    let content_list = self
-                        .shared_state
-                        .content_matching_binding(&change.object_id)
-                        .await?;
-                    let tasks_for_binding =
-                        self.create_task(&change.object_id, content_list).await?;
-                    tasks.extend(tasks_for_binding);
-                }
-                internal_api::ChangeType::NewContent => {
-                    let bindings = self
-                        .shared_state
-                        .filter_extractor_binding_for_content(&change.object_id)
-                        .await?;
-                    let content = self
-                        .shared_state
-                        .get_conent_metadata(&change.object_id)
-                        .await?;
-                    for binding in bindings {
-                        let task_for_binding =
-                            self.create_task(&binding.id, vec![content.clone()]).await?;
-                        tasks.extend(task_for_binding);
-                    }
-                }
-                internal_api::ChangeType::ExecutorAdded => {
-                    info!("executor {} added", change.object_id);
-                }
-                internal_api::ChangeType::ExecutorRemoved => {
-                    info!("executor {} removed", change.object_id);
-                }
-            };
-            info!("created {} tasks", tasks.len());
-        }
-        Ok(tasks)
-    }
-
-    #[tracing::instrument(skip(self))]
-    pub async fn distribute_work(&self) -> Result<HashMap<String, String>, anyhow::Error> {
-        let unallocated_tasks = self.shared_state.unassigned_tasks().await?;
-
-        // work_id -> executor_id
-        let mut task_assignments = HashMap::new();
-        for task in unallocated_tasks {
-            let executors = self
-                .shared_state
-                .get_executors_for_extractor(&task.extractor)
-                .await?;
-            if !executors.is_empty() {
-                let rand_index = rand::random::<usize>() % executors.len();
-                let executor_meta = executors[rand_index].clone();
-                task_assignments.insert(task.id.clone(), executor_meta.id.clone());
-            }
-        }
-        info!("finishing work assignment: {:?}", task_assignments);
-        Ok(task_assignments)
-    }
-
-    pub async fn create_task(
-        &self,
-        extractor_binding_id: &str,
-        content_list: Vec<internal_api::ContentMetadata>,
-    ) -> Result<Vec<internal_api::Task>> {
-        let extractor_binding = self
-            .shared_state
-            .get_extractor_binding(extractor_binding_id)
-            .await?;
-        let extractor = self
-            .shared_state
-            .extractor_with_name(&extractor_binding.extractor)
-            .await?;
-        let mut output_mapping: HashMap<String, String> = HashMap::new();
-        for name in extractor.outputs.keys() {
-            let index_name = extractor_binding
-                .output_index_name_mapping
-                .get(name)
-                .unwrap();
-            let table_name = extractor_binding
-                .index_name_table_mapping
-                .get(index_name)
-                .unwrap();
-            output_mapping.insert(name.clone(), table_name.clone());
-        }
-        let mut tasks = Vec::new();
-        for content in content_list {
-            let mut hasher = DefaultHasher::new();
-            extractor_binding.name.hash(&mut hasher);
-            extractor_binding.namespace.hash(&mut hasher);
-            content.id.hash(&mut hasher);
-            let id = format!("{:x}", hasher.finish());
-            let task = internal_api::Task {
-                id,
-                extractor: extractor_binding.extractor.clone(),
-                extractor_binding: extractor_binding.name.clone(),
-                output_index_table_mapping: output_mapping.clone(),
-                namespace: extractor_binding.namespace.clone(),
-                content_metadata: content.clone(),
-                input_params: extractor_binding.input_params.clone(),
-                outcome: internal_api::TaskOutcome::Unknown,
-            };
-            info!("created task: {:?}", task);
-            tasks.push(task);
-        }
-        Ok(tasks)
     }
 
     pub async fn list_content(
@@ -296,7 +184,7 @@ impl Coordinator {
         binding: internal_api::ExtractorBinding,
         extractor: internal_api::ExtractorDescription,
     ) -> Result<()> {
-        if &extractor.input_params != &serde_json::Value::Null {
+        if extractor.input_params != serde_json::Value::Null {
             let input_params_schema =
                 JSONSchema::compile(&extractor.input_params).map_err(|e| {
                     anyhow!(
@@ -324,17 +212,16 @@ impl Coordinator {
     }
 
     #[tracing::instrument(skip(self))]
-    pub async fn process_and_distribute_work(&self) -> Result<(), anyhow::Error> {
+    pub async fn run_scheduler(&self) -> Result<(), anyhow::Error> {
         let state_changes = self.shared_state.unprocessed_state_change_events().await?;
-        let tasks = self.process_extraction_events(&state_changes).await?;
-        self.shared_state.create_tasks(tasks.clone()).await?;
-        self.shared_state
-            .mark_change_events_as_processed(state_changes)
-            .await?;
-
-        let task_ids = tasks.into_iter().map(|t| t.id).collect();
-
-        self.task_allocator.allocate_tasks(task_ids).await
+        for change in state_changes {
+            info!(
+                "processing change event: {}, type: {}, id: {}",
+                change.id, change.change_type, change.object_id
+            );
+            self.scheduler.handle_change_event(change).await?;
+        }
+        Ok(())
     }
 
     pub fn get_state_watcher(&self) -> Receiver<StateChange> {
@@ -413,7 +300,7 @@ mod tests {
 
         // Run scheduler without any bindings to make sure that the event is processed
         // and we don't have any tasks
-        coordinator.process_and_distribute_work().await?;
+        coordinator.run_scheduler().await?;
         let events = shared_state.unprocessed_state_change_events().await?;
         assert_eq!(events.len(), 0);
         let tasks = shared_state.unassigned_tasks().await?;
@@ -449,7 +336,7 @@ mod tests {
             2,
             shared_state.unprocessed_state_change_events().await?.len()
         );
-        coordinator.process_and_distribute_work().await?;
+        coordinator.run_scheduler().await?;
         assert_eq!(
             0,
             shared_state.unprocessed_state_change_events().await?.len()
@@ -477,7 +364,7 @@ mod tests {
                 source: "some_extractor_produced_this".to_string(),
             }])
             .await?;
-        coordinator.process_and_distribute_work().await?;
+        coordinator.run_scheduler().await?;
         assert_eq!(
             0,
             shared_state.unprocessed_state_change_events().await?.len()

--- a/src/coordinator_filters.rs
+++ b/src/coordinator_filters.rs
@@ -178,9 +178,11 @@ mod test_extractor_mimetype_filter {
         // Assert that content with mime type matches an extractor that supports the
         // same mime type
         let res = matches_mime_type(
-            &[mime::TEXT_PLAIN.to_string(),
+            &[
+                mime::TEXT_PLAIN.to_string(),
                 mime::IMAGE_PNG.to_string(),
-                mime::APPLICATION_PDF.to_string()],
+                mime::APPLICATION_PDF.to_string(),
+            ],
             &mime::TEXT_PLAIN.to_string(),
         );
         assert!(res);

--- a/src/coordinator_filters.rs
+++ b/src/coordinator_filters.rs
@@ -178,11 +178,9 @@ mod test_extractor_mimetype_filter {
         // Assert that content with mime type matches an extractor that supports the
         // same mime type
         let res = matches_mime_type(
-            &vec![
-                mime::TEXT_PLAIN.to_string(),
+            &[mime::TEXT_PLAIN.to_string(),
                 mime::IMAGE_PNG.to_string(),
-                mime::APPLICATION_PDF.to_string(),
-            ],
+                mime::APPLICATION_PDF.to_string()],
             &mime::TEXT_PLAIN.to_string(),
         );
         assert!(res);
@@ -190,7 +188,7 @@ mod test_extractor_mimetype_filter {
         // Assert that content with mime type matches an extractor that supports wild
         // card mime type
         let res = matches_mime_type(
-            &vec![mime::STAR_STAR.to_string()],
+            &[mime::STAR_STAR.to_string()],
             &mime::TEXT_PLAIN.to_string(),
         );
         assert!(res);
@@ -198,7 +196,7 @@ mod test_extractor_mimetype_filter {
         // Assert that content with mime type does not match an extractor that supports
         // the same mime type
         let res = matches_mime_type(
-            &vec![mime::TEXT_PLAIN.to_string()],
+            &[mime::TEXT_PLAIN.to_string()],
             &mime::APPLICATION_PDF.to_string(),
         );
         assert!(!res);

--- a/src/coordinator_service.rs
+++ b/src/coordinator_service.rs
@@ -559,7 +559,7 @@ async fn run_scheduler(
             _ = state_watcher_rx.changed() => {
                 if is_leader.load(Ordering::Relaxed) {
                     let _state_change = state_watcher_rx.borrow_and_update().clone();
-                   if let Err(err) = coordinator.process_and_distribute_work().await {
+                   if let Err(err) = coordinator.run_scheduler().await {
                           error!("error processing and distributing work: {:?}", err);
                    }
                 }

--- a/src/coordinator_service.rs
+++ b/src/coordinator_service.rs
@@ -285,7 +285,7 @@ impl CoordinatorService for CoordinatorServiceServer {
                 select! {
                     _ = shutdown_rx.changed() => {
                         info!("shutting down server, stopping heartbeats from executor: {}", executor_id);
-                        return;
+                        break;
                     }
                     frame = in_stream.next() => {
                         // Ensure the frame has something
@@ -294,26 +294,23 @@ impl CoordinatorService for CoordinatorServiceServer {
                         }
                         if let Err(err) = frame.as_ref().unwrap() {
                             info!("error receiving heartbeat request: {:?}", err);
-                            if let Err(err) = coordinator.remove_executor(&executor_id).await {
-                                error!("error removing executor: {}", err);
-                            }
                             break;
                         }
-                        executor_id = frame.unwrap().unwrap().executor_id.clone();
+                        // We could have used Option<> here but it would be inconvenient to dereference
+                        // it every time we need to use it below
+                        if executor_id == "" {
+                            executor_id = frame.unwrap().unwrap().executor_id;
+                        }
                         let tasks = coordinator.heartbeat(&executor_id).await;
                             if let Err(err) = &tasks {
                                 if let Err(err) =
                                     tx.send(Err(tonic::Status::internal(err.to_string()))).await
                                 {
-                                    info!("heartbeats stopped, removing executor: {}", executor_id);
-                                    if let Err(err) = coordinator.remove_executor(&executor_id).await {
-                                        error!("error removing executor: {}", err);
-                                    }
                                     error!(
                                         "error sending error message in heartbeat response: {}",
                                         err
                                     );
-                                    return;
+                                    break;
                                 }
                                 continue;
                             }
@@ -328,10 +325,14 @@ impl CoordinatorService for CoordinatorServiceServer {
                             };
                             if let Err(err) = tx.send(Ok(resp)).await {
                                 error!("error sending heartbeat response: {:?}", err);
-                                return;
+                                break;
                             }
                     }
                 }
+            }
+            info!("heartbeats stopped, removing executor: {}", executor_id);
+            if let Err(err) = coordinator.remove_executor(&executor_id).await {
+                error!("error removing executor: {}", err);
             }
         });
         Ok(tonic::Response::new(Box::pin(rx) as HBResponseStream))
@@ -552,8 +553,6 @@ async fn run_scheduler(
     // tokio::time::interval(tokio::time::Duration::from_secs(5));
     let is_leader = AtomicBool::new(false);
 
-    // Throw away the first value since it's garbage
-    _ = state_watcher_rx.changed().await;
     loop {
         tokio::select! {
             _ = state_watcher_rx.changed() => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,6 +24,7 @@ mod data_manager;
 mod extractor_router;
 mod grpc_helper;
 mod metadata_storage;
+mod scheduler;
 mod test_util;
 mod tls;
 mod tonic_streamer;

--- a/src/scheduler/mod.rs
+++ b/src/scheduler/mod.rs
@@ -1,15 +1,156 @@
-use indexify_internal_api::StateChange;
+use std::{
+    collections::{hash_map::DefaultHasher, HashMap},
+    hash::{Hash, Hasher},
+};
 
-use crate::state::SharedState;
+use anyhow::{Ok, Result};
+use indexify_internal_api as internal_api;
+use indexify_internal_api::StateChange;
+use tracing::info;
+
+use crate::{
+    state::SharedState,
+    task_allocator::{planner::plan::TaskAllocationPlan, TaskAllocator},
+};
 
 pub struct Scheduler {
     shared_state: SharedState,
+    task_allocator: TaskAllocator,
 }
 
 impl Scheduler {
-    pub fn new(shared_state: SharedState) -> Self {
-        Scheduler { shared_state }
+    pub fn new(shared_state: SharedState, task_allocator: TaskAllocator) -> Self {
+        Scheduler {
+            shared_state,
+            task_allocator,
+        }
     }
 
-    pub async fn handle_change_event(&self, change_events: StateChange) {}
+    pub async fn handle_change_event(&self, state_change: StateChange) -> Result<()> {
+
+        // Create new tasks
+        let tasks = self.create_new_tasks(state_change.clone()).await?;
+
+
+        // Allocate tasks and commit task assignments
+        let allocation_plan = self.allocate_tasks(tasks).await?;
+        self.shared_state.commit_task_assignments(allocation_plan.0).await?;
+
+        // Redistribute tasks and commit task assignments
+        let allocation_plan = self.redistribute_tasks(state_change).await?; 
+        self.shared_state.commit_task_assignments(allocation_plan.0).await?;
+        Ok(())
+    }
+
+    pub async fn create_new_tasks(
+        &self,
+        state_change: StateChange,
+    ) -> Result<Vec<internal_api::Task>> {
+        let tasks = match &state_change.change_type {
+            internal_api::ChangeType::NewBinding => {
+                let content_list = self
+                    .shared_state
+                    .content_matching_binding(&state_change.object_id)
+                    .await?;
+                
+                self
+                    .create_task(&state_change.object_id, content_list)
+                    .await?
+            }
+            internal_api::ChangeType::NewContent => {
+                let bindings = self
+                    .shared_state
+                    .filter_extractor_binding_for_content(&state_change.object_id)
+                    .await?;
+                let content = self
+                    .shared_state
+                    .get_conent_metadata(&state_change.object_id)
+                    .await?;
+                let mut tasks = Vec::new();
+                for binding in bindings {
+                    let tasks_for_binding =
+                        self.create_task(&binding.id, vec![content.clone()]).await?;
+                    tasks.extend(tasks_for_binding)
+                }
+                tasks
+            }
+            _ => Vec::new(),
+        };
+        Ok(tasks)
+    }
+
+    pub async fn allocate_tasks(
+        &self,
+        tasks: Vec<internal_api::Task>,
+    ) -> Result<TaskAllocationPlan> {
+        let task_ids = tasks.iter().map(|task| task.id.clone()).collect();
+        self.task_allocator.allocate_tasks(task_ids).await
+    }
+
+    pub async fn redistribute_tasks(
+        &self,
+        state_change: StateChange,
+    ) -> Result<TaskAllocationPlan> {
+        if state_change.change_type == internal_api::ChangeType::ExecutorRemoved ||
+            state_change.change_type == internal_api::ChangeType::ExecutorAdded
+        {
+            let executor = self
+                .shared_state
+                .get_executor_by_id(&state_change.object_id)
+                .await?;
+            return self
+                .task_allocator
+                .reallocate_all_tasks_matching_extractor(&executor.extractor.name)
+                .await;
+        }
+        Ok(TaskAllocationPlan(HashMap::new()))
+    }
+
+    pub async fn create_task(
+        &self,
+        extractor_binding_id: &str,
+        content_list: Vec<internal_api::ContentMetadata>,
+    ) -> Result<Vec<internal_api::Task>> {
+        let extractor_binding = self
+            .shared_state
+            .get_extractor_binding(extractor_binding_id)
+            .await?;
+        let extractor = self
+            .shared_state
+            .extractor_with_name(&extractor_binding.extractor)
+            .await?;
+        let mut output_mapping: HashMap<String, String> = HashMap::new();
+        for name in extractor.outputs.keys() {
+            let index_name = extractor_binding
+                .output_index_name_mapping
+                .get(name)
+                .unwrap();
+            let table_name = extractor_binding
+                .index_name_table_mapping
+                .get(index_name)
+                .unwrap();
+            output_mapping.insert(name.clone(), table_name.clone());
+        }
+        let mut tasks = Vec::new();
+        for content in content_list {
+            let mut hasher = DefaultHasher::new();
+            extractor_binding.name.hash(&mut hasher);
+            extractor_binding.namespace.hash(&mut hasher);
+            content.id.hash(&mut hasher);
+            let id = format!("{:x}", hasher.finish());
+            let task = internal_api::Task {
+                id,
+                extractor: extractor_binding.extractor.clone(),
+                extractor_binding: extractor_binding.name.clone(),
+                output_index_table_mapping: output_mapping.clone(),
+                namespace: extractor_binding.namespace.clone(),
+                content_metadata: content.clone(),
+                input_params: extractor_binding.input_params.clone(),
+                outcome: internal_api::TaskOutcome::Unknown,
+            };
+            info!("created task: {:?}", task);
+            tasks.push(task);
+        }
+        Ok(tasks)
+    }
 }

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -725,7 +725,7 @@ impl App {
     pub async fn list_indexes(&self, namespace: &str) -> Result<Vec<internal_api::Index>> {
         let store = self.indexify_state.read().await;
         let indexes = store
-            .namespace_extractors
+            .namespace_index_table
             .get(namespace)
             .cloned()
             .unwrap_or_default();

--- a/src/state/store/mod.rs
+++ b/src/state/store/mod.rs
@@ -233,7 +233,7 @@ impl RaftStateMachine<TypeConfig> for StateMachineStore {
             match ent.payload {
                 EntryPayload::Blank => {}
                 EntryPayload::Normal(req) => {
-                    change_events.extend(req.state_changes.clone());
+                    change_events.extend(req.new_state_changes.clone());
                     sm.apply(req.clone());
                 }
                 EntryPayload::Membership(mem) => {

--- a/src/state/store/requests.rs
+++ b/src/state/store/requests.rs
@@ -9,7 +9,8 @@ use super::{ExecutorId, TaskId};
 #[derive(Serialize, Deserialize, Clone)]
 pub struct Request {
     pub payload: RequestPayload,
-    pub state_changes: Vec<StateChange>,
+    pub new_state_changes: Vec<StateChange>,
+    pub state_changes_processed: Vec<StateChangeProcessed>,
 }
 
 #[derive(Serialize, Deserialize, Clone)]

--- a/src/state/store/state_machine_objects.rs
+++ b/src/state/store/state_machine_objects.rs
@@ -53,7 +53,7 @@ pub struct IndexifyState {
     pub extractor_executors_table: HashMap<ExtractorName, HashSet<ExecutorId>>,
 
     /// Namespace -> Index index
-    pub namespace_extractors: HashMap<NamespaceName, HashSet<internal_api::Index>>,
+    pub namespace_index_table: HashMap<NamespaceName, HashSet<internal_api::Index>>,
 
     /// Tasks that are currently unfinished, by extractor. Once they are
     /// finished, they are removed from this set.
@@ -157,7 +157,7 @@ impl IndexifyState {
                 namespace,
                 id,
             } => {
-                self.namespace_extractors
+                self.namespace_index_table
                     .entry(namespace.clone())
                     .or_default()
                     .insert(index.clone());

--- a/src/state/store/state_machine_objects.rs
+++ b/src/state/store/state_machine_objects.rs
@@ -105,10 +105,18 @@ impl IndexifyState {
                         .extractor_executors_table
                         .entry(executor_meta.extractor.name.clone())
                         .or_default();
-                    executors.remove(executor_meta.extractor.name.as_str());
+                    executors.remove(&executor_meta.id);
                 }
                 // Remove from the executor load table
                 self.executor_running_task_count.remove(&executor_id);
+
+                // Remove all tasks assigned to this executor
+                let tasks = self.task_assignments.remove(&executor_id);
+                if let Some(tasks) = tasks {
+                    for task_id in tasks {
+                        self.unassigned_tasks.insert(task_id);
+                    }
+                }
             }
             RequestPayload::CreateTasks { tasks } => {
                 for task in tasks {

--- a/src/task_allocator/mod.rs
+++ b/src/task_allocator/mod.rs
@@ -1,9 +1,9 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 
-use crate::state::{
-    store::{ExecutorId, TaskId},
-    SharedState,
-};
+use anyhow::Result;
+
+use self::planner::plan::TaskAllocationPlan;
+use crate::state::{store::TaskId, SharedState};
 
 pub mod planner;
 
@@ -24,33 +24,20 @@ impl TaskAllocator {
         }
     }
 
-    pub async fn allocate_tasks(&self, task_ids: HashSet<TaskId>) -> Result<(), anyhow::Error> {
-        let plan = self.planner.plan_allocations(task_ids).await?;
-        self.commit_task_assignments(plan.into()).await?;
-        Ok(())
+    pub async fn allocate_tasks(&self, task_ids: HashSet<TaskId>) -> Result<TaskAllocationPlan> {
+        self.planner.plan_allocations(task_ids).await
     }
 
     /// Reschedule all tasks that match an extractor, even if they are already
     /// assigned to a different executor.
-    async fn reallocate_all_tasks_matching_extractor(
+    pub async fn reallocate_all_tasks_matching_extractor(
         &self,
-        extractor_name: String,
-    ) -> Result<(), anyhow::Error> {
+        extractor_name: &str,
+    ) -> Result<TaskAllocationPlan> {
         let task_ids = self
             .shared_state
-            .unfinished_tasks_by_extractor(extractor_name.as_str())
+            .unfinished_tasks_by_extractor(extractor_name)
             .await?;
-        let plan = self.planner.plan_allocations(task_ids).await?;
-        self.commit_task_assignments(plan.into()).await?;
-        Ok(())
-    }
-
-    async fn commit_task_assignments(
-        &self,
-        task_to_executor_assignments: HashMap<TaskId, ExecutorId>,
-    ) -> Result<(), anyhow::Error> {
-        self.shared_state
-            .commit_task_assignments(task_to_executor_assignments)
-            .await
+        self.planner.plan_allocations(task_ids).await
     }
 }

--- a/src/task_allocator/planner/load_aware_distributor.rs
+++ b/src/task_allocator/planner/load_aware_distributor.rs
@@ -270,16 +270,11 @@ mod tests {
     use std::{collections::HashMap, sync::Arc, time::Instant};
 
     use indexify_internal_api as internal_api;
-    
     use internal_api::ContentMetadata;
     use serde_json::json;
 
     use super::*;
-    use crate::{
-        server_config::ServerConfig,
-        state::App,
-        test_util::db_utils::mock_extractor,
-    };
+    use crate::{server_config::ServerConfig, state::App, test_util::db_utils::mock_extractor};
 
     fn create_task(id: &str, extractor: &str, binding: &str) -> internal_api::Task {
         internal_api::Task {
@@ -392,7 +387,9 @@ mod tests {
             .await?;
 
         let task = create_task("test-task", &mock_extractor().name, "test-binding");
-        shared_state.create_tasks(vec![task.clone()]).await?;
+        shared_state
+            .create_tasks(vec![task.clone()], "change_id")
+            .await?;
 
         let distributor = LoadAwareDistributor::new(shared_state.clone());
         let result = distributor
@@ -462,7 +459,9 @@ mod tests {
             tasks.push(task1);
             tasks.push(task2);
         }
-        shared_state.create_tasks(tasks.clone()).await?;
+        shared_state
+            .create_tasks(tasks.clone(), "change_id")
+            .await?;
 
         let distributor = LoadAwareDistributor::new(shared_state.clone());
         let result = distributor
@@ -548,7 +547,9 @@ mod tests {
             tasks.push(task1);
             tasks.push(task2);
         }
-        shared_state.create_tasks(tasks.clone()).await?;
+        shared_state
+            .create_tasks(tasks.clone(), "change_id")
+            .await?;
 
         // arbitrarily increase the load on the first text executor and json executor
         let mut sm = shared_state.indexify_state.write().await;
@@ -672,7 +673,9 @@ mod tests {
             tasks.push(task1);
             tasks.push(task2);
         }
-        shared_state.create_tasks(tasks.clone()).await?;
+        shared_state
+            .create_tasks(tasks.clone(), "change_id")
+            .await?;
 
         let distributor = LoadAwareDistributor::new(shared_state.clone());
         // start the timer


### PR DESCRIPTION
The scheduler now handles when extractor instances die and rebalances work if new ones comes online 