### PR TITLE
Added extractors for init compose

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,9 +1,6 @@
 version: "3"
 networks:
   server:
-    ipam:
-      config:
-        - subnet: 172.21.0.0/24
 services:
   indexify:
     image: tensorlake/indexify
@@ -19,7 +16,8 @@ services:
       - postgres
     networks:
       server:
-        ipv4_address: 172.21.0.2
+        aliases:
+          - indexify
     volumes:
       - data:/tmp/indexify-blob-storage
   postgres:
@@ -32,13 +30,20 @@ services:
       - POSTGRES_DB=indexify
     networks:
       server:
-        ipv4_address: 172.21.0.5
+        aliases:
+          - postgres
   embedding-extractor:
     image: tensorlake/minilm-l6
-    command: ["join", "--coordinator", "172.21.0.2:8950", "--ingestion-addr", "172.21.0.2:8900"]
+    command:
+      [
+        "join",
+        "--coordinator",
+        "indexify:8950",
+        "--ingestion-addr",
+        "indexify:8900"
+      ]
     networks:
       server:
-        ipv4_address: 172.21.0.9
     volumes:
       - data:/tmp/indexify-blob-storage
 volumes:

--- a/src/cmd/init_compose.rs
+++ b/src/cmd/init_compose.rs
@@ -3,28 +3,43 @@ use clap::Args as ClapArgs;
 
 use super::GlobalArgs;
 
+struct TemplateExtractorValue {
+    docker_image: String,
+    service_name: String,
+}
+
 #[derive(Template)]
 #[template(path = "docker_compose.yaml.jinja2")]
 struct DockerComposeTemplate {
-    // Add fields here when we templatize this
+    extractors: Vec<TemplateExtractorValue>,
 }
 
 #[derive(Debug, ClapArgs)]
 pub struct Args {
     #[arg(short, long)]
     path: Option<String>,
+    #[arg(long)]
+    extractor: Vec<String>,
 }
 
 impl Args {
     pub async fn run(self, _: GlobalArgs) {
-        let Self { path } = self;
+        let Self { path, extractor } = self;
         let path = path.unwrap_or_else(|| "./docker-compose.yaml".to_string());
         println!("Initializing docker compose file at: {}", &path);
         let path = std::path::Path::new(&path);
         let prefix = path.parent().expect("failed to get parent directory");
         std::fs::create_dir_all(prefix).expect("failed to create parent directory");
 
-        let template = DockerComposeTemplate {};
+        let extractors = extractor
+            .into_iter()
+            .map(|extractor| TemplateExtractorValue {
+                service_name: extractor.replace('/', "-"),
+                docker_image: extractor,
+            })
+            .collect();
+
+        let template = DockerComposeTemplate { extractors };
         let compose_file = template.render().unwrap();
         std::fs::write(&path, compose_file).expect("failed to write docker-compose file");
     }

--- a/templates/docker_compose.yaml.jinja2
+++ b/templates/docker_compose.yaml.jinja2
@@ -1,9 +1,6 @@
 version: "3"
 networks:
   server:
-    ipam:
-      config:
-        - subnet: 172.21.0.0/24
 services:
   indexify:
     image: tensorlake/indexify
@@ -19,7 +16,8 @@ services:
       - postgres
     networks:
       server:
-        ipv4_address: 172.21.0.2
+        aliases:
+          - indexify
     volumes:
       - data:/tmp/indexify-blob-storage
   postgres:
@@ -32,15 +30,17 @@ services:
       - POSTGRES_DB=indexify
     networks:
       server:
-        ipv4_address: 172.21.0.5
-  embedding-extractor:
-    image: tensorlake/minilm-l6
-    command: ["join", "--coordinator", "172.21.0.2:8950", "--ingestion-addr", "172.21.0.2:8900"]
+        aliases:
+          - postgres
+  {% for extractor in extractors %}
+  {{ extractor.service_name }}:
+    image: {{ extractor.docker_image }}
+    command: ["join", "--coordinator", "indexify:8950", "--ingestion-addr", "indexify:8900"]
     networks:
       server:
-        ipv4_address: 172.21.0.9
     volumes:
       - data:/tmp/indexify-blob-storage
+  {% endfor %}
 volumes:
   data:
 


### PR DESCRIPTION
Also added network aliases instead of hard-coded IP address to compose files, since they're much easier to work with.

You can pass as many `--extractor` arguments as you want and they'd all become a unique service in the resulting compose file