### PR TITLE
Update getting_started.md

### DIFF
--- a/docs/docs/getting_started.md
+++ b/docs/docs/getting_started.md
@@ -97,7 +97,7 @@ indexify-extractor download hub://embedding/minilm-l6
 
 Once the extractor SDK and extractors are downloaded, start and join them to the Indexify Control Plane.
 ```shell
-indexify-extractor join minilm_l6:MiniLMExtractor
+indexify-extractor join minilm_l6:MiniLML6Extractor
 ```
 The extractor is now ready to receive content you upload and extract embedding using the MiniLML6Extractor
 


### PR DESCRIPTION
Hey there, thank you for this awesome project!

I was following your docs and ran into this error when trying to join the `minilm_l6` extractor. Not sure if this is a typo
or if it was renamed in previous versions, but I was getting this:

```
...snip

AttributeError: module 'minilm_l6' has no attribute 'MiniLMExtractor'. Did you mean: 'MiniLML6Extractor'?

...snip
```