### PR TITLE
UI - Group content metadata by extractor name

### DIFF
--- a/ui/src/components/ExtractedMetaDataTable.tsx
+++ b/ui/src/components/ExtractedMetaDataTable.tsx
@@ -68,7 +68,7 @@ const ExtractedMetadataTable = ({
       }}
     >
       <Typography variant="h4" pb={2}>
-        Metadata:
+        Metadata - {extractedMetadata[0].extractor_name}:
       </Typography>
       <DataGrid
         sx={{ backgroundColor: "white" }}

--- a/ui/src/utils/helpers.ts
+++ b/ui/src/utils/helpers.ts
@@ -1,3 +1,5 @@
+import { IExtractedMetadata } from "getindexify";
+
 export const stringToColor = (str: string) => {
   let hash = 0;
   str.split("").forEach((char) => {
@@ -9,4 +11,23 @@ export const stringToColor = (str: string) => {
     color += value.toString(16).padStart(2, "0");
   }
   return color;
+};
+
+export const groupMetadataByExtractor = (
+  metadataArray: IExtractedMetadata[]
+): Record<string, IExtractedMetadata[]> => {
+  return metadataArray.reduce((accumulator, currentItem) => {
+    // Use the extractor_name as the key
+    const key = currentItem.extractor_name;
+
+    // If the key doesn't exist yet, initialize it
+    if (!accumulator[key]) {
+      accumulator[key] = [];
+    }
+
+    // Add the current item to the appropriate group
+    accumulator[key].push(currentItem);
+
+    return accumulator;
+  }, {} as Record<string, IExtractedMetadata[]>);
 };


### PR DESCRIPTION
Update to handle multiple extractors metadata outputs
![Screenshot 2024-03-15 at 12 57 24 PM](https://github.com/tensorlakeai/indexify/assets/12518571/de17566e-f528-47e3-ac1d-b0fb086b9bc6)
