### PR TITLE
Raft Metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3067,6 +3067,7 @@ dependencies = [
  "moka 0.12.5",
  "nanoid",
  "object_store",
+ "once_cell",
  "openraft",
  "opensearch",
  "opentelemetry 0.20.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3072,6 +3072,7 @@ dependencies = [
  "opensearch",
  "opentelemetry 0.20.0",
  "pgvector",
+ "pin-project-lite",
  "qdrant-client",
  "rand",
  "redis",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -196,6 +196,7 @@ vectordb = { workspace = true }
 lance = { workspace = true }
 async-stream = "0.3.5"
 json-schema-tools = {workspace=true}
+once_cell = "1.19.0"
 
 [dev-dependencies]
 tracing-test = { version = "0.2", features = ["no-env-filter"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -197,6 +197,7 @@ lance = { workspace = true }
 async-stream = "0.3.5"
 json-schema-tools = {workspace=true}
 once_cell = "1.19.0"
+pin-project-lite = "0.2.13"
 
 [dev-dependencies]
 tracing-test = { version = "0.2", features = ["no-env-filter"] }

--- a/crates/indexify_proto/src/indexify_coordinator.rs
+++ b/crates/indexify_proto/src/indexify_coordinator.rs
@@ -436,6 +436,89 @@ pub struct GetAllSchemaResponse {
     #[prost(message, repeated, tag = "1")]
     pub schemas: ::prost::alloc::vec::Vec<StructuredDataSchema>,
 }
+///   Raft Metrics Snapshot
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GetRaftMetricsSnapshotRequest {}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Uint64List {
+    #[prost(uint64, repeated, tag = "1")]
+    pub values: ::prost::alloc::vec::Vec<u64>,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct RaftMetricsSnapshotResponse {
+    ///   indexify metrics
+    #[prost(map = "string, uint64", tag = "1")]
+    pub fail_connect_to_peer: ::std::collections::HashMap<
+        ::prost::alloc::string::String,
+        u64,
+    >,
+    #[prost(map = "string, uint64", tag = "2")]
+    pub sent_bytes: ::std::collections::HashMap<::prost::alloc::string::String, u64>,
+    #[prost(map = "string, uint64", tag = "3")]
+    pub recv_bytes: ::std::collections::HashMap<::prost::alloc::string::String, u64>,
+    #[prost(map = "string, uint64", tag = "4")]
+    pub sent_failures: ::std::collections::HashMap<::prost::alloc::string::String, u64>,
+    #[prost(map = "string, uint64", tag = "5")]
+    pub snapshot_send_success: ::std::collections::HashMap<
+        ::prost::alloc::string::String,
+        u64,
+    >,
+    #[prost(map = "string, uint64", tag = "6")]
+    pub snapshot_send_failure: ::std::collections::HashMap<
+        ::prost::alloc::string::String,
+        u64,
+    >,
+    #[prost(map = "string, uint64", tag = "7")]
+    pub snapshot_recv_success: ::std::collections::HashMap<
+        ::prost::alloc::string::String,
+        u64,
+    >,
+    #[prost(map = "string, uint64", tag = "8")]
+    pub snapshot_recv_failure: ::std::collections::HashMap<
+        ::prost::alloc::string::String,
+        u64,
+    >,
+    #[prost(map = "string, uint64", tag = "9")]
+    pub snapshot_send_inflights: ::std::collections::HashMap<
+        ::prost::alloc::string::String,
+        u64,
+    >,
+    #[prost(map = "string, uint64", tag = "10")]
+    pub snapshot_recv_inflights: ::std::collections::HashMap<
+        ::prost::alloc::string::String,
+        u64,
+    >,
+    #[prost(map = "string, message", tag = "11")]
+    pub snapshot_sent_seconds: ::std::collections::HashMap<
+        ::prost::alloc::string::String,
+        Uint64List,
+    >,
+    #[prost(map = "string, message", tag = "12")]
+    pub snapshot_recv_seconds: ::std::collections::HashMap<
+        ::prost::alloc::string::String,
+        Uint64List,
+    >,
+    #[prost(uint64, repeated, tag = "13")]
+    pub snapshot_size: ::prost::alloc::vec::Vec<u64>,
+    #[prost(uint64, tag = "14")]
+    pub last_snapshot_creation_time_millis: u64,
+    ///   the open raft metrics
+    #[prost(bool, tag = "15")]
+    pub running_state_ok: bool,
+    #[prost(uint64, tag = "16")]
+    pub id: u64,
+    #[prost(uint64, tag = "17")]
+    pub current_term: u64,
+    #[prost(uint64, tag = "18")]
+    pub vote: u64,
+    #[prost(uint64, tag = "19")]
+    pub last_log_index: u64,
+    #[prost(uint64, tag = "20")]
+    pub current_leader: u64,
+}
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
 pub enum TaskOutcome {
@@ -1144,6 +1227,36 @@ pub mod coordinator_service_client {
                 );
             self.inner.unary(req, path, codec).await
         }
+        pub async fn get_raft_metrics_snapshot(
+            &mut self,
+            request: impl tonic::IntoRequest<super::GetRaftMetricsSnapshotRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::RaftMetricsSnapshotResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/indexify_coordinator.CoordinatorService/GetRaftMetricsSnapshot",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "indexify_coordinator.CoordinatorService",
+                        "GetRaftMetricsSnapshot",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
+        }
     }
 }
 /// Generated server implementations.
@@ -1294,6 +1407,13 @@ pub mod coordinator_service_server {
             request: tonic::Request<super::GetAllSchemaRequest>,
         ) -> std::result::Result<
             tonic::Response<super::GetAllSchemaResponse>,
+            tonic::Status,
+        >;
+        async fn get_raft_metrics_snapshot(
+            &self,
+            request: tonic::Request<super::GetRaftMetricsSnapshotRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::RaftMetricsSnapshotResponse>,
             tonic::Status,
         >;
     }
@@ -2317,6 +2437,56 @@ pub mod coordinator_service_server {
                     let fut = async move {
                         let inner = inner.0;
                         let method = ListSchemasSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/indexify_coordinator.CoordinatorService/GetRaftMetricsSnapshot" => {
+                    #[allow(non_camel_case_types)]
+                    struct GetRaftMetricsSnapshotSvc<T: CoordinatorService>(pub Arc<T>);
+                    impl<
+                        T: CoordinatorService,
+                    > tonic::server::UnaryService<super::GetRaftMetricsSnapshotRequest>
+                    for GetRaftMetricsSnapshotSvc<T> {
+                        type Response = super::RaftMetricsSnapshotResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::GetRaftMetricsSnapshotRequest>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as CoordinatorService>::get_raft_metrics_snapshot(
+                                        &inner,
+                                        request,
+                                    )
+                                    .await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = GetRaftMetricsSnapshotSvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(

--- a/protos/coordinator_service.proto
+++ b/protos/coordinator_service.proto
@@ -43,6 +43,8 @@ service CoordinatorService {
     rpc GetSchema(GetSchemaRequest) returns (GetSchemaResponse) {}
 
     rpc ListSchemas(GetAllSchemaRequest) returns (GetAllSchemaResponse) {}
+
+    rpc GetRaftMetricsSnapshot(GetRaftMetricsSnapshotRequest) returns (RaftMetricsSnapshotResponse) {}
 }
 
 message GetContentMetadataRequest {
@@ -314,3 +316,36 @@ message GetAllSchemaRequest {
 message GetAllSchemaResponse {
     repeated StructuredDataSchema schemas = 1;
 }
+
+//  Raft Metrics Snapshot
+message GetRaftMetricsSnapshotRequest {}
+
+message Uint64List {
+  repeated uint64 values = 1;
+}
+
+message RaftMetricsSnapshotResponse {
+    //  indexify metrics
+    map<string, uint64> fail_connect_to_peer = 1;
+    map<string, uint64> sent_bytes = 2;
+    map<string, uint64> recv_bytes = 3;
+    map<string, uint64> sent_failures = 4;
+    map<string, uint64> snapshot_send_success = 5;
+    map<string, uint64> snapshot_send_failure = 6;
+    map<string, uint64> snapshot_recv_success = 7;
+    map<string, uint64> snapshot_recv_failure = 8;
+    map<string, uint64> snapshot_send_inflights = 9;
+    map<string, uint64> snapshot_recv_inflights = 10;
+    map<string, Uint64List> snapshot_sent_seconds = 11;
+    map<string, Uint64List> snapshot_recv_seconds = 12;
+    repeated uint64 snapshot_size = 13;
+    uint64 last_snapshot_creation_time_millis = 14;
+    //  the open raft metrics
+    bool running_state_ok = 15;
+    uint64 id = 16;
+    uint64 current_term = 17;
+    uint64 vote = 18;
+    uint64 last_log_index = 19;
+    uint64 current_leader = 20;
+}
+//  End Raft Metrics Snapshot

--- a/src/coordinator.rs
+++ b/src/coordinator.rs
@@ -15,7 +15,7 @@ use tracing::info;
 use crate::{
     coordinator_filters::*,
     scheduler::Scheduler,
-    state::SharedState,
+    state::{RaftMetrics, SharedState},
     task_allocator::TaskAllocator,
 };
 
@@ -268,6 +268,10 @@ impl Coordinator {
 
     pub fn get_leader_change_watcher(&self) -> Receiver<bool> {
         self.shared_state.leader_change_rx.clone()
+    }
+
+    pub fn get_raft_metrics(&self) -> RaftMetrics {
+        self.shared_state.get_raft_metrics()
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,13 +1,12 @@
 use clap::Parser;
 use tracing_core::{Level, LevelFilter};
 use tracing_subscriber::{
-    prelude::__tracing_subscriber_SubscriberExt,
-    util::SubscriberInitExt,
-    Layer,
+    prelude::__tracing_subscriber_SubscriberExt, util::SubscriberInitExt, Layer,
 };
 
 pub mod coordinator_filters;
 pub mod coordinator_service;
+pub mod metrics;
 pub mod server;
 pub mod server_config;
 pub mod state;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,9 @@
 use clap::Parser;
 use tracing_core::{Level, LevelFilter};
 use tracing_subscriber::{
-    prelude::__tracing_subscriber_SubscriberExt, util::SubscriberInitExt, Layer,
+    prelude::__tracing_subscriber_SubscriberExt,
+    util::SubscriberInitExt,
+    Layer,
 };
 
 pub mod coordinator_filters;

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -101,6 +101,25 @@ pub mod raft_metrics {
         };
 
         use once_cell::sync::Lazy;
+        use serde::Serialize;
+
+        #[derive(Serialize)]
+        pub struct MetricsSnapshot {
+            pub fail_connect_to_peer: HashMap<String, u64>,
+            pub sent_bytes: HashMap<String, u64>,
+            pub recv_bytes: HashMap<String, u64>,
+            pub sent_failures: HashMap<String, u64>,
+            pub snapshot_send_success: HashMap<String, u64>,
+            pub snapshot_send_failure: HashMap<String, u64>,
+            pub snapshot_recv_success: HashMap<String, u64>,
+            pub snapshot_recv_failure: HashMap<String, u64>,
+            pub snapshot_send_inflights: HashMap<String, u64>,
+            pub snapshot_recv_inflights: HashMap<String, u64>,
+            pub snapshot_sent_seconds: HashMap<String, Vec<Duration>>,
+            pub snapshot_recv_seconds: HashMap<String, Vec<Duration>>,
+            pub snapshot_size: Vec<u64>,
+            pub last_snapshot_creation_time: Duration,
+        }
 
         struct RaftMetrics {
             fail_connect_to_peer: HashMap<String, u64>,
@@ -259,6 +278,29 @@ pub mod raft_metrics {
         pub fn set_last_snapshot_creation_time(time: Instant) {
             let mut metrics = RAFT_METRICS.write().unwrap_or_else(|e| e.into_inner());
             metrics.last_snapshot_creation_time = Some(time);
+        }
+
+        pub fn get_metrics_snapshot() -> MetricsSnapshot {
+            let metrics = RAFT_METRICS.read().unwrap_or_else(|e| e.into_inner());
+            MetricsSnapshot {
+                fail_connect_to_peer: metrics.fail_connect_to_peer.clone(),
+                sent_bytes: metrics.sent_bytes.clone(),
+                recv_bytes: metrics.recv_bytes.clone(),
+                sent_failures: metrics.sent_failures.clone(),
+                snapshot_send_success: metrics.snapshot_send_success.clone(),
+                snapshot_send_failure: metrics.snapshot_send_failure.clone(),
+                snapshot_recv_success: metrics.snapshot_recv_success.clone(),
+                snapshot_recv_failure: metrics.snapshot_recv_failure.clone(),
+                snapshot_send_inflights: metrics.snapshot_send_inflights.clone(),
+                snapshot_recv_inflights: metrics.snapshot_recv_inflights.clone(),
+                snapshot_sent_seconds: metrics.snapshot_sent_seconds.clone(),
+                snapshot_recv_seconds: metrics.snapshot_recv_seconds.clone(),
+                snapshot_size: metrics.snapshot_size.clone(),
+                last_snapshot_creation_time: metrics
+                    .last_snapshot_creation_time
+                    .map(|t| t.elapsed())
+                    .unwrap_or_default(),
+            }
         }
     }
 }

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -1,0 +1,52 @@
+pub mod raft_metrics {
+    pub mod network {
+        use once_cell::sync::Lazy;
+        use std::collections::HashMap;
+        use std::sync::Mutex;
+
+        struct RaftMetrics {
+            fail_connect_to_peer: HashMap<String, u64>,
+            sent_bytes: HashMap<String, u64>,
+            recv_bytes: HashMap<String, u64>,
+            sent_failures: HashMap<String, u64>,
+        }
+
+        impl RaftMetrics {
+            fn new() -> Self {
+                RaftMetrics {
+                    fail_connect_to_peer: HashMap::new(),
+                    sent_bytes: HashMap::new(),
+                    recv_bytes: HashMap::new(),
+                    sent_failures: HashMap::new(),
+                }
+            }
+        }
+
+        static RAFT_METRICS: Lazy<Mutex<RaftMetrics>> =
+            Lazy::new(|| Mutex::new(RaftMetrics::new()));
+
+        pub fn incr_fail_connect_to_peer(node_addr: String) {
+            let mut metrics = RAFT_METRICS.lock().unwrap();
+            let count = metrics.fail_connect_to_peer.entry(node_addr).or_insert(0);
+            *count += 1;
+        }
+
+        pub fn incr_sent_bytes(node_addr: String, bytes: u64) {
+            let mut metrics = RAFT_METRICS.lock().unwrap();
+            let count = metrics.sent_bytes.entry(node_addr).or_insert(0);
+            *count += bytes;
+        }
+
+        pub fn incr_recv_bytes(node_addr: String, bytes: u64) {
+            let mut metrics = RAFT_METRICS.lock().unwrap();
+            let count = metrics.recv_bytes.entry(node_addr).or_insert(0);
+            *count += bytes;
+        }
+
+        pub fn incr_sent_failures(node_addr: String) {
+            let mut metrics = RAFT_METRICS.lock().unwrap();
+            let count = metrics.sent_failures.entry(node_addr).or_insert(0);
+            *count += 1;
+        }
+    }
+}

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -96,7 +96,7 @@ pub mod raft_metrics {
     pub mod network {
         use std::{
             collections::HashMap,
-            sync::Mutex,
+            sync::RwLock,
             time::{Duration, Instant},
         };
 
@@ -140,11 +140,12 @@ pub mod raft_metrics {
             }
         }
 
-        static RAFT_METRICS: Lazy<Mutex<RaftMetrics>> =
-            Lazy::new(|| Mutex::new(RaftMetrics::new()));
+        //  TODO: Make the locks more granular and atomic
+        static RAFT_METRICS: Lazy<RwLock<RaftMetrics>> =
+            Lazy::new(|| RwLock::new(RaftMetrics::new()));
 
         pub fn incr_fail_connect_to_peer(node_addr: &str) {
-            let mut metrics = RAFT_METRICS.lock().unwrap();
+            let mut metrics = RAFT_METRICS.write().unwrap_or_else(|e| e.into_inner());
             let count = metrics
                 .fail_connect_to_peer
                 .entry(node_addr.into())
@@ -153,25 +154,25 @@ pub mod raft_metrics {
         }
 
         pub fn incr_sent_bytes(node_addr: &str, bytes: u64) {
-            let mut metrics = RAFT_METRICS.lock().unwrap();
+            let mut metrics = RAFT_METRICS.write().unwrap_or_else(|e| e.into_inner());
             let count = metrics.sent_bytes.entry(node_addr.into()).or_insert(0);
             *count += bytes;
         }
 
         pub fn incr_recv_bytes(node_addr: &str, bytes: u64) {
-            let mut metrics = RAFT_METRICS.lock().unwrap();
+            let mut metrics = RAFT_METRICS.write().unwrap_or_else(|e| e.into_inner());
             let count = metrics.recv_bytes.entry(node_addr.into()).or_insert(0);
             *count += bytes;
         }
 
         pub fn incr_sent_failures(node_addr: &str) {
-            let mut metrics = RAFT_METRICS.lock().unwrap();
+            let mut metrics = RAFT_METRICS.write().unwrap_or_else(|e| e.into_inner());
             let count = metrics.sent_failures.entry(node_addr.into()).or_insert(0);
             *count += 1;
         }
 
         pub fn incr_snapshot_send_success(node_addr: &str) {
-            let mut metrics = RAFT_METRICS.lock().unwrap();
+            let mut metrics = RAFT_METRICS.write().unwrap_or_else(|e| e.into_inner());
             let count = metrics
                 .snapshot_send_success
                 .entry(node_addr.into())
@@ -180,7 +181,7 @@ pub mod raft_metrics {
         }
 
         pub fn incr_snapshot_send_failure(node_addr: &str) {
-            let mut metrics = RAFT_METRICS.lock().unwrap();
+            let mut metrics = RAFT_METRICS.write().unwrap_or_else(|e| e.into_inner());
             let count = metrics
                 .snapshot_send_failure
                 .entry(node_addr.into())
@@ -189,7 +190,7 @@ pub mod raft_metrics {
         }
 
         pub fn incr_snapshot_recv_success(node_addr: &str) {
-            let mut metrics = RAFT_METRICS.lock().unwrap();
+            let mut metrics = RAFT_METRICS.write().unwrap_or_else(|e| e.into_inner());
             let count = metrics
                 .snapshot_recv_success
                 .entry(node_addr.into())
@@ -198,7 +199,7 @@ pub mod raft_metrics {
         }
 
         pub fn incr_snapshot_recv_failure(node_addr: &str) {
-            let mut metrics = RAFT_METRICS.lock().unwrap();
+            let mut metrics = RAFT_METRICS.write().unwrap_or_else(|e| e.into_inner());
             let count = metrics
                 .snapshot_recv_failure
                 .entry(node_addr.into())
@@ -207,7 +208,7 @@ pub mod raft_metrics {
         }
 
         pub fn incr_snapshot_send_inflight(node_addr: &str, increment_cnt: i64) {
-            let mut metrics = RAFT_METRICS.lock().unwrap();
+            let mut metrics = RAFT_METRICS.write().unwrap_or_else(|e| e.into_inner());
             let count = metrics
                 .snapshot_send_inflights
                 .entry(node_addr.into())
@@ -220,7 +221,7 @@ pub mod raft_metrics {
         }
 
         pub fn incr_snapshot_recv_inflight(node_addr: &str, increment_cnt: i64) {
-            let mut metrics = RAFT_METRICS.lock().unwrap();
+            let mut metrics = RAFT_METRICS.write().unwrap_or_else(|e| e.into_inner());
             let count = metrics
                 .snapshot_recv_inflights
                 .entry(node_addr.into())
@@ -233,7 +234,7 @@ pub mod raft_metrics {
         }
 
         pub fn incr_snapshot_sent_seconds(node_addr: &str, duration: Duration) {
-            let mut metrics = RAFT_METRICS.lock().unwrap();
+            let mut metrics = RAFT_METRICS.write().unwrap_or_else(|e| e.into_inner());
             let durations = metrics
                 .snapshot_sent_seconds
                 .entry(node_addr.into())
@@ -242,7 +243,7 @@ pub mod raft_metrics {
         }
 
         pub fn incr_snapshot_recv_seconds(node_addr: &str, duration: Duration) {
-            let mut metrics = RAFT_METRICS.lock().unwrap();
+            let mut metrics = RAFT_METRICS.write().unwrap_or_else(|e| e.into_inner());
             let durations = metrics
                 .snapshot_recv_seconds
                 .entry(node_addr.into())
@@ -251,12 +252,12 @@ pub mod raft_metrics {
         }
 
         pub fn add_snapshot_size(size: u64) {
-            let mut metrics = RAFT_METRICS.lock().unwrap();
+            let mut metrics = RAFT_METRICS.write().unwrap_or_else(|e| e.into_inner());
             metrics.snapshot_size.push(size);
         }
 
         pub fn set_last_snapshot_creation_time(time: Instant) {
-            let mut metrics = RAFT_METRICS.lock().unwrap();
+            let mut metrics = RAFT_METRICS.write().unwrap_or_else(|e| e.into_inner());
             metrics.last_snapshot_creation_time = Some(time);
         }
     }

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -1,10 +1,11 @@
-use pin_project_lite::pin_project;
 use std::{
     future::Future,
     pin::Pin,
     task::{Context, Poll},
     time::{Duration, Instant},
 };
+
+use pin_project_lite::pin_project;
 
 pin_project! {
     #[must_use = "futures do nothing unless you `.await` or poll them"]
@@ -93,10 +94,9 @@ where
 
 pub mod raft_metrics {
     pub mod network {
+        use std::{collections::HashMap, sync::Mutex, time::Duration};
+
         use once_cell::sync::Lazy;
-        use std::collections::HashMap;
-        use std::sync::Mutex;
-        use std::time::Duration;
 
         struct RaftMetrics {
             fail_connect_to_peer: HashMap<String, u64>,
@@ -214,7 +214,7 @@ pub mod raft_metrics {
             let durations = metrics
                 .snapshot_sent_seconds
                 .entry(node_addr)
-                .or_insert(Vec::new());
+                .or_default();
             durations.push(duration);
         }
 
@@ -223,7 +223,7 @@ pub mod raft_metrics {
             let durations = metrics
                 .snapshot_recv_seconds
                 .entry(node_addr)
-                .or_insert(Vec::new());
+                .or_default();
             durations.push(duration);
         }
     }

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -211,19 +211,13 @@ pub mod raft_metrics {
 
         pub fn incr_snapshot_sent_seconds(node_addr: String, duration: Duration) {
             let mut metrics = RAFT_METRICS.lock().unwrap();
-            let durations = metrics
-                .snapshot_sent_seconds
-                .entry(node_addr)
-                .or_default();
+            let durations = metrics.snapshot_sent_seconds.entry(node_addr).or_default();
             durations.push(duration);
         }
 
         pub fn incr_snapshot_recv_seconds(node_addr: String, duration: Duration) {
             let mut metrics = RAFT_METRICS.lock().unwrap();
-            let durations = metrics
-                .snapshot_recv_seconds
-                .entry(node_addr)
-                .or_default();
+            let durations = metrics.snapshot_recv_seconds.entry(node_addr).or_default();
             durations.push(duration);
         }
     }

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -94,7 +94,11 @@ where
 
 pub mod raft_metrics {
     pub mod network {
-        use std::{collections::HashMap, sync::Mutex, time::Duration};
+        use std::{
+            collections::HashMap,
+            sync::Mutex,
+            time::{Duration, Instant},
+        };
 
         use once_cell::sync::Lazy;
 
@@ -111,6 +115,8 @@ pub mod raft_metrics {
             snapshot_recv_inflights: HashMap<String, u64>,
             snapshot_sent_seconds: HashMap<String, Vec<Duration>>,
             snapshot_recv_seconds: HashMap<String, Vec<Duration>>,
+            snapshot_size: Vec<u64>,
+            last_snapshot_creation_time: Option<Instant>,
         }
 
         impl RaftMetrics {
@@ -128,6 +134,8 @@ pub mod raft_metrics {
                     snapshot_recv_inflights: HashMap::new(),
                     snapshot_sent_seconds: HashMap::new(),
                     snapshot_recv_seconds: HashMap::new(),
+                    snapshot_size: Vec::new(),
+                    last_snapshot_creation_time: None,
                 }
             }
         }
@@ -219,6 +227,16 @@ pub mod raft_metrics {
             let mut metrics = RAFT_METRICS.lock().unwrap();
             let durations = metrics.snapshot_recv_seconds.entry(node_addr).or_default();
             durations.push(duration);
+        }
+
+        pub fn add_snapshot_size(size: u64) {
+            let mut metrics = RAFT_METRICS.lock().unwrap();
+            metrics.snapshot_size.push(size);
+        }
+
+        pub fn set_last_snapshot_creation_time(time: Instant) {
+            let mut metrics = RAFT_METRICS.lock().unwrap();
+            metrics.last_snapshot_creation_time = Some(time);
         }
     }
 }

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -9,6 +9,10 @@ pub mod raft_metrics {
             sent_bytes: HashMap<String, u64>,
             recv_bytes: HashMap<String, u64>,
             sent_failures: HashMap<String, u64>,
+            snapshot_send_success: HashMap<String, u64>,
+            snapshot_send_failure: HashMap<String, u64>,
+            snapshot_recv_success: HashMap<String, u64>,
+            snapshot_recv_failure: HashMap<String, u64>,
         }
 
         impl RaftMetrics {
@@ -18,6 +22,10 @@ pub mod raft_metrics {
                     sent_bytes: HashMap::new(),
                     recv_bytes: HashMap::new(),
                     sent_failures: HashMap::new(),
+                    snapshot_send_success: HashMap::new(),
+                    snapshot_send_failure: HashMap::new(),
+                    snapshot_recv_success: HashMap::new(),
+                    snapshot_recv_failure: HashMap::new(),
                 }
             }
         }
@@ -46,6 +54,30 @@ pub mod raft_metrics {
         pub fn incr_sent_failures(node_addr: String) {
             let mut metrics = RAFT_METRICS.lock().unwrap();
             let count = metrics.sent_failures.entry(node_addr).or_insert(0);
+            *count += 1;
+        }
+
+        pub fn incr_snapshot_send_success(node_addr: String) {
+            let mut metrics = RAFT_METRICS.lock().unwrap();
+            let count = metrics.snapshot_send_success.entry(node_addr).or_insert(0);
+            *count += 1;
+        }
+
+        pub fn incr_snapshot_send_failure(node_addr: String) {
+            let mut metrics = RAFT_METRICS.lock().unwrap();
+            let count = metrics.snapshot_send_failure.entry(node_addr).or_insert(0);
+            *count += 1;
+        }
+
+        pub fn incr_snapshot_recv_success(node_addr: String) {
+            let mut metrics = RAFT_METRICS.lock().unwrap();
+            let count = metrics.snapshot_recv_success.entry(node_addr).or_insert(0);
+            *count += 1;
+        }
+
+        pub fn incr_snapshot_recv_failure(node_addr: String) {
+            let mut metrics = RAFT_METRICS.lock().unwrap();
+            let count = metrics.snapshot_recv_failure.entry(node_addr).or_insert(0);
             *count += 1;
         }
     }

--- a/src/state/grpc_server.rs
+++ b/src/state/grpc_server.rs
@@ -40,6 +40,12 @@ impl RaftGrpcServer {
         }
     }
 
+    fn incr_recv_bytes(&self, request: &Request<RaftRequest>) {
+        let addr = self.get_request_addr(&request);
+        let bytes_recv = request.get_ref().data.len() as u64;
+        raft_metrics::network::incr_recv_bytes(addr, bytes_recv);
+    }
+
     /// Get nodes from the cluster
     fn get_nodes_in_cluster(&self) -> BTreeMap<u64, BasicNode> {
         self.raft
@@ -124,9 +130,7 @@ impl RaftApi for RaftGrpcServer {
         &self,
         request: Request<RaftRequest>,
     ) -> Result<tonic::Response<RaftReply>, Status> {
-        let addr = self.get_request_addr(&request);
-        let bytes_recv = request.get_ref().data.len() as u64;
-        raft_metrics::network::incr_recv_bytes(addr, bytes_recv);
+        self.incr_recv_bytes(&request);
 
         if (self.ensure_leader().await?).is_some() {
             return Err(GrpcHelper::internal_err(
@@ -147,9 +151,7 @@ impl RaftApi for RaftGrpcServer {
         &self,
         request: Request<RaftRequest>,
     ) -> Result<tonic::Response<RaftReply>, Status> {
-        let addr = self.get_request_addr(&request);
-        let bytes_recv = request.get_ref().data.len() as u64;
-        raft_metrics::network::incr_recv_bytes(addr, bytes_recv);
+        self.incr_recv_bytes(&request);
 
         let ae_req = GrpcHelper::parse_req(request)?;
         let resp = self
@@ -165,9 +167,7 @@ impl RaftApi for RaftGrpcServer {
         &self,
         request: Request<RaftRequest>,
     ) -> Result<tonic::Response<RaftReply>, Status> {
-        let addr = self.get_request_addr(&request);
-        let bytes_recv = request.get_ref().data.len() as u64;
-        raft_metrics::network::incr_recv_bytes(addr, bytes_recv);
+        self.incr_recv_bytes(&request);
 
         let is_req = GrpcHelper::parse_req(request)?;
         let resp = self
@@ -186,9 +186,7 @@ impl RaftApi for RaftGrpcServer {
         &self,
         request: Request<RaftRequest>,
     ) -> Result<tonic::Response<RaftReply>, Status> {
-        let addr = self.get_request_addr(&request);
-        let bytes_recv = request.get_ref().data.len() as u64;
-        raft_metrics::network::incr_recv_bytes(addr, bytes_recv);
+        self.incr_recv_bytes(&request);
 
         let v_req = GrpcHelper::parse_req(request)?;
 
@@ -205,9 +203,7 @@ impl RaftApi for RaftGrpcServer {
         &self,
         request: Request<RaftRequest>,
     ) -> Result<tonic::Response<RaftReply>, Status> {
-        let addr = self.get_request_addr(&request);
-        let bytes_recv = request.get_ref().data.len() as u64;
-        raft_metrics::network::incr_recv_bytes(addr, bytes_recv);
+        self.incr_recv_bytes(&request);
 
         let req = GrpcHelper::parse_req::<StateMachineUpdateRequest>(request)?;
 

--- a/src/state/grpc_server.rs
+++ b/src/state/grpc_server.rs
@@ -11,9 +11,9 @@ use tonic::{Request, Status};
 use tracing::info;
 
 use super::{raft_client::RaftClient, NodeId};
-use crate::metrics::{raft_metrics, CounterGuard};
 use crate::{
     grpc_helper::GrpcHelper,
+    metrics::{raft_metrics, CounterGuard},
     state::{store::requests, Raft},
 };
 
@@ -41,7 +41,7 @@ impl RaftGrpcServer {
     }
 
     fn incr_recv_bytes(&self, request: &Request<RaftRequest>) {
-        let addr = self.get_request_addr(&request);
+        let addr = self.get_request_addr(request);
         let bytes_recv = request.get_ref().data.len() as u64;
         raft_metrics::network::incr_recv_bytes(addr, bytes_recv);
     }
@@ -241,7 +241,7 @@ impl RaftApi for RaftGrpcServer {
             .map_err(|e| GrpcHelper::internal_err(e.to_string()))?;
 
             let bytes_sent = forwarding_req.data.len() as u64;
-            raft_metrics::network::incr_sent_bytes(leader_address.into(), bytes_sent);
+            raft_metrics::network::incr_sent_bytes(leader_address, bytes_sent);
 
             return client.forward(forwarding_req).await;
         };

--- a/src/state/network.rs
+++ b/src/state/network.rs
@@ -5,8 +5,12 @@ use openraft::{
     error::{NetworkError, RemoteError, Unreachable},
     network::{RaftNetwork, RaftNetworkFactory},
     raft::{
-        AppendEntriesRequest, AppendEntriesResponse, InstallSnapshotRequest,
-        InstallSnapshotResponse, VoteRequest, VoteResponse,
+        AppendEntriesRequest,
+        AppendEntriesResponse,
+        InstallSnapshotRequest,
+        InstallSnapshotResponse,
+        VoteRequest,
+        VoteResponse,
     },
     BasicNode,
 };
@@ -24,7 +28,8 @@ use crate::{
         raft_client::RaftClient,
         store::requests::{RequestPayload, StateMachineUpdateRequest},
         typ::{InstallSnapshotError, RPCError, RaftError},
-        NodeId, TypeConfig,
+        NodeId,
+        TypeConfig,
     },
 };
 
@@ -79,10 +84,10 @@ impl Network {
             serde_json::from_str(&response.into_inner().data);
         let reply = result.map_err(|e| {
             raft_metrics::network::incr_sent_failures(target_addr.into());
-            return anyhow::anyhow!(format!(
+            anyhow::anyhow!(format!(
                 "Failed to parse the response received from forwarding a state machine request: {}",
                 e.to_string()
-            ));
+            ))
         })?;
 
         Ok(reply)
@@ -123,10 +128,10 @@ impl Network {
         let reply = serde_json::from_str::<StateMachineUpdateResponse>(&response.into_inner().data)
             .map_err(|e| {
                 raft_metrics::network::incr_sent_failures(target_addr.into());
-                return anyhow::anyhow!(
+                anyhow::anyhow!(
                     "Failed to parse the response received from sending a join_cluster request: {}",
                     e.to_string()
-                );
+                )
             })?;
 
         Ok(reply)
@@ -188,7 +193,7 @@ impl RaftNetwork<TypeConfig> for NetworkConnection {
 
         let resp = grpc_res.map_err(|e| {
             raft_metrics::network::incr_sent_failures(self.target_node.addr.clone());
-            return self.status_to_unreachable(e);
+            self.status_to_unreachable(e)
         })?;
 
         let raft_res = GrpcHelper::parse_raft_reply(resp)
@@ -264,7 +269,7 @@ impl RaftNetwork<TypeConfig> for NetworkConnection {
 
         let resp = grpc_res.map_err(|e| {
             raft_metrics::network::incr_sent_failures(self.target_node.addr.clone());
-            return self.status_to_unreachable(e);
+            self.status_to_unreachable(e)
         })?;
 
         let raft_res = GrpcHelper::parse_raft_reply(resp)

--- a/src/state/raft_client.rs
+++ b/src/state/raft_client.rs
@@ -36,7 +36,7 @@ impl RaftClient {
         let client = RaftApiClient::connect(format!("http://{}", addr))
             .await
             .map_err(|e| {
-                raft_metrics::network::incr_fail_connect_to_peer(format!("http:://{}", addr));
+                raft_metrics::network::incr_fail_connect_to_peer(&format!("http:://{}", addr));
                 anyhow!("unable to connect to raft: {} at addr {}", e, addr)
             })?;
         clients.insert(addr.to_string(), client.clone());

--- a/src/state/raft_client.rs
+++ b/src/state/raft_client.rs
@@ -6,6 +6,8 @@ use tokio::sync::Mutex;
 use tonic::transport::Channel;
 use tracing::info;
 
+use crate::metrics::raft_metrics;
+
 pub struct RaftClient {
     clients: Arc<Mutex<HashMap<String, RaftApiClient<Channel>>>>,
 }
@@ -33,7 +35,10 @@ impl RaftClient {
 
         let client = RaftApiClient::connect(format!("http://{}", addr))
             .await
-            .map_err(|e| anyhow!("unable to connect to raft: {} at addr {}", e, addr))?;
+            .map_err(|e| {
+                raft_metrics::network::incr_fail_connect_to_peer(format!("http:://{}", addr));
+                return anyhow!("unable to connect to raft: {} at addr {}", e, addr);
+            })?;
         clients.insert(addr.to_string(), client.clone());
         Ok(client)
     }

--- a/src/state/raft_client.rs
+++ b/src/state/raft_client.rs
@@ -37,7 +37,7 @@ impl RaftClient {
             .await
             .map_err(|e| {
                 raft_metrics::network::incr_fail_connect_to_peer(format!("http:://{}", addr));
-                return anyhow!("unable to connect to raft: {} at addr {}", e, addr);
+                anyhow!("unable to connect to raft: {} at addr {}", e, addr)
             })?;
         clients.insert(addr.to_string(), client.clone());
         Ok(client)

--- a/src/state/raft_client.rs
+++ b/src/state/raft_client.rs
@@ -36,7 +36,7 @@ impl RaftClient {
         let client = RaftApiClient::connect(format!("http://{}", addr))
             .await
             .map_err(|e| {
-                raft_metrics::network::incr_fail_connect_to_peer(&format!("http:://{}", addr));
+                raft_metrics::network::incr_fail_connect_to_peer(addr);
                 anyhow!("unable to connect to raft: {} at addr {}", e, addr)
             })?;
         clients.insert(addr.to_string(), client.clone());


### PR DESCRIPTION
## This PR

* Creates a global struct to maintain Raft metrics and ensures the struct is initialized lazily with a Mutex wrapper
* The `RaftMetrics` struct uses `String` instead of `&str` to avoid any issues with lifetimes that might crop up. This will probably require regular export of the metrics to avoid memory issues. 
* Creates helper methods to modify the metrics
* Uses helper methods when internal requests are being made to track various properties of the cluster
* Adds utilities like `TimedFuture` and `CounterGuard` to help keep track of metrics
* Adds gRPC endpoint to get Raft metrics