### PR TITLE
Adds Server Endpoint For Raft Metrics

### DIFF
--- a/crates/indexify_proto/src/indexify_coordinator.rs
+++ b/crates/indexify_proto/src/indexify_coordinator.rs
@@ -505,7 +505,7 @@ pub struct RaftMetricsSnapshotResponse {
     pub snapshot_size: ::prost::alloc::vec::Vec<u64>,
     #[prost(uint64, tag = "14")]
     pub last_snapshot_creation_time_millis: u64,
-    ///   the open raft metrics
+    ///   open raft metrics
     #[prost(bool, tag = "15")]
     pub running_state_ok: bool,
     #[prost(uint64, tag = "16")]

--- a/protos/coordinator_service.proto
+++ b/protos/coordinator_service.proto
@@ -340,7 +340,7 @@ message RaftMetricsSnapshotResponse {
     map<string, Uint64List> snapshot_recv_seconds = 12;
     repeated uint64 snapshot_size = 13;
     uint64 last_snapshot_creation_time_millis = 14;
-    //  the open raft metrics
+    //  open raft metrics
     bool running_state_ok = 15;
     uint64 id = 16;
     uint64 current_term = 17;

--- a/src/api.rs
+++ b/src/api.rs
@@ -562,3 +562,27 @@ pub struct StructuredDataSchema {
     pub content_source: String,
     pub namespace: String,
 }
+
+#[derive(Serialize, Deserialize)]
+pub struct RaftMetricsSnapshotResponse {
+    pub fail_connect_to_peer: HashMap<String, u64>,
+    pub sent_bytes: HashMap<String, u64>,
+    pub recv_bytes: HashMap<String, u64>,
+    pub sent_failures: HashMap<String, u64>,
+    pub snapshot_send_success: HashMap<String, u64>,
+    pub snapshot_send_failure: HashMap<String, u64>,
+    pub snapshot_recv_success: HashMap<String, u64>,
+    pub snapshot_recv_failure: HashMap<String, u64>,
+    pub snapshot_send_inflights: HashMap<String, u64>,
+    pub snapshot_recv_inflights: HashMap<String, u64>,
+    pub snapshot_sent_seconds: HashMap<String, Vec<u64>>,
+    pub snapshot_recv_seconds: HashMap<String, Vec<u64>>,
+    pub snapshot_size: Vec<u64>,
+    pub last_snapshot_creation_time_millis: u64,
+    pub running_state_ok: bool,
+    pub id: u64,
+    pub current_term: u64,
+    pub vote: u64,
+    pub last_log_index: u64,
+    pub current_leader: u64,
+}

--- a/src/coordinator_client.rs
+++ b/src/coordinator_client.rs
@@ -1,10 +1,10 @@
-use axum::http::StatusCode;
 use std::{collections::HashMap, sync::Arc};
 
 use anyhow::{anyhow, Ok, Result};
-use axum::Json;
+use axum::{http::StatusCode, Json};
 use indexify_proto::indexify_coordinator::{
-    self, coordinator_service_client::CoordinatorServiceClient,
+    self,
+    coordinator_service_client::CoordinatorServiceClient,
 };
 use tokio::sync::Mutex;
 use tonic::transport::Channel;

--- a/src/coordinator_client.rs
+++ b/src/coordinator_client.rs
@@ -1,9 +1,15 @@
+use axum::http::StatusCode;
 use std::{collections::HashMap, sync::Arc};
 
 use anyhow::{anyhow, Ok, Result};
-use indexify_proto::indexify_coordinator::coordinator_service_client::CoordinatorServiceClient;
+use axum::Json;
+use indexify_proto::indexify_coordinator::{
+    self, coordinator_service_client::CoordinatorServiceClient,
+};
 use tokio::sync::Mutex;
 use tonic::transport::Channel;
+
+use crate::api::{IndexifyAPIError, RaftMetricsSnapshotResponse};
 
 #[derive(Debug)]
 pub struct CoordinatorClient {
@@ -36,5 +42,53 @@ impl CoordinatorClient {
             })?;
         clients.insert(self.addr.to_string(), client.clone());
         Ok(client)
+    }
+
+    pub async fn get_raft_metrics_snapshot(
+        &self,
+    ) -> Result<Json<RaftMetricsSnapshotResponse>, IndexifyAPIError> {
+        let mut client = self
+            .get()
+            .await
+            .map_err(|e| IndexifyAPIError::new(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+        let grpc_res = client
+            .get_raft_metrics_snapshot(tonic::Request::new(
+                indexify_coordinator::GetRaftMetricsSnapshotRequest {},
+            ))
+            .await
+            .map_err(|e| IndexifyAPIError::new(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+        let raft_metrics = grpc_res.into_inner();
+        let snapshot_response = RaftMetricsSnapshotResponse {
+            fail_connect_to_peer: raft_metrics.fail_connect_to_peer,
+            sent_bytes: raft_metrics.sent_bytes,
+            recv_bytes: raft_metrics.recv_bytes,
+            sent_failures: raft_metrics.sent_failures,
+            snapshot_send_success: raft_metrics.snapshot_send_success,
+            snapshot_send_failure: raft_metrics.snapshot_send_failure,
+            snapshot_recv_success: raft_metrics.snapshot_recv_success,
+            snapshot_recv_failure: raft_metrics.snapshot_recv_failure,
+            snapshot_send_inflights: raft_metrics.snapshot_send_inflights,
+            snapshot_recv_inflights: raft_metrics.snapshot_recv_inflights,
+            snapshot_sent_seconds: raft_metrics
+                .snapshot_sent_seconds
+                .into_iter()
+                .map(|(k, v)| (k, v.values))
+                .collect(),
+            snapshot_recv_seconds: raft_metrics
+                .snapshot_recv_seconds
+                .into_iter()
+                .map(|(k, v)| (k, v.values))
+                .collect(),
+            snapshot_size: raft_metrics.snapshot_size,
+            last_snapshot_creation_time_millis: raft_metrics.last_snapshot_creation_time_millis,
+            running_state_ok: raft_metrics.running_state_ok,
+            id: raft_metrics.id,
+            current_term: raft_metrics.current_term,
+            vote: raft_metrics.vote,
+            last_log_index: raft_metrics.last_log_index,
+            current_leader: raft_metrics.current_leader,
+        };
+        Ok(Json(snapshot_response))
+            .map_err(|e| IndexifyAPIError::new(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -7,7 +7,9 @@ use axum::{
     http::StatusCode,
     response::{IntoResponse, Response},
     routing::{get, post},
-    Extension, Json, Router,
+    Extension,
+    Json,
+    Router,
 };
 use axum_otel_metrics::HttpMetricsLayerBuilder;
 use axum_server::Handle;

--- a/src/server.rs
+++ b/src/server.rs
@@ -224,7 +224,7 @@ impl Server {
                 post(extract_content).with_state(namespace_endpoint_state.clone()),
             )
             .route(
-                "metrics",
+                "/metrics/raft",
                 get(get_raft_metrics_snapshot).with_state(namespace_endpoint_state.clone()),
             )
             .route("/ui", get(ui_index_handler))
@@ -955,7 +955,6 @@ async fn get_extracted_metadata(
 #[axum::debug_handler]
 #[tracing::instrument]
 async fn get_raft_metrics_snapshot(
-    Path(url): Path<String>,
     State(state): State<NamespaceEndpointState>,
 ) -> Result<Json<RaftMetricsSnapshotResponse>, IndexifyAPIError> {
     state.coordinator_client.get_raft_metrics_snapshot().await


### PR DESCRIPTION
This PR adds a server endpoint to fetch raft metrics

Note: The metrics have been tested via browser GET request. Basic metrics are updating correctly 