### PR TITLE
State Machine Changes

### DIFF
--- a/src/data_manager.rs
+++ b/src/data_manager.rs
@@ -486,12 +486,11 @@ impl DataManager {
         let namespace = namespace.to_string();
         let query = query.to_string();
         let handle = self.rt.handle().clone();
-        
 
         tokio::task::spawn_blocking(move || {
             let namespace = namespace.to_string();
             let query = query.to_string();
-            
+
             handle.block_on(async move {
                 let namespace = namespace.to_string();
                 let query = query.to_string();

--- a/src/metadata_storage/sqlite.rs
+++ b/src/metadata_storage/sqlite.rs
@@ -143,12 +143,9 @@ impl MetadataReader for SqliteIndexManager {
         let query =
             format!("SELECT * FROM {table_name} WHERE namespace = $1 and content_source = $2");
         let conn = self.conn.lock().await;
-        let mut stmt = conn.prepare(&query).map_err(|e| {
-            GlueStorageError(format!(
-                "unable to execute query on sqlite: {}",
-                e
-            ))
-        })?;
+        let mut stmt = conn
+            .prepare(&query)
+            .map_err(|e| GlueStorageError(format!("unable to execute query on sqlite: {}", e)))?;
         let metadata = stmt
             .query_map(params![namespace, content_source], |row| {
                 row_to_extracted_metadata(row)

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -19,18 +19,23 @@ use network::Network;
 use openraft::{
     self,
     error::{InitializeError, RaftError},
-    BasicNode, TokioRuntime,
+    BasicNode,
+    TokioRuntime,
 };
 use serde::Serialize;
 use store::{
     requests::{RequestPayload, StateChangeProcessed, StateMachineUpdateRequest},
     state_machine_objects::IndexifyState,
-    ExecutorId, ExecutorIdRef, Response, TaskId,
+    ExecutorId,
+    ExecutorIdRef,
+    Response,
+    TaskId,
 };
 use tokio::{
     sync::{
         watch::{self, Receiver, Sender},
-        Mutex, RwLock,
+        Mutex,
+        RwLock,
     },
     task::JoinHandle,
 };
@@ -1049,7 +1054,8 @@ mod tests {
         state::{
             store::{
                 requests::{RequestPayload, StateMachineUpdateRequest},
-                ExecutorId, TaskId,
+                ExecutorId,
+                TaskId,
             },
             App,
         },
@@ -1261,9 +1267,9 @@ mod tests {
         let read_back = |node: Arc<App>| async move {
             match node.tasks_for_executor("executor_id", None).await {
                 Ok(tasks_vec)
-                    if tasks_vec.len() == 1
-                        && tasks_vec.first().unwrap().id == "task_id"
-                        && tasks_vec.first().unwrap().outcome == TaskOutcome::Unknown =>
+                    if tasks_vec.len() == 1 &&
+                        tasks_vec.first().unwrap().id == "task_id" &&
+                        tasks_vec.first().unwrap().outcome == TaskOutcome::Unknown =>
                 {
                     Ok(true)
                 }

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -869,12 +869,12 @@ impl App {
 
     pub async fn list_indexes(&self, namespace: &str) -> Result<Vec<internal_api::Index>> {
         let store = self.indexify_state.read().await;
-        let indexes = store
+        let index_ids = store
             .namespace_index_table
             .get(namespace)
             .cloned()
             .unwrap_or_default();
-        let indexes = indexes.into_iter().collect_vec();
+        let indexes = self.state_machine.get_indexes_from_ids(index_ids).await?;
         Ok(indexes)
     }
 

--- a/src/state/store/mod.rs
+++ b/src/state/store/mod.rs
@@ -295,6 +295,16 @@ impl StateMachineStore {
             .map_err(|e| anyhow::anyhow!("Failed to get tasks for executor: {}", e))
     }
 
+    pub async fn get_indexes_from_ids(
+        &self,
+        task_ids: HashSet<String>,
+    ) -> Result<Vec<indexify_internal_api::Index>> {
+        self.state_machine_reader
+            .get_indexes_from_ids(task_ids, &self.db)
+            .await
+            .map_err(|e| anyhow::anyhow!(e))
+    }
+
     pub async fn get_executors_from_ids(
         &self,
         executor_ids: HashSet<String>,

--- a/src/state/store/mod.rs
+++ b/src/state/store/mod.rs
@@ -15,12 +15,29 @@ use indexify_internal_api::{ContentMetadata, ExecutorMetadata, StateChange, Stru
 use itertools::Itertools;
 use openraft::{
     storage::{LogFlushed, LogState, RaftLogStorage, RaftStateMachine, Snapshot},
-    AnyError, BasicNode, Entry, EntryPayload, ErrorSubject, ErrorVerb, LogId, OptionalSend,
-    RaftLogReader, RaftSnapshotBuilder, SnapshotMeta, StorageError, StorageIOError,
-    StoredMembership, Vote,
+    AnyError,
+    BasicNode,
+    Entry,
+    EntryPayload,
+    ErrorSubject,
+    ErrorVerb,
+    LogId,
+    OptionalSend,
+    RaftLogReader,
+    RaftSnapshotBuilder,
+    SnapshotMeta,
+    StorageError,
+    StorageIOError,
+    StoredMembership,
+    Vote,
 };
 use rocksdb::{
-    ColumnFamily, ColumnFamilyDescriptor, Direction, OptimisticTransactionDB, Options, Transaction,
+    ColumnFamily,
+    ColumnFamilyDescriptor,
+    Direction,
+    OptimisticTransactionDB,
+    Options,
+    Transaction,
 };
 use serde::{de::DeserializeOwned, Deserialize};
 use strum::{AsRefStr, IntoEnumIterator};

--- a/src/state/store/state_machine_objects.rs
+++ b/src/state/store/state_machine_objects.rs
@@ -13,8 +13,16 @@ use super::{
     requests::{RequestPayload, StateChangeProcessed, StateMachineUpdateRequest},
     serializer::JsonEncode,
     store_utils::{decrement_running_task_count, increment_running_task_count},
-    ContentId, ExecutorId, ExtractorName, JsonEncoder, NamespaceName, SchemaId, StateChangeId,
-    StateMachineColumns, StateMachineError, TaskId,
+    ContentId,
+    ExecutorId,
+    ExtractorName,
+    JsonEncoder,
+    NamespaceName,
+    SchemaId,
+    StateChangeId,
+    StateMachineColumns,
+    StateMachineError,
+    TaskId,
 };
 
 #[derive(thiserror::Error, Debug, Clone, serde::Serialize, serde::Deserialize, Default)]

--- a/src/state/store/state_machine_objects.rs
+++ b/src/state/store/state_machine_objects.rs
@@ -8,22 +8,13 @@ use anyhow::Result;
 use indexify_internal_api as internal_api;
 use internal_api::{ExtractorDescription, StateChange};
 use rocksdb::OptimisticTransactionDB;
-use tracing::error;
 
 use super::{
     requests::{RequestPayload, StateChangeProcessed, StateMachineUpdateRequest},
     serializer::JsonEncode,
     store_utils::{decrement_running_task_count, increment_running_task_count},
-    ContentId,
-    ExecutorId,
-    ExtractorName,
-    JsonEncoder,
-    NamespaceName,
-    SchemaId,
-    StateChangeId,
-    StateMachineColumns,
-    StateMachineError,
-    TaskId,
+    ContentId, ExecutorId, ExtractorName, JsonEncoder, NamespaceName, SchemaId, StateChangeId,
+    StateMachineColumns, StateMachineError, TaskId,
 };
 
 #[derive(thiserror::Error, Debug, Clone, serde::Serialize, serde::Deserialize, Default)]
@@ -720,105 +711,6 @@ impl IndexifyState {
     ) {
         self.unprocessed_state_changes
             .remove(&state_change.state_change_id);
-    }
-
-    pub async fn get_tasks_for_executor(
-        &self,
-        executor_id: &str,
-        limit: Option<u64>,
-        db: &Arc<OptimisticTransactionDB>,
-    ) -> Result<Vec<indexify_internal_api::Task>, StateMachineError> {
-        //  NOTE: Don't do deserialization within the transaction
-        let txn = db.transaction();
-        let task_ids_key = executor_id.as_bytes();
-        let task_ids_bytes = txn
-            .get_cf(StateMachineColumns::TaskAssignments.cf(db), task_ids_key)
-            .map_err(|e| StateMachineError::TransactionError(e.to_string()))?;
-
-        let task_ids: Vec<String> = task_ids_bytes
-            .map(|task_id_bytes| {
-                JsonEncoder::decode(&task_id_bytes)
-                    .map_err(StateMachineError::from)
-                    .unwrap_or_else(|e| {
-                        error!("Failed to deserialize task id: {}", e);
-                        Vec::new()
-                    })
-            })
-            .unwrap_or_else(Vec::new);
-
-        let limit = limit.unwrap_or(task_ids.len() as u64) as usize;
-
-        let tasks: Result<Vec<indexify_internal_api::Task>, StateMachineError> = task_ids
-            .into_iter()
-            .take(limit)
-            .map(|task_id| {
-                let task_bytes = txn
-                    .get_cf(StateMachineColumns::Tasks.cf(db), task_id.as_bytes())
-                    .map_err(|e| StateMachineError::TransactionError(e.to_string()))?
-                    .ok_or_else(|| {
-                        StateMachineError::DatabaseError(format!("Task {} not found", task_id))
-                    })?;
-                JsonEncoder::decode(&task_bytes).map_err(StateMachineError::from)
-            })
-            .collect();
-        tasks
-    }
-
-    pub async fn get_executors_from_ids(
-        &self,
-        executor_ids: HashSet<String>,
-        db: &Arc<OptimisticTransactionDB>,
-    ) -> Result<Vec<internal_api::ExecutorMetadata>, StateMachineError> {
-        let txn = db.transaction();
-        let executors: Result<Vec<internal_api::ExecutorMetadata>, StateMachineError> =
-            executor_ids
-                .into_iter()
-                .map(|executor_id| {
-                    let executor_bytes = txn
-                        .get_cf(
-                            StateMachineColumns::Executors.cf(db),
-                            executor_id.as_bytes(),
-                        )
-                        .map_err(|e| StateMachineError::TransactionError(e.to_string()))?
-                        .ok_or_else(|| {
-                            StateMachineError::DatabaseError(format!(
-                                "Executor {} not found",
-                                executor_id
-                            ))
-                        })?;
-                    JsonEncoder::decode(&executor_bytes).map_err(StateMachineError::from)
-                })
-                .collect();
-        executors
-    }
-
-    // FIXME Move this out of here since reading from here requires taking a read
-    // lock on the whole statemachine
-    pub async fn get_content_from_ids(
-        &self,
-        content_ids: HashSet<String>,
-        db: &Arc<OptimisticTransactionDB>,
-    ) -> Result<Vec<internal_api::ContentMetadata>, StateMachineError> {
-        let txn = db.transaction();
-        let content: Result<Vec<internal_api::ContentMetadata>, StateMachineError> = content_ids
-            .into_iter()
-            .map(|content_id| {
-                let content_bytes = txn
-                    .get_cf(
-                        StateMachineColumns::ContentTable.cf(db),
-                        content_id.as_bytes(),
-                    )
-                    .map_err(|e| StateMachineError::TransactionError(e.to_string()))?
-                    .ok_or_else(|| {
-                        StateMachineError::DatabaseError(format!(
-                            "Content {} not found",
-                            content_id
-                        ))
-                    })?;
-                serde_json::from_slice(&content_bytes).map_err(StateMachineError::from)
-            })
-            .collect();
-        content
     }
 
     fn update_schema_reverse_idx(&mut self, schema: internal_api::StructuredDataSchema) {

--- a/src/state/store/state_machine_objects.rs
+++ b/src/state/store/state_machine_objects.rs
@@ -37,7 +37,7 @@ pub struct IndexifyState {
     pub extractor_executors_table: HashMap<ExtractorName, HashSet<ExecutorId>>,
 
     /// Namespace -> Index index
-    pub namespace_index_table: HashMap<NamespaceName, HashSet<internal_api::Index>>, /* TODO: Store id in the second column, not the entire index */
+    pub namespace_index_table: HashMap<NamespaceName, HashSet<String>>,
 
     /// Tasks that are currently unfinished, by extractor. Once they are
     /// finished, they are removed from this set.
@@ -657,14 +657,14 @@ impl IndexifyState {
             }
             // change required
             RequestPayload::CreateIndex {
-                index,
+                index: _,
                 namespace,
-                id: _,
+                id,
             } => {
                 self.namespace_index_table
                     .entry(namespace.clone())
                     .or_default()
-                    .insert(index.clone());
+                    .insert(id);
             }
             RequestPayload::UpdateTask {
                 task,

--- a/src/state/store/state_machine_objects.rs
+++ b/src/state/store/state_machine_objects.rs
@@ -30,13 +30,13 @@ pub struct IndexifyState {
     /// Namespace -> Content ID
     pub content_namespace_table: HashMap<NamespaceName, HashSet<ContentId>>,
 
-    /// Namespace -> Extractor bindings
-    pub extraction_policies_table: HashMap<NamespaceName, HashSet<internal_api::ExtractionPolicy>>, /* TODO: Change this to store extraction policy id in the second col because we have data elsewhere */
+    /// Namespace -> Extraction policy id
+    pub extraction_policies_table: HashMap<NamespaceName, HashSet<String>>,
 
     /// Extractor -> Executors table
     pub extractor_executors_table: HashMap<ExtractorName, HashSet<ExecutorId>>,
 
-    /// Namespace -> Index index
+    /// Namespace -> Index id
     pub namespace_index_table: HashMap<NamespaceName, HashSet<String>>,
 
     /// Tasks that are currently unfinished, by extractor. Once they are
@@ -643,7 +643,7 @@ impl IndexifyState {
                 self.extraction_policies_table
                     .entry(extraction_policy.namespace.clone())
                     .or_default()
-                    .insert(extraction_policy.clone());
+                    .insert(extraction_policy.id);
                 if let Some(schema) = updated_structured_data_schema {
                     self.update_schema_reverse_idx(schema);
                 }

--- a/src/state/store/state_machine_reader.rs
+++ b/src/state/store/state_machine_reader.rs
@@ -1,13 +1,15 @@
 use std::{collections::HashSet, sync::Arc};
 
+use indexify_internal_api;
 use rocksdb::OptimisticTransactionDB;
 use tracing::error;
 
 use super::{
     serializer::{JsonEncode, JsonEncoder},
-    StateMachineColumns, StateMachineError, TaskId,
+    StateMachineColumns,
+    StateMachineError,
+    TaskId,
 };
-use indexify_internal_api;
 
 #[derive(Clone)]
 pub struct StateMachineReader {}

--- a/src/state/store/state_machine_reader.rs
+++ b/src/state/store/state_machine_reader.rs
@@ -1,0 +1,113 @@
+use std::{collections::HashSet, sync::Arc};
+
+use rocksdb::OptimisticTransactionDB;
+use tracing::error;
+
+use super::{
+    serializer::{JsonEncode, JsonEncoder},
+    StateMachineColumns, StateMachineError,
+};
+use indexify_internal_api;
+
+#[derive(Clone)]
+pub struct StateMachineReader {}
+
+impl StateMachineReader {
+    pub async fn get_tasks_for_executor(
+        &self,
+        executor_id: &str,
+        limit: Option<u64>,
+        db: &Arc<OptimisticTransactionDB>,
+    ) -> Result<Vec<indexify_internal_api::Task>, StateMachineError> {
+        //  NOTE: Don't do deserialization within the transaction
+        let txn = db.transaction();
+        let task_ids_key = executor_id.as_bytes();
+        let task_ids_bytes = txn
+            .get_cf(StateMachineColumns::TaskAssignments.cf(db), task_ids_key)
+            .map_err(|e| StateMachineError::TransactionError(e.to_string()))?;
+
+        let task_ids: Vec<String> = task_ids_bytes
+            .map(|task_id_bytes| {
+                JsonEncoder::decode(&task_id_bytes)
+                    .map_err(StateMachineError::from)
+                    .unwrap_or_else(|e| {
+                        error!("Failed to deserialize task id: {}", e);
+                        Vec::new()
+                    })
+            })
+            .unwrap_or_else(Vec::new);
+
+        let limit = limit.unwrap_or(task_ids.len() as u64) as usize;
+
+        let tasks: Result<Vec<indexify_internal_api::Task>, StateMachineError> = task_ids
+            .into_iter()
+            .take(limit)
+            .map(|task_id| {
+                let task_bytes = txn
+                    .get_cf(StateMachineColumns::Tasks.cf(db), task_id.as_bytes())
+                    .map_err(|e| StateMachineError::TransactionError(e.to_string()))?
+                    .ok_or_else(|| {
+                        StateMachineError::DatabaseError(format!("Task {} not found", task_id))
+                    })?;
+                JsonEncoder::decode(&task_bytes).map_err(StateMachineError::from)
+            })
+            .collect();
+        tasks
+    }
+
+    pub async fn get_executors_from_ids(
+        &self,
+        executor_ids: HashSet<String>,
+        db: &Arc<OptimisticTransactionDB>,
+    ) -> Result<Vec<indexify_internal_api::ExecutorMetadata>, StateMachineError> {
+        let txn = db.transaction();
+        let executors: Result<Vec<indexify_internal_api::ExecutorMetadata>, StateMachineError> =
+            executor_ids
+                .into_iter()
+                .map(|executor_id| {
+                    let executor_bytes = txn
+                        .get_cf(
+                            StateMachineColumns::Executors.cf(db),
+                            executor_id.as_bytes(),
+                        )
+                        .map_err(|e| StateMachineError::TransactionError(e.to_string()))?
+                        .ok_or_else(|| {
+                            StateMachineError::DatabaseError(format!(
+                                "Executor {} not found",
+                                executor_id
+                            ))
+                        })?;
+                    JsonEncoder::decode(&executor_bytes).map_err(StateMachineError::from)
+                })
+                .collect();
+        executors
+    }
+
+    pub async fn get_content_from_ids(
+        &self,
+        content_ids: HashSet<String>,
+        db: &Arc<OptimisticTransactionDB>,
+    ) -> Result<Vec<indexify_internal_api::ContentMetadata>, StateMachineError> {
+        let txn = db.transaction();
+        let content: Result<Vec<indexify_internal_api::ContentMetadata>, StateMachineError> =
+            content_ids
+                .into_iter()
+                .map(|content_id| {
+                    let content_bytes = txn
+                        .get_cf(
+                            StateMachineColumns::ContentTable.cf(db),
+                            content_id.as_bytes(),
+                        )
+                        .map_err(|e| StateMachineError::TransactionError(e.to_string()))?
+                        .ok_or_else(|| {
+                            StateMachineError::DatabaseError(format!(
+                                "Content {} not found",
+                                content_id
+                            ))
+                        })?;
+                    serde_json::from_slice(&content_bytes).map_err(StateMachineError::from)
+                })
+                .collect();
+        content
+    }
+}

--- a/src/state/store/state_machine_reader.rs
+++ b/src/state/store/state_machine_reader.rs
@@ -131,4 +131,34 @@ impl StateMachineReader {
                 .collect();
         content
     }
+
+    pub async fn get_extraction_policies_from_ids(
+        &self,
+        extraction_policy_ids: HashSet<String>,
+        db: &Arc<OptimisticTransactionDB>,
+    ) -> Result<Vec<indexify_internal_api::ExtractionPolicy>, StateMachineError> {
+        let txn = db.transaction();
+        let extraction_policies: Result<
+            Vec<indexify_internal_api::ExtractionPolicy>,
+            StateMachineError,
+        > = extraction_policy_ids
+            .into_iter()
+            .map(|extraction_policy_id| {
+                let extraction_policy_bytes = txn
+                    .get_cf(
+                        StateMachineColumns::ExtractionPolicies.cf(db),
+                        extraction_policy_id.as_bytes(),
+                    )
+                    .map_err(|e| StateMachineError::TransactionError(e.to_string()))?
+                    .ok_or_else(|| {
+                        StateMachineError::DatabaseError(format!(
+                            "Extraction Policy {} not found",
+                            extraction_policy_id
+                        ))
+                    })?;
+                serde_json::from_slice(&extraction_policy_bytes).map_err(StateMachineError::from)
+            })
+            .collect();
+        extraction_policies
+    }
 }

--- a/src/task_allocator/planner/load_aware_distributor.rs
+++ b/src/task_allocator/planner/load_aware_distributor.rs
@@ -153,7 +153,13 @@ impl LoadAwareDistributor {
                 .state_machine
                 .get_from_cf::<ExecutorMetadata, _>(StateMachineColumns::Executors, executor_id)
                 .await
-                .ok();
+                .and_then(|opt| {
+                    if opt.is_none() {
+                        error!("Executor with id {} not found", executor_id);
+                    }
+                    Ok(opt)
+                })
+                .unwrap_or(None);
             match executor {
                 Some(executor) => {
                     let extractor_name = executor.extractor.name.clone();

--- a/src/task_allocator/planner/load_aware_distributor.rs
+++ b/src/task_allocator/planner/load_aware_distributor.rs
@@ -153,11 +153,11 @@ impl LoadAwareDistributor {
                 .state_machine
                 .get_from_cf::<ExecutorMetadata, _>(StateMachineColumns::Executors, executor_id)
                 .await
-                .and_then(|opt| {
+                .map(|opt| {
                     if opt.is_none() {
                         error!("Executor with id {} not found", executor_id);
                     }
-                    Ok(opt)
+                    opt
                 })
                 .unwrap_or(None);
             match executor {


### PR DESCRIPTION
## This PR

* Moves all reader methods into a separate module so that the state machine lock isn't held unnecessarily
* Returns an Option from `get_from_cf` so call sites can choose to not throw an error if the key is not found
* Removes data stored in reverse indexes so only ids are stored. Actual data is fetched from RocksDB