### PR TITLE
Return write size from put() functions

### DIFF
--- a/src/blob_storage/mod.rs
+++ b/src/blob_storage/mod.rs
@@ -32,14 +32,19 @@ pub struct BlobStorageConfig {
     pub disk: Option<DiskStorageConfig>,
 }
 
+pub struct PutResult {
+    pub url: String,
+    pub size_bytes: u64,
+}
+
 #[async_trait]
 pub trait BlobStorageWriter {
-    async fn put(&self, key: &str, data: Bytes) -> Result<String, anyhow::Error>;
+    async fn put(&self, key: &str, data: Bytes) -> Result<PutResult, anyhow::Error>;
     async fn put_stream(
         &self,
         key: &str,
         data: BoxStream<'static, Result<Bytes>>,
-    ) -> Result<String, anyhow::Error>;
+    ) -> Result<PutResult, anyhow::Error>;
     async fn delete(&self, key: &str) -> Result<()>;
 }
 
@@ -70,7 +75,7 @@ impl BlobStorage {
 
 #[async_trait]
 impl BlobStorageWriter for BlobStorage {
-    async fn put(&self, key: &str, data: Bytes) -> Result<String, anyhow::Error> {
+    async fn put(&self, key: &str, data: Bytes) -> Result<PutResult, anyhow::Error> {
         if key.starts_with("s3://") {
             let (bucket, key) = parse_s3_url(key)
                 .map_err(|err| anyhow::anyhow!("unable to parse s3 url: {}", err))?;
@@ -111,7 +116,7 @@ impl BlobStorageWriter for BlobStorage {
         &self,
         key: &str,
         data: BoxStream<'static, Result<Bytes>>,
-    ) -> Result<String, anyhow::Error> {
+    ) -> Result<PutResult, anyhow::Error> {
         if key.starts_with("s3://") {
             let (bucket, key) = parse_s3_url(key)
                 .map_err(|err| anyhow::anyhow!("unable to parse s3 url: {}", err))?;

--- a/src/blob_storage/s3.rs
+++ b/src/blob_storage/s3.rs
@@ -10,6 +10,7 @@ use object_store::{
 };
 use tokio::{io::AsyncWriteExt, sync::mpsc};
 use tokio_stream::wrappers::UnboundedReceiverStream;
+use crate::blob_storage::PutResult;
 
 use super::{BlobStorageReader, BlobStorageWriter};
 
@@ -29,22 +30,27 @@ impl S3Storage {
 
 #[async_trait]
 impl BlobStorageWriter for S3Storage {
-    async fn put(&self, key: &str, data: Bytes) -> Result<String> {
+    async fn put(&self, key: &str, data: Bytes) -> Result<PutResult> {
+        let size_bytes = data.len() as u64;
         self.client.put(&key.into(), data).await?;
-        Ok(format!("s3://{}/{}", self.bucket, key))
+        Ok(PutResult{ url: format!("s3://{}/{}", self.bucket, key), 
+            size_bytes })
     }
 
     async fn put_stream(
         &self,
         key: &str,
         mut data: BoxStream<'static, Result<Bytes>>,
-    ) -> Result<String> {
+    ) -> Result<PutResult> {
         let (_, mut writer) = self.client.put_multipart(&key.into()).await?;
+        let mut size_bytes: u64 = 0;
         while let Some(chunk) = data.next().await {
-            writer.write_all(&chunk?).await?;
+            let chunk = chunk?;
+            size_bytes += chunk.len() as u64;
+            writer.write_all(&chunk).await?;
         }
         writer.shutdown().await?;
-        Ok(format!("s3://{}/{}", self.bucket, key))
+        Ok(PutResult{ url: format!("s3://{}/{}", self.bucket, key), size_bytes })
     }
 
     async fn delete(&self, key: &str) -> Result<()> {


### PR DESCRIPTION
Since in stream case write size is unknown until completion, return total bytes written from put functions.