### PR TITLE
Functions for doing stream writes to disk and s3.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3325,6 +3325,7 @@ dependencies = [
  "sqlx",
  "strum 0.26.1",
  "tar",
+ "tempfile",
  "thiserror",
  "tokio",
  "tokio-rustls 0.25.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -201,6 +201,7 @@ gluesql = {workspace=true, default-features=false, features=["json-storage"]}
 
 [dev-dependencies]
 tracing-test = { version = "0.2", features = ["no-env-filter"] }
+tempfile = "3.2.0"
 
 [build-dependencies]
 # All features enabled

--- a/src/blob_storage/disk.rs
+++ b/src/blob_storage/disk.rs
@@ -7,6 +7,7 @@ use tokio::{fs::File, io::AsyncWriteExt, sync::mpsc};
 use tokio_stream::wrappers::UnboundedReceiverStream;
 
 use super::{BlobStorageReader, BlobStorageWriter, DiskStorageConfig};
+use crate::blob_storage::PutResult;
 
 #[derive(Debug)]
 pub struct DiskStorage {
@@ -24,12 +25,39 @@ impl DiskStorage {
 #[async_trait]
 impl BlobStorageWriter for DiskStorage {
     #[tracing::instrument(skip(self))]
-    async fn put(&self, key: &str, data: Bytes) -> Result<String, anyhow::Error> {
+    async fn put(&self, key: &str, data: Bytes) -> Result<PutResult, anyhow::Error> {
         let path = format!("{}/{}", self.config.path, key);
         let mut file = File::create(&path).await?;
         file.write_all(&data).await?;
+        file.shutdown().await?;
         let path = format!("file://{}", path);
-        Ok(path)
+        Ok(PutResult {
+            url: path,
+            size_bytes: data.len() as u64,
+        })
+    }
+
+    async fn put_stream(
+        &self,
+        key: &str,
+        data: impl futures::Stream<Item = Result<Bytes>> + Send + Unpin,
+    ) -> Result<PutResult, anyhow::Error> {
+        let path = format!("{}/{}", self.config.path, key);
+        let mut file = File::create(&path).await?;
+        let mut stream = data;
+        // TODO: need to handle partially successful writes
+        let mut size_bytes: u64 = 0;
+        while let Some(chunk) = stream.next().await {
+            let chunk = chunk?;
+            file.write_all(&chunk).await?;
+            size_bytes += chunk.len() as u64;
+        }
+        file.shutdown().await?;
+        let path = format!("file://{}", path);
+        Ok(PutResult {
+            url: path,
+            size_bytes,
+        })
     }
 
     #[tracing::instrument(skip(self))]
@@ -61,5 +89,75 @@ impl BlobStorageReader for DiskFileReader {
             }
         });
         Box::pin(UnboundedReceiverStream::new(rx))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{fs::File, io::Read};
+
+    use futures::stream;
+    use tempfile::tempdir;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_put() -> Result<(), anyhow::Error> {
+        let dir = tempdir()?;
+        let config = DiskStorageConfig {
+            path: dir.path().to_str().unwrap().to_string(),
+        };
+        let storage = DiskStorage::new(config)?;
+
+        let key = "testfile";
+        let data = Bytes::from_static(b"testdata");
+
+        let res = storage.put(key, data.clone()).await?;
+        assert_eq!(
+            res.url,
+            format!("file://{}/{}", dir.path().to_str().unwrap(), key)
+        );
+        assert_eq!(res.size_bytes, 8);
+
+        let mut file = File::open(format!("{}/{}", dir.path().to_str().unwrap(), key))?;
+        let mut contents = String::new();
+        file.read_to_string(&mut contents)?;
+        assert_eq!(contents, "testdata");
+
+        dir.close()?;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_put_stream() -> Result<(), anyhow::Error> {
+        let dir = tempdir()?;
+        let config = DiskStorageConfig {
+            path: dir.path().to_str().unwrap().to_string(),
+        };
+        let storage = DiskStorage::new(config)?;
+
+        let key = "testfile";
+        let data = stream::iter(vec![
+            Ok(Bytes::from_static(b"testdata")),
+            Ok(Bytes::from_static(b"testdata1")),
+            Ok(Bytes::from_static(b"testdata2")),
+        ]);
+
+        let res = storage.put_stream(key, Box::pin(data)).await?;
+        assert_eq!(
+            res.url,
+            format!("file://{}/{}", dir.path().to_str().unwrap(), key)
+        );
+        assert_eq!(res.size_bytes, 26);
+
+        let mut file = File::open(format!("{}/{}", dir.path().to_str().unwrap(), key))?;
+        let mut contents = String::new();
+        file.read_to_string(&mut contents)?;
+        assert_eq!(contents, "testdatatestdata1testdata2");
+
+        dir.close()?;
+
+        Ok(())
     }
 }

--- a/src/blob_storage/mod.rs
+++ b/src/blob_storage/mod.rs
@@ -32,6 +32,7 @@ pub struct BlobStorageConfig {
     pub disk: Option<DiskStorageConfig>,
 }
 
+#[derive(Debug)]
 pub struct PutResult {
     pub url: String,
     pub size_bytes: u64,

--- a/src/blob_storage/s3.rs
+++ b/src/blob_storage/s3.rs
@@ -3,15 +3,16 @@ use std::sync::Arc;
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use bytes::Bytes;
-use futures::{stream::BoxStream, StreamExt};
+use futures::{stream::BoxStream, Stream, StreamExt};
 use object_store::{
     aws::{AmazonS3, AmazonS3Builder},
     ObjectStore,
 };
-use tokio::sync::mpsc;
+use tokio::{io::AsyncWriteExt, sync::mpsc};
 use tokio_stream::wrappers::UnboundedReceiverStream;
 
 use super::{BlobStorageReader, BlobStorageWriter};
+use crate::blob_storage::PutResult;
 
 pub struct S3Storage {
     bucket: String,
@@ -29,9 +30,32 @@ impl S3Storage {
 
 #[async_trait]
 impl BlobStorageWriter for S3Storage {
-    async fn put(&self, key: &str, data: Bytes) -> Result<String> {
+    async fn put(&self, key: &str, data: Bytes) -> Result<PutResult> {
+        let size_bytes = data.len() as u64;
         self.client.put(&key.into(), data).await?;
-        Ok(format!("s3://{}/{}", self.bucket, key))
+        Ok(PutResult {
+            url: format!("s3://{}/{}", self.bucket, key),
+            size_bytes,
+        })
+    }
+
+    async fn put_stream(
+        &self,
+        key: &str,
+        mut data: impl Stream<Item = Result<Bytes>> + Send + Unpin,
+    ) -> Result<PutResult> {
+        let (_, mut writer) = self.client.put_multipart(&key.into()).await?;
+        let mut size_bytes: u64 = 0;
+        while let Some(chunk) = data.next().await {
+            let chunk = chunk?;
+            size_bytes += chunk.len() as u64;
+            writer.write_all(&chunk).await?;
+        }
+        writer.shutdown().await?;
+        Ok(PutResult {
+            url: format!("s3://{}/{}", self.bucket, key),
+            size_bytes,
+        })
     }
 
     async fn delete(&self, key: &str) -> Result<()> {

--- a/src/data_manager.rs
+++ b/src/data_manager.rs
@@ -9,6 +9,7 @@ use std::{
 
 use anyhow::{anyhow, Result};
 use bytes::Bytes;
+use futures::Stream;
 use indexify_internal_api as internal_api;
 use indexify_proto::indexify_coordinator;
 use itertools::Itertools;
@@ -17,7 +18,7 @@ use tracing::{error, info};
 
 use crate::{
     api::{self, BeginExtractedContentIngest},
-    blob_storage::{BlobStorage, BlobStorageWriter},
+    blob_storage::{BlobStorage, BlobStorageWriter, PutResult},
     coordinator_client::CoordinatorClient,
     grpc_helper::GrpcHelper,
     metadata_storage::{
@@ -235,8 +236,17 @@ impl DataManager {
     #[tracing::instrument]
     pub async fn add_texts(&self, namespace: &str, content_list: Vec<api::Content>) -> Result<()> {
         for text in content_list {
+            let stream = futures::stream::once(async { Ok(Bytes::from(text.bytes)) });
             let content_metadata = self
-                .write_content_bytes(namespace, text, None, None, "ingestion")
+                .write_content_bytes(
+                    namespace,
+                    Box::pin(stream),
+                    &text.labels,
+                    text.content_type,
+                    None,
+                    None,
+                    "ingestion",
+                )
                 .await?;
             let req: indexify_coordinator::CreateContentRequest =
                 indexify_coordinator::CreateContentRequest {
@@ -280,21 +290,30 @@ impl DataManager {
     }
 
     #[tracing::instrument(skip(self, data))]
-    pub async fn upload_file(&self, namespace: &str, data: Bytes, name: &str) -> Result<()> {
+    pub async fn upload_file(
+        &self,
+        namespace: &str,
+        data: impl Stream<Item = Result<Bytes>> + Send + Unpin,
+        name: &str,
+    ) -> Result<()> {
         let ext = Path::new(name)
             .extension()
             .unwrap_or_default()
             .to_str()
             .unwrap_or_default();
         let content_mime = mime_guess::from_ext(ext).first_or_octet_stream();
-        let content = api::Content {
-            content_type: content_mime.to_string(),
-            bytes: data.to_vec(),
-            labels: HashMap::new(),
-            features: vec![],
-        };
+        let labels = HashMap::new();
+
         let content_metadata = self
-            .write_content_bytes(namespace, content, Some(name), None, "ingestion")
+            .write_content_bytes(
+                namespace,
+                data,
+                &labels,
+                content_mime.to_string(),
+                Some(name),
+                None,
+                "ingestion",
+            )
             .await
             .map_err(|e| anyhow!("unable to write content to blob store: {}", e))?;
         let req = indexify_coordinator::CreateContentRequest {
@@ -317,7 +336,9 @@ impl DataManager {
     async fn write_content_bytes(
         &self,
         namespace: &str,
-        content: api::Content,
+        data: impl Stream<Item = Result<Bytes>> + Send + Unpin,
+        labels: &HashMap<String, String>,
+        content_type: String,
         file_name: Option<&str>,
         parent_id: Option<String>,
         source: &str,
@@ -333,13 +354,11 @@ impl DataManager {
             parent_id.hash(&mut s);
         }
         let id = format!("{:x}", s.finish());
-        let content_size = content.bytes.len() as u64;
-        let storage_url = self
-            .write_to_blob_store(namespace, &file_name, Bytes::from(content.bytes))
+        let res = self
+            .write_to_blob_store(namespace, &file_name, data)
             .await
             .map_err(|e| anyhow!("unable to write text to blob store: {}", e))?;
-        let labels = content
-            .labels
+        let labels = labels
             .clone()
             .into_iter()
             .map(|(k, v)| (k, v.to_string()))
@@ -347,14 +366,14 @@ impl DataManager {
         Ok(indexify_coordinator::ContentMetadata {
             id,
             file_name,
-            storage_url,
+            storage_url: res.url,
             parent_id: parent_id.unwrap_or_default(),
             created_at: current_ts_secs as i64,
-            mime: content.content_type,
+            mime: content_type,
             namespace: namespace.to_string(),
             labels,
             source: source.to_string(),
-            size_bytes: content_size,
+            size_bytes: res.size_bytes,
         })
     }
 
@@ -434,16 +453,20 @@ impl DataManager {
         let mut features = HashMap::new();
         for content in extracted_content.content_list {
             let content: api::Content = content.into();
+            let stream = futures::stream::once(async { Ok(Bytes::from(content.bytes)) });
+
             let content_metadata = self
                 .write_content_bytes(
                     namespace.as_str(),
-                    content.clone(),
+                    Box::pin(stream),
+                    &content.labels,
+                    content.content_type,
                     None,
                     Some(ingest_metadata.parent_content_id.to_string()),
                     &ingest_metadata.extraction_policy,
                 )
                 .await?;
-            features.insert(content_metadata.id.clone(), content.features.clone());
+            features.insert(content_metadata.id.clone(), content.features);
             new_content_metadata.push(content_metadata.clone());
         }
         for content_meta in new_content_metadata {
@@ -575,13 +598,13 @@ impl DataManager {
         Ok(extractors)
     }
 
-    #[tracing::instrument]
+    #[tracing::instrument(skip(file))]
     async fn write_to_blob_store(
         &self,
         namespace: &str,
         name: &str,
-        file: Bytes,
-    ) -> Result<String> {
-        self.blob_storage.put(name, file).await
+        file: impl Stream<Item = Result<Bytes>> + Send + Unpin,
+    ) -> Result<PutResult> {
+        self.blob_storage.put_stream(name, file).await
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -563,15 +563,11 @@ async fn upload_file(
 ) -> Result<(), IndexifyAPIError> {
     while let Some(file) = files.next_field().await.unwrap() {
         let name = file.file_name().unwrap().to_string();
-        let data = file.bytes().await.unwrap();
-        info!(
-            "writing to blob store, file name = {:?}, data = {:?}",
-            name,
-            data.len()
-        );
+        info!("writing to blob store, file name = {:?}", name);
+        let stream = file.map(|res| res.map_err(|err| anyhow::anyhow!(err)));
         state
             .data_manager
-            .upload_file(&namespace, data, &name)
+            .upload_file(&namespace, stream, &name)
             .await
             .map_err(|e| {
                 IndexifyAPIError::new(


### PR DESCRIPTION
Add put_stream trait function for writing streams to blob store.

Return number of bytes written from put() functions since in stream case total bytes are not known until all data is written.

Pass stream from upload_file().