### PR TITLE
Metadata storage refactoring

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,6 +85,7 @@ sqlx = { version = "0.7.3", features = [
     "runtime-tokio",
     "tls-rustls",
     "postgres",
+    "sqlite",
     "macros",
     "time",
     "json",

--- a/src/metadata_storage/mod.rs
+++ b/src/metadata_storage/mod.rs
@@ -11,6 +11,7 @@ use crate::server_config::{MetadataStoreConfig, MetadataStoreKind};
 pub mod postgres;
 pub mod query_engine;
 pub mod sqlite;
+mod sqlx;
 
 fn table_name(namespace: &str) -> String {
     format!("metadata_{}", namespace)

--- a/src/metadata_storage/postgres.rs
+++ b/src/metadata_storage/postgres.rs
@@ -20,7 +20,14 @@ use sqlx::{
     Row,
 };
 
-use super::{table_name, ExtractedMetadata, MetadataReader, MetadataScanStream, MetadataStorage};
+use super::{
+    sqlx::row_to_extracted_metadata,
+    table_name,
+    ExtractedMetadata,
+    MetadataReader,
+    MetadataScanStream,
+    MetadataStorage,
+};
 use crate::utils::{timestamp_secs, PostgresIndexName};
 
 pub struct PostgresIndexManager {
@@ -212,25 +219,6 @@ impl MetadataReader for PostgresIndexManager {
             });
 
         Ok(Box::pin(rows))
-    }
-}
-
-fn row_to_extracted_metadata(row: &PgRow) -> ExtractedMetadata {
-    let id: String = row.get(0);
-    let extractor: String = row.get(2);
-    let extraction_policy: String = row.get(3);
-    let content_source: String = row.get(4);
-    let data: serde_json::Value = row.get(6);
-    let content_id: String = row.get(7);
-    let parent_content_id: String = row.get(8);
-    ExtractedMetadata {
-        id,
-        content_id,
-        parent_content_id,
-        content_source,
-        metadata: data,
-        extractor_name: extractor,
-        extraction_policy,
     }
 }
 

--- a/src/metadata_storage/query_engine.rs
+++ b/src/metadata_storage/query_engine.rs
@@ -203,7 +203,7 @@ mod tests {
 
     async fn create_sqlite_metadata_store() -> Arc<SqliteIndexManager> {
         std::fs::remove_file("/tmp/foo").unwrap_or(());
-        SqliteIndexManager::new("/tmp/foo").unwrap()
+        SqliteIndexManager::new("sqlite:///tmp/foo?mode=rwc").unwrap()
     }
 
     async fn create_postgres_metadata_store() -> Arc<PostgresIndexManager> {

--- a/src/metadata_storage/sqlite.rs
+++ b/src/metadata_storage/sqlite.rs
@@ -3,41 +3,43 @@ use std::{
     sync::{atomic::AtomicBool, Arc},
 };
 
-use anyhow::anyhow;
 use async_trait::async_trait;
-use futures::{
-    stream::{self},
-    StreamExt,
-};
+use futures::StreamExt;
 use gluesql::core::{
-    data::{Value, ValueError},
+    data::{Key, Value},
     error::Error::StorageMsg as GlueStorageError,
     store::DataRow,
 };
 use itertools::Itertools;
-use rusqlite::{params, Connection};
-use serde::{Deserialize, Serialize};
-use tokio::sync::Mutex;
+use sqlx::{
+    sqlite::{SqlitePoolOptions, SqliteRow},
+    Pool,
+    Row,
+    Sqlite,
+};
 
-use super::{table_name, ExtractedMetadata, MetadataReader, MetadataScanStream, MetadataStorage};
+use super::{
+    sqlx::row_to_extracted_metadata,
+    table_name,
+    ExtractedMetadata,
+    MetadataReader,
+    MetadataScanStream,
+    MetadataStorage,
+};
 use crate::utils::{timestamp_secs, PostgresIndexName};
 
 pub struct SqliteIndexManager {
-    conn: Arc<Mutex<Connection>>,
+    pool: Pool<Sqlite>,
     default_table_created: AtomicBool,
 }
 
 impl SqliteIndexManager {
     pub fn new(conn_url: &str) -> anyhow::Result<Arc<Self>> {
-        let conn = if conn_url.starts_with("memory") {
-            Connection::open_in_memory()
-        } else {
-            Connection::open(conn_url)
-        };
-        let conn = conn.map_err(|e| anyhow!("unable to open sqlite connection: {}", e))?;
-        let conn = Arc::new(Mutex::new(conn));
+        let pool = SqlitePoolOptions::new()
+            .max_connections(5)
+            .connect_lazy(conn_url)?;
         Ok(Arc::new(Self {
-            conn,
+            pool,
             default_table_created: AtomicBool::new(false),
         }))
     }
@@ -61,8 +63,7 @@ impl MetadataStorage for SqliteIndexManager {
             created_at BIGINT
         );"
         );
-        let conn = self.conn.lock().await;
-        let _ = conn.execute(&query, params![])?;
+        let _ = sqlx::query(&query).execute(&self.pool).await?;
         Ok(())
     }
 
@@ -70,8 +71,7 @@ impl MetadataStorage for SqliteIndexManager {
     async fn drop_metadata_table(&self, namespace: &str) -> anyhow::Result<()> {
         let table_name = PostgresIndexName::new(&table_name(namespace));
         let query = format!("DROP TABLE IF EXISTS {table_name};");
-        let conn = self.conn.lock().await;
-        let _ = conn.execute(&query, params![])?;
+        let _ = sqlx::query(&query).execute(&self.pool).await?;
         Ok(())
     }
 
@@ -89,23 +89,29 @@ impl MetadataStorage for SqliteIndexManager {
             self.default_table_created
                 .store(true, std::sync::atomic::Ordering::Relaxed);
         }
-        let query = format!("INSERT INTO {index_name} (id, namespace, extractor, extractor_policy_name, content_source, index_name, data, content_id, parent_content_id, created_at) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10) ON CONFLICT (id) DO UPDATE SET data = EXCLUDED.data;");
-        let conn = self.conn.lock().await;
-        let _ = conn.execute(
-            &query,
-            params![
-                metadata.id,
-                namespace,
-                metadata.extractor_name,
-                metadata.extraction_policy,
-                metadata.content_source,
-                index_name.to_string(),
-                metadata.metadata,
-                metadata.content_id,
-                metadata.parent_content_id,
-                timestamp_secs() as i64,
-            ],
-        )?;
+        let query = format!(
+            "
+            INSERT INTO {index_name} (
+                id, namespace, extractor, extractor_policy_name,
+                content_source, index_name, data, content_id,
+                parent_content_id, created_at
+            ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+            ON CONFLICT (id) DO UPDATE SET data = EXCLUDED.data;
+        "
+        );
+        let _ = sqlx::query(&query)
+            .bind(metadata.id)
+            .bind(namespace)
+            .bind(metadata.extractor_name)
+            .bind(metadata.extraction_policy)
+            .bind(metadata.content_source)
+            .bind(index_name.to_string())
+            .bind(metadata.metadata)
+            .bind(metadata.content_id)
+            .bind(metadata.parent_content_id)
+            .bind(timestamp_secs() as i64)
+            .execute(&self.pool)
+            .await?;
         Ok(())
     }
 
@@ -115,19 +121,18 @@ impl MetadataStorage for SqliteIndexManager {
         content_id: &str,
     ) -> anyhow::Result<Vec<ExtractedMetadata>> {
         let index_table_name = PostgresIndexName::new(&table_name(namespace));
-        let conn = self.conn.lock().await;
         let query =
             format!("SELECT * FROM {index_table_name} WHERE namespace = $1 and content_id = $2");
-        let mut stmt = conn.prepare(&query)?;
-        let metadata_iter = stmt
-            .query_map(params![namespace, content_id], |row| {
-                row_to_extracted_metadata(row)
-            })
-            .map_err(|e| anyhow!("unable to query metadata from sqlite: {}", e))?;
-        let mut extracted_attributes = Vec::new();
-        for metadata in metadata_iter {
-            extracted_attributes.push(metadata?);
-        }
+
+        let extracted_attributes = sqlx::query(&query)
+            .bind(namespace)
+            .bind(content_id)
+            .fetch_all(&self.pool)
+            .await?
+            .iter()
+            .map(row_to_extracted_metadata)
+            .collect();
+
         Ok(extracted_attributes)
     }
 
@@ -139,8 +144,12 @@ impl MetadataStorage for SqliteIndexManager {
         let index_table_name = PostgresIndexName::new(&table_name(namespace));
         let query =
             format!("DELETE FROM {index_table_name} WHERE namespace = $1 and content_id = $2");
-        let conn = self.conn.lock().await;
-        let _ = conn.execute(&query, params![namespace, content_id])?;
+
+        sqlx::query(&query)
+            .bind(namespace)
+            .bind(content_id)
+            .execute(&self.pool)
+            .await?;
 
         Ok(())
     }
@@ -154,17 +163,17 @@ impl MetadataReader for SqliteIndexManager {
         id: &str,
     ) -> anyhow::Result<Option<ExtractedMetadata>> {
         let table_name = PostgresIndexName::new(&table_name(namespace));
-        let query = format!("SELECT * FROM {table_name} WHERE namespace = $1 and id = $2");
-        let conn = self.conn.lock().await;
-        let mut stmt = conn.prepare(&query)?;
-        let mut metadata = stmt
-            .query_map(params![namespace, id], row_to_extracted_metadata)
-            .map_err(|e| anyhow!("unable to query metadata from sqlite: {}", e))?;
-        if let Some(metadata) = metadata.next() {
-            let metadata = metadata.map_err(|e| anyhow!(e.to_string()))?;
-            return Ok(Some(metadata));
-        }
-        Ok(None)
+        let query = format!("SELECT * FROM {table_name} WHERE namespace = $2 and id = $3");
+        let metadata = sqlx::query(&query)
+            .bind(namespace)
+            .bind(id)
+            .bind(table_name.to_string())
+            .fetch_all(&self.pool)
+            .await?
+            .first()
+            .map(row_to_extracted_metadata);
+
+        Ok(metadata)
     }
 
     fn get_metadata_scan_query(&self, namespace: &str) -> String {
@@ -186,95 +195,50 @@ impl MetadataReader for SqliteIndexManager {
         namespace: &str,
         content_source: &str,
     ) -> MetadataScanStream<'a> {
-        let conn = self.conn.lock().await;
-        let mut stmt = conn
-            .prepare(query)
-            .map_err(|e| GlueStorageError(format!("unable to execute query on sqlite: {}", e)))?;
-        let metadata = stmt
-            .query_map(params![namespace, content_source], |row| {
-                row_to_structured_data(row)
-            })
-            .map_err(|e| {
-                GlueStorageError(format!("unable to query metadata from sqlite: {}", e))
-            })?;
-        let mut metadata_list = vec![];
-        for m in metadata {
-            let m = m.map_err(|e| GlueStorageError(e.to_string()))?;
-            let mut out_rows: Vec<gluesql::core::data::Value> = Vec::new();
-            out_rows.push(gluesql::core::data::Value::Str(m.content_id.clone()));
-            let meta = match m.metadata.clone() {
-                serde_json::Value::Object(json_map) => json_map
-                    .into_iter()
-                    .map(|(key, value)| value.try_into().map(|value| (key, value)))
-                    .collect::<gluesql::core::error::Result<BTreeMap<String, Value>>>(),
-                _ => Err(ValueError::JsonObjectTypeRequired.into()),
-            };
-            let meta = meta
-                .map_err(|e| gluesql::core::error::Error::StorageMsg(e.to_string()))
-                .unwrap();
-            out_rows.extend(meta.values().cloned().collect_vec());
+        let rows = sqlx::query(query)
+            .bind(namespace.to_string())
+            .bind(content_source.to_string())
+            .fetch(&self.pool)
+            .then(|row: Result<SqliteRow, sqlx::Error>| async move {
+                let row = row.map_err(|e| {
+                    GlueStorageError(format!("error scanning metadata from sqlite: {}", e))
+                })?;
+                let content_id: String = row.get(0);
+                let mut out_rows: Vec<Value> = Vec::new();
+                out_rows.push(Value::Str(content_id.clone()));
 
-            let key = gluesql::core::data::Key::Str(m.content_id.clone());
-            metadata_list.push(std::result::Result::Ok((key, DataRow::Vec(out_rows))));
-        }
-        let metadata_stream = stream::iter(metadata_list).boxed();
-        std::result::Result::Ok(metadata_stream)
+                let data: serde_json::Value = row.get(1);
+                let data = match data {
+                    serde_json::Value::Object(json_map) => json_map
+                        .into_iter()
+                        .map(|(key, value)| {
+                            let value = Value::try_from(value)?;
+
+                            Ok((key, value))
+                        })
+                        .collect::<Result<BTreeMap<String, Value>, gluesql::prelude::Error>>()
+                        .map_err(|e| {
+                            GlueStorageError(format!("invalid metadata from sqlite: {}", e))
+                        })?,
+                    _ => return Err(GlueStorageError("expected JSON object".to_string())),
+                };
+                out_rows.extend(data.values().cloned().collect_vec());
+
+                Ok((Key::Str(content_id), DataRow::Vec(out_rows)))
+            });
+
+        Ok(Box::pin(rows))
     }
-}
-
-fn row_to_extracted_metadata(
-    row: &rusqlite::Row,
-) -> std::result::Result<ExtractedMetadata, rusqlite::Error> {
-    let id: String = row.get(0)?;
-    let extractor_name: String = row.get(2)?;
-    let extraction_policy: String = row.get(3)?;
-    let content_source: String = row.get(4)?;
-    let data: serde_json::Value = row.get(6)?;
-    let content_id: String = row.get(7)?;
-    let parent_content_id: String = row.get(8)?;
-    std::result::Result::Ok(ExtractedMetadata {
-        id,
-        extractor_name,
-        extraction_policy,
-        content_source,
-        metadata: data,
-        content_id,
-        parent_content_id,
-    })
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-struct MetadataJson {
-    content_id: String,
-    metadata: serde_json::Value,
-}
-
-fn row_to_structured_data(
-    row: &rusqlite::Row,
-) -> std::result::Result<MetadataJson, rusqlite::Error> {
-    let content_id: String = row.get(0)?;
-    let data: serde_json::Value = row.get(1)?;
-    std::result::Result::Ok(MetadataJson {
-        content_id,
-        metadata: data,
-    })
 }
 
 #[cfg(test)]
 mod tests {
-    use rusqlite::params;
-
     use super::*;
     use crate::{metadata_storage::test_metadata_storage, utils::PostgresIndexName};
 
     #[tokio::test]
     async fn test_create_index() {
-        let conn = Connection::open_in_memory().unwrap();
-        let conn = Arc::new(Mutex::new(conn));
-        let index_manager = SqliteIndexManager {
-            conn,
-            default_table_created: AtomicBool::new(false),
-        };
+        let index_manager = SqliteIndexManager::new("sqlite::memory:").unwrap();
         let namespace = "test_namespace";
         index_manager
             .create_metadata_table(namespace)
@@ -283,22 +247,17 @@ mod tests {
         let table_name = PostgresIndexName::new(&table_name(namespace));
         let query =
             format!("SELECT name FROM sqlite_master WHERE type='table' AND name='{table_name}';");
-        let conn = index_manager.conn.lock().await;
-        let mut stmt = conn.prepare(&query).unwrap();
-        let table_name_out: String = stmt.query_row(params![], |row| row.get(0)).unwrap();
+        let table_name_out: String = sqlx::query(&query)
+            .fetch_one(&index_manager.pool)
+            .await
+            .unwrap()
+            .get(0);
         assert_eq!(table_name_out, "metadata_test_namespace".to_string());
     }
 
     #[tokio::test]
     async fn test_sqlite_metadata_storage() {
-        let conn = Connection::open_in_memory().unwrap();
-        let conn = Arc::new(Mutex::new(conn));
-        let index_manager = SqliteIndexManager {
-            conn,
-            default_table_created: AtomicBool::new(false),
-        };
-        let index_manager = Arc::new(index_manager);
-
+        let index_manager = SqliteIndexManager::new("sqlite::memory:").unwrap();
         test_metadata_storage(index_manager).await;
     }
 }

--- a/src/metadata_storage/sqlx.rs
+++ b/src/metadata_storage/sqlx.rs
@@ -1,8 +1,15 @@
-use sqlx::Row;
+use std::collections::BTreeMap;
+
+use gluesql::core::{
+    data::{Key, Value},
+    error::{Error::StorageMsg as GlueStorageError, Result as GlueResult},
+    store::DataRow,
+};
+use itertools::Itertools;
 
 use super::ExtractedMetadata;
 
-pub fn row_to_extracted_metadata<'a, T: Row>(row: &'a T) -> ExtractedMetadata
+pub fn row_to_extracted_metadata<'a, T: sqlx::Row>(row: &'a T) -> ExtractedMetadata
 where
     usize: sqlx::ColumnIndex<T>,
     String: sqlx::Decode<'a, T::Database> + sqlx::Type<T::Database>,
@@ -24,4 +31,32 @@ where
         extractor_name: extractor,
         extraction_policy,
     }
+}
+
+pub fn row_to_metadata_scan_item<'a, T: sqlx::Row>(row: &'a T) -> GlueResult<(Key, DataRow)>
+where
+    usize: sqlx::ColumnIndex<T>,
+    String: sqlx::Decode<'a, T::Database> + sqlx::Type<T::Database>,
+    sqlx::types::Json<serde_json::Value>: sqlx::Decode<'a, T::Database> + sqlx::Type<T::Database>,
+{
+    let content_id: String = row.get(0);
+    let mut out_rows: Vec<Value> = Vec::new();
+    out_rows.push(Value::Str(content_id.clone()));
+
+    let data: serde_json::Value = row.get(1);
+    let data = match data {
+        serde_json::Value::Object(json_map) => json_map
+            .into_iter()
+            .map(|(key, value)| {
+                let value = Value::try_from(value)?;
+
+                Ok((key, value))
+            })
+            .collect::<GlueResult<BTreeMap<String, Value>>>()
+            .map_err(|e| GlueStorageError(format!("invalid metadata: {}", e)))?,
+        _ => return Err(GlueStorageError("expected JSON object".to_string())),
+    };
+    out_rows.extend(data.values().cloned().collect_vec());
+
+    Ok((Key::Str(content_id), DataRow::Vec(out_rows)))
 }

--- a/src/metadata_storage/sqlx.rs
+++ b/src/metadata_storage/sqlx.rs
@@ -1,0 +1,27 @@
+use sqlx::Row;
+
+use super::ExtractedMetadata;
+
+pub fn row_to_extracted_metadata<'a, T: Row>(row: &'a T) -> ExtractedMetadata
+where
+    usize: sqlx::ColumnIndex<T>,
+    String: sqlx::Decode<'a, T::Database> + sqlx::Type<T::Database>,
+    sqlx::types::Json<serde_json::Value>: sqlx::Decode<'a, T::Database> + sqlx::Type<T::Database>,
+{
+    let id: String = row.get(0);
+    let extractor: String = row.get(2);
+    let extraction_policy: String = row.get(3);
+    let content_source: String = row.get(4);
+    let data: serde_json::Value = row.get(6);
+    let content_id: String = row.get(7);
+    let parent_content_id: String = row.get(8);
+    ExtractedMetadata {
+        id,
+        content_id,
+        parent_content_id,
+        content_source,
+        metadata: data,
+        extractor_name: extractor,
+        extraction_policy,
+    }
+}


### PR DESCRIPTION
depends on https://github.com/tensorlakeai/indexify/pull/461, https://github.com/tensorlakeai/indexify/pull/469

1. Change sqlite metadata storage impl from rusqlite to sqlx, aligning with postgres impl

2. Refactor metadata storage implementations
Add row_to_metadata_scan_item function to metadata_storage/sqlx module.
Make both postgres, sqlite impl codes to use sqlx::row_to_metadata_scan_item in scan_metadata impl.

I added metadata_storage::sqlx module rather than putting shared functions to query_engine because the functions in metadata_storage::sqlx are only used by storages that depends on sqlx (though all current query engine implementation depends on sqlx).