### PR TITLE
Add schama SQL DDL to list schema API response,

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -563,14 +563,8 @@ pub struct ListStateChangesResponse {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct GetStructuredDataSchemasResponse {
-    pub schemas: Vec<StructuredDataSchema>,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-pub struct StructuredDataSchema {
-    pub columns: serde_json::Value,
-    pub content_source: String,
-    pub namespace: String,
+    pub schemas: Vec<internal_api::StructuredDataSchema>,
+    pub ddls: Vec<String>,
 }
 
 #[derive(Serialize, Deserialize)]


### PR DESCRIPTION
Add list of DDLs to GetStructuredDataSchemasResponse.
Add to_ddl method to StructuredDataSchema in indexify_interal_api.
Update both query_engine and server modules to use StructuredDataSchema::to_ddl.


btw.
is `SchemaColumnType::Null` required to have it? Null can be the value but it cannot be the column data type in gluesql so.
