### PR TITLE
Add column comment support to metadata schema

### DIFF
--- a/crates/indexify_internal_api/src/lib.rs
+++ b/crates/indexify_internal_api/src/lib.rs
@@ -715,6 +715,7 @@ pub struct ExtractedEmbeddings {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct SchemaColumn {
+    #[serde(rename = "type")]
     column_type: SchemaColumnType,
     comment: Option<String>,
 }

--- a/src/metadata_storage/query_engine.rs
+++ b/src/metadata_storage/query_engine.rs
@@ -197,7 +197,7 @@ mod tests {
             namespace: ns.to_string(),
             columns: columns
                 .into_iter()
-                .map(|(name, dtype)| (name.to_string(), dtype))
+                .map(|(name, dtype)| (name.to_string(), dtype.into()))
                 .collect(),
             content_source: cs.to_string(),
             id: nanoid!(16),
@@ -208,13 +208,13 @@ mod tests {
         index_manager: Arc<T>,
     ) {
         let cols1 = vec![
-            ("id", SchemaColumnType::Text),
-            ("name", SchemaColumnType::Text),
+            ("id", SchemaColumnType::Text.into()),
+            ("name", SchemaColumnType::Text.into()),
         ];
         let schema = create_schema("test", cols1, "User");
         let cols2 = vec![
-            ("id", SchemaColumnType::Text),
-            ("foo", SchemaColumnType::Text),
+            ("id", SchemaColumnType::Text.into()),
+            ("foo", SchemaColumnType::Text.into()),
         ];
         let schema2 = create_schema("test", cols2, "User2");
         let query_engine = QueryEngine::new(index_manager, vec![schema, schema2], "test");


### PR DESCRIPTION
ref. https://github.com/tensorlakeai/indexify-extractors/pull/126

I've modified the `OutputSchema` in `indexify_internal_api` to support not only column types but also column comments in the metadata. This utilizes the comments optionally provided by the extractor, which are then used as column comments when generating SQL DDLs. For example:

```sql
CREATE TABLE IF NOT EXISTS "ingestion" (
  "content_id" TEXT NULL,
  "bounding_box" LIST NULL COMMENT 'Bounding box coordinates in the format [x1, y1, x2, y2]',
  "object_name" TEXT NULL
);
```