### PR TITLE
Integrate Cortex Click chatbot and blog posts

### DIFF
--- a/docs/docs/answers/Accelerating_data_retrieval_in_financial_reports_with_Haystack_integration.md
+++ b/docs/docs/answers/Accelerating_data_retrieval_in_financial_reports_with_Haystack_integration.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/G8yZAUE" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Accelerating_financial_analysis_by_extracting_data_from_financial_reports.md
+++ b/docs/docs/answers/Accelerating_financial_analysis_by_extracting_data_from_financial_reports.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/BQgnG5X" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Accelerating_news_aggregation_with_metadata_enriched_search_results.md
+++ b/docs/docs/answers/Accelerating_news_aggregation_with_metadata_enriched_search_results.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/7FaHMDx" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Accelerating_news_aggregation_with_metadataenriched_search_results.md
+++ b/docs/docs/answers/Accelerating_news_aggregation_with_metadataenriched_search_results.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/7FaHMDx" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Adding_documents_to_Indexify_for_embedding_extraction.md
+++ b/docs/docs/answers/Adding_documents_to_Indexify_for_embedding_extraction.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/wTQ7QQG" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Advanced_Indexify_Configuration_Understanding_Vector_Index_Storage_Options.md
+++ b/docs/docs/answers/Advanced_Indexify_Configuration_Understanding_Vector_Index_Storage_Options.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/npw0Dnf" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Advancing_healthcare_research_with_indexed_medical_journals.md
+++ b/docs/docs/answers/Advancing_healthcare_research_with_indexed_medical_journals.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/6fGdnQd" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Analyzing_Indexify_executor_coordinator_and_server_metrics_with_Grafana_dashboards.md
+++ b/docs/docs/answers/Analyzing_Indexify_executor_coordinator_and_server_metrics_with_Grafana_dashboards.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/8Pjreid" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Analyzing_call_center_interactions_for_insights_using_speaker_diarization.md
+++ b/docs/docs/answers/Analyzing_call_center_interactions_for_insights_using_speaker_diarization.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/T6Ypqg7" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Augmenting_legal_document_analysis_using_Indexify_for_precise_information_retrieval.md
+++ b/docs/docs/answers/Augmenting_legal_document_analysis_using_Indexify_for_precise_information_retrieval.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/gAu9Xnf" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Augmenting_reality_in_mobile_applications_with_object_detection_and_classification.md
+++ b/docs/docs/answers/Augmenting_reality_in_mobile_applications_with_object_detection_and_classification.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/4wCAGYl" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Automate_ingestion_and_indexing_of_user_generated_content_across_platforms.md
+++ b/docs/docs/answers/Automate_ingestion_and_indexing_of_user_generated_content_across_platforms.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/P2krYv9" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Automate_ingestion_and_indexing_of_usergenerated_content_across_platforms.md
+++ b/docs/docs/answers/Automate_ingestion_and_indexing_of_usergenerated_content_across_platforms.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/P2krYv9" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Automated_extraction_of_scientific_journal_content_for_research_databases.md
+++ b/docs/docs/answers/Automated_extraction_of_scientific_journal_content_for_research_databases.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/itM4juD" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Automatically_classifying_and_indexing_content_by_source_with_Indexify.md
+++ b/docs/docs/answers/Automatically_classifying_and_indexing_content_by_source_with_Indexify.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/GxOxrd6" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Automating_Indexify_infrastructure_updates_and_scaling_using_Terraform.md
+++ b/docs/docs/answers/Automating_Indexify_infrastructure_updates_and_scaling_using_Terraform.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/SgjzgFR" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Automating_celebrity_recognition_in_media_archives_with_face_extraction_technology.md
+++ b/docs/docs/answers/Automating_celebrity_recognition_in_media_archives_with_face_extraction_technology.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/9Us5iOF" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Automating_content_analysis_and_summarization_in_TypeScript_projects.md
+++ b/docs/docs/answers/Automating_content_analysis_and_summarization_in_TypeScript_projects.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/jECTMvc" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Automating_content_based_quiz_creation_for_e_learning_platforms.md
+++ b/docs/docs/answers/Automating_content_based_quiz_creation_for_e_learning_platforms.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/zYMcNmR" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Automating_content_classification_and_tagging_in_content_management_systems.md
+++ b/docs/docs/answers/Automating_content_classification_and_tagging_in_content_management_systems.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/W4l2uVx" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Automating_content_curation_for_newsletters_from_Wikipedia_entries.md
+++ b/docs/docs/answers/Automating_content_curation_for_newsletters_from_Wikipedia_entries.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/tgJM4CW" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Automating_content_tagging_in_media_libraries_using_object_detection_models.md
+++ b/docs/docs/answers/Automating_content_tagging_in_media_libraries_using_object_detection_models.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/x5tCdVr" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Automating_contentbased_quiz_creation_for_elearning_platforms.md
+++ b/docs/docs/answers/Automating_contentbased_quiz_creation_for_elearning_platforms.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/zYMcNmR" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Automating_customer_support_with_real_time_document_extraction_and_indexing.md
+++ b/docs/docs/answers/Automating_customer_support_with_real_time_document_extraction_and_indexing.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/wFUHpWU" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Automating_customer_support_with_realtime_document_extraction_and_indexing.md
+++ b/docs/docs/answers/Automating_customer_support_with_realtime_document_extraction_and_indexing.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/wFUHpWU" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Automating_data_extraction_from_scanned_PDF_invoices_for_accounting_software_integration.md
+++ b/docs/docs/answers/Automating_data_extraction_from_scanned_PDF_invoices_for_accounting_software_integration.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/ndFnv2J" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Automating_document_digitization_with_PDF_to_textimage_extraction.md
+++ b/docs/docs/answers/Automating_document_digitization_with_PDF_to_textimage_extraction.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/GAm9ToE" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Automating_embedding_extraction_with_Indexifys_Extractor_SDK.md
+++ b/docs/docs/answers/Automating_embedding_extraction_with_Indexifys_Extractor_SDK.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/LYpTvi8" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Automating_extraction_of_historical_data_from_Wikipedia_for_academic_research.md
+++ b/docs/docs/answers/Automating_extraction_of_historical_data_from_Wikipedia_for_academic_research.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/sPII9Of" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Automating_extraction_of_key_points_from_corporate_presentation_videos.md
+++ b/docs/docs/answers/Automating_extraction_of_key_points_from_corporate_presentation_videos.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/zAJXhX3" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Automating_extraction_of_key_topics_from_corporate_call_recordings.md
+++ b/docs/docs/answers/Automating_extraction_of_key_topics_from_corporate_call_recordings.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/i0BI3eV" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Automating_file_uploads_for_indexing_using_Indexifys_Python_and_TypeScript_libraries.md
+++ b/docs/docs/answers/Automating_file_uploads_for_indexing_using_Indexifys_Python_and_TypeScript_libraries.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/cX4WMeE" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Automating_historical_sports_data_retrieval_and_indexing_for_research.md
+++ b/docs/docs/answers/Automating_historical_sports_data_retrieval_and_indexing_for_research.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/OmUhdCT" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Automating_information_extraction_from_PDFs_for_academic_research.md
+++ b/docs/docs/answers/Automating_information_extraction_from_PDFs_for_academic_research.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/aPJYkkF" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Automating_inventory_management_through_image_based_product_categorization.md
+++ b/docs/docs/answers/Automating_inventory_management_through_image_based_product_categorization.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/fspuaih" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Automating_inventory_management_through_imagebased_product_categorization.md
+++ b/docs/docs/answers/Automating_inventory_management_through_imagebased_product_categorization.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/fspuaih" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Automating_legal_document_analysis_with_custom_retrieval_models.md
+++ b/docs/docs/answers/Automating_legal_document_analysis_with_custom_retrieval_models.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/2UYSH65" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Automating_metadata_extraction_for_digital_archives_enhancing_retrievability.md
+++ b/docs/docs/answers/Automating_metadata_extraction_for_digital_archives_enhancing_retrievability.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/vGDOot4" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Automating_news_aggregation_and_analysis_by_indexing_articles_with_Indexify_for_LangChain_querying.md
+++ b/docs/docs/answers/Automating_news_aggregation_and_analysis_by_indexing_articles_with_Indexify_for_LangChain_querying.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/kQjZVAm" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Automating_news_clipping_services_with_voice_activity_detection_in_audio_streams.md
+++ b/docs/docs/answers/Automating_news_clipping_services_with_voice_activity_detection_in_audio_streams.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/qz5gsom" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Automating_resume_screening_with_a_custom_CV_extractor_for_HR_platforms.md
+++ b/docs/docs/answers/Automating_resume_screening_with_a_custom_CV_extractor_for_HR_platforms.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/JoBOV8H" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Automating_skills_extraction_from_resumes_for_HR_recruitment_processes.md
+++ b/docs/docs/answers/Automating_skills_extraction_from_resumes_for_HR_recruitment_processes.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/SUmlyU6" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Automating_subtitle_generation_for_video_content_with_Indexify_extractors.md
+++ b/docs/docs/answers/Automating_subtitle_generation_for_video_content_with_Indexify_extractors.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/13FO93E" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Automating_the_digitization_of_printed_books_into_accessible_e_books.md
+++ b/docs/docs/answers/Automating_the_digitization_of_printed_books_into_accessible_e_books.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/9iAMvlX" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Automating_the_digitization_of_printed_books_into_accessible_ebooks.md
+++ b/docs/docs/answers/Automating_the_digitization_of_printed_books_into_accessible_ebooks.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/9iAMvlX" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Automating_the_extraction_of_financial_tables_from_PDF_reports_for_market_analysis.md
+++ b/docs/docs/answers/Automating_the_extraction_of_financial_tables_from_PDF_reports_for_market_analysis.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/bUZ4Z5s" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Automating_transcription_and_indexing_of_corporate_meeting_records_with_Whisper_ASR.md
+++ b/docs/docs/answers/Automating_transcription_and_indexing_of_corporate_meeting_records_with_Whisper_ASR.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/Bf3uUt1" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Batch_uploading_documents_for_legal_case_analysis_and_indexing.md
+++ b/docs/docs/answers/Batch_uploading_documents_for_legal_case_analysis_and_indexing.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/TPyVbh2" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Boosting_SEO_strategies_by_extracting_and_indexing_important_keywords_from_webpages.md
+++ b/docs/docs/answers/Boosting_SEO_strategies_by_extracting_and_indexing_important_keywords_from_webpages.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/eE8o8QJ" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Boosting_content_moderation_efficiency_in_social_media_platforms.md
+++ b/docs/docs/answers/Boosting_content_moderation_efficiency_in_social_media_platforms.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/20wkIL9" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Boosting_e_commerce_with_image_based_product_searches_using_embedding_extraction.md
+++ b/docs/docs/answers/Boosting_e_commerce_with_image_based_product_searches_using_embedding_extraction.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/R0pOU11" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Boosting_ecommerce_with_imagebased_product_searches_using_embedding_extraction.md
+++ b/docs/docs/answers/Boosting_ecommerce_with_imagebased_product_searches_using_embedding_extraction.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/R0pOU11" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Boosting_efficiency_in_legal_document_analysis_with_precise_retrieval.md
+++ b/docs/docs/answers/Boosting_efficiency_in_legal_document_analysis_with_precise_retrieval.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/QKmtT5z" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Building_RAG_systems_with_Indexifys_semantic_search_for_improved_QA.md
+++ b/docs/docs/answers/Building_RAG_systems_with_Indexifys_semantic_search_for_improved_QA.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/MTTCDOb" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Building_a_content_library_for_media_monitoring_services.md
+++ b/docs/docs/answers/Building_a_content_library_for_media_monitoring_services.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/H1ODmyi" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Building_a_content_moderation_system_that_automatically_flags_unwanted_scenes_in_uploaded_videos.md
+++ b/docs/docs/answers/Building_a_content_moderation_system_that_automatically_flags_unwanted_scenes_in_uploaded_videos.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/AfbD50Y" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Building_a_context_aware_chatbot_with_TypeScript_and_Indexify.md
+++ b/docs/docs/answers/Building_a_context_aware_chatbot_with_TypeScript_and_Indexify.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/3Q44hZh" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Building_a_context_aware_recommendation_system_for_digital_libraries_using_Indexify.md
+++ b/docs/docs/answers/Building_a_context_aware_recommendation_system_for_digital_libraries_using_Indexify.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/CfTcX8u" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Building_a_contextaware_chatbot_with_TypeScript_and_Indexify.md
+++ b/docs/docs/answers/Building_a_contextaware_chatbot_with_TypeScript_and_Indexify.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/3Q44hZh" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Building_a_contextaware_recommendation_system_for_digital_libraries_using_Indexify.md
+++ b/docs/docs/answers/Building_a_contextaware_recommendation_system_for_digital_libraries_using_Indexify.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/CfTcX8u" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Building_a_control_plane_for_data_tracking_with_Indexifys_feature_extraction_lineage.md
+++ b/docs/docs/answers/Building_a_control_plane_for_data_tracking_with_Indexifys_feature_extraction_lineage.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/IvndxAm" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Building_a_custom_search_engine_for_Wikipedia_content.md
+++ b/docs/docs/answers/Building_a_custom_search_engine_for_Wikipedia_content.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/zqpDRiT" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Building_a_knowledge_base_from_PDF_user_manuals_for_tech_support_automation.md
+++ b/docs/docs/answers/Building_a_knowledge_base_from_PDF_user_manuals_for_tech_support_automation.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/33lxgXk" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Building_a_multimedia_library_with_easy_retrieval_of_video_content_based_on_extracted_audio.md
+++ b/docs/docs/answers/Building_a_multimedia_library_with_easy_retrieval_of_video_content_based_on_extracted_audio.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/6VPefty" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Building_a_searchable_digital_asset_library_from_diverse_multimedia_content.md
+++ b/docs/docs/answers/Building_a_searchable_digital_asset_library_from_diverse_multimedia_content.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/C1Su1xA" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Building_a_semantic_search_engine_for_scientific_publications.md
+++ b/docs/docs/answers/Building_a_semantic_search_engine_for_scientific_publications.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/KTD0JQs" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Building_a_video_extractor_for_analyzing_and_tagging_film_and_TV_content.md
+++ b/docs/docs/answers/Building_a_video_extractor_for_analyzing_and_tagging_film_and_TV_content.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/WO9D2Pp" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Building_advanced_customer_support_FAQs_using_Haystacks_natural_language_processing.md
+++ b/docs/docs/answers/Building_advanced_customer_support_FAQs_using_Haystacks_natural_language_processing.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/m4zAhjm" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Building_advanced_duplicate_detection_systems_with_Hash_embedding.md
+++ b/docs/docs/answers/Building_advanced_duplicate_detection_systems_with_Hash_embedding.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/7eA7uLR" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Building_an_interactive_QA_feature_for_educational_audio_materials.md
+++ b/docs/docs/answers/Building_an_interactive_QA_feature_for_educational_audio_materials.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/QpfJY4g" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Building_and_deploying_custom_Indexify_Docker_containers_for_scalability.md
+++ b/docs/docs/answers/Building_and_deploying_custom_Indexify_Docker_containers_for_scalability.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/VbET4U6" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Building_corporate_knowledge_hubs_with_DSPy_and_Indexify.md
+++ b/docs/docs/answers/Building_corporate_knowledge_hubs_with_DSPy_and_Indexify.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/XUEASER" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Building_custom_document_retrieval_models_with_Indexify_and_DSPy.md
+++ b/docs/docs/answers/Building_custom_document_retrieval_models_with_Indexify_and_DSPy.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/bQo1K3Q" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Building_dynamic_content_removal_systems_for_real_time_data_management.md
+++ b/docs/docs/answers/Building_dynamic_content_removal_systems_for_real_time_data_management.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/PtCtReg" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Building_dynamic_content_removal_systems_for_realtime_data_management.md
+++ b/docs/docs/answers/Building_dynamic_content_removal_systems_for_realtime_data_management.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/PtCtReg" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Building_extractor_for_real_time_financial_report_insights.md
+++ b/docs/docs/answers/Building_extractor_for_real_time_financial_report_insights.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/GJjTLro" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Building_extractor_for_realtime_financial_report_insights.md
+++ b/docs/docs/answers/Building_extractor_for_realtime_financial_report_insights.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/GJjTLro" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Building_image_metadata_extractors_for_digital_asset_management_systems.md
+++ b/docs/docs/answers/Building_image_metadata_extractors_for_digital_asset_management_systems.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/A3xvrra" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Building_multi_layered_content_analysis_systems_with_chained_extraction_policies.md
+++ b/docs/docs/answers/Building_multi_layered_content_analysis_systems_with_chained_extraction_policies.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/sJ9cp8I" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Building_multilayered_content_analysis_systems_with_chained_extraction_policies.md
+++ b/docs/docs/answers/Building_multilayered_content_analysis_systems_with_chained_extraction_policies.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/sJ9cp8I" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Building_personalized_learning_assistants_with_Indexify_extraction_policies.md
+++ b/docs/docs/answers/Building_personalized_learning_assistants_with_Indexify_extraction_policies.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/XWeUu9L" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Building_powerful_content_management_systems_utilizing_Indexifys_indexing_and_retrieval_APIs.md
+++ b/docs/docs/answers/Building_powerful_content_management_systems_utilizing_Indexifys_indexing_and_retrieval_APIs.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/2A1XBG9" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Building_video_based_QA_bots_for_educational_platforms.md
+++ b/docs/docs/answers/Building_video_based_QA_bots_for_educational_platforms.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/I8EAjez" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Building_videobased_QA_bots_for_educational_platforms.md
+++ b/docs/docs/answers/Building_videobased_QA_bots_for_educational_platforms.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/I8EAjez" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Building_visual_search_engines_for_online_fashion_retailers.md
+++ b/docs/docs/answers/Building_visual_search_engines_for_online_fashion_retailers.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/0FUKtdn" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Cataloging_digital_assets_for_museums_with_custom_extraction_policies.md
+++ b/docs/docs/answers/Cataloging_digital_assets_for_museums_with_custom_extraction_policies.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/khAABTD" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Choosing_the_Right_Backend_for_Indexifys_Blob_Storage_Needs.md
+++ b/docs/docs/answers/Choosing_the_Right_Backend_for_Indexifys_Blob_Storage_Needs.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/PyuTUkG" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Compiling_biographical_data_from_Wikipedia_for_a_digital_encyclopedia.md
+++ b/docs/docs/answers/Compiling_biographical_data_from_Wikipedia_for_a_digital_encyclopedia.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/DNh8KEA" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Compiling_government_paperwork_into_a_navigable_digital_repository.md
+++ b/docs/docs/answers/Compiling_government_paperwork_into_a_navigable_digital_repository.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/F164iiJ" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Configuring_Blob_Storage_for_Indexify_with_S3_or_Disk_Backends.md
+++ b/docs/docs/answers/Configuring_Blob_Storage_for_Indexify_with_S3_or_Disk_Backends.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/cI9s3bX" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Configuring_Indexify_for_real_time_content_indexing_and_retrieval.md
+++ b/docs/docs/answers/Configuring_Indexify_for_real_time_content_indexing_and_retrieval.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/CP6iqnI" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Configuring_Indexify_for_realtime_content_indexing_and_retrieval.md
+++ b/docs/docs/answers/Configuring_Indexify_for_realtime_content_indexing_and_retrieval.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/CP6iqnI" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Configuring_Indexify_in_Visual_Studio_Code_with_DevContainers.md
+++ b/docs/docs/answers/Configuring_Indexify_in_Visual_Studio_Code_with_DevContainers.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/EBTit6c" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Configuring_Prometheus_to_collect_Indexify_service_metrics_for_performance_tuning.md
+++ b/docs/docs/answers/Configuring_Prometheus_to_collect_Indexify_service_metrics_for_performance_tuning.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/NZzuSk5" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Converting_educational_resources_into_accessible_indexed_learning_materials.md
+++ b/docs/docs/answers/Converting_educational_resources_into_accessible_indexed_learning_materials.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/dJsf86o" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Crafting_custom_research_assistants_using_Indexifys_retriever_chains.md
+++ b/docs/docs/answers/Crafting_custom_research_assistants_using_Indexifys_retriever_chains.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/WBd64U8" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Creating_AI_powered_QA_bots_for_sports_trivia.md
+++ b/docs/docs/answers/Creating_AI_powered_QA_bots_for_sports_trivia.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/vRAnKfS" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Creating_AIpowered_QA_bots_for_sports_trivia.md
+++ b/docs/docs/answers/Creating_AIpowered_QA_bots_for_sports_trivia.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/vRAnKfS" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Creating_QA_bots_with_Indexify_RAG_for_sports_personalities.md
+++ b/docs/docs/answers/Creating_QA_bots_with_Indexify_RAG_for_sports_personalities.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/V53m5c5" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Creating_a_QA_system_for_technical_documents_using_LayoutLM_Document_QA.md
+++ b/docs/docs/answers/Creating_a_QA_system_for_technical_documents_using_LayoutLM_Document_QA.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/C6CscqQ" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Creating_a_content_recommendation_engine_with_multimedia_extractors.md
+++ b/docs/docs/answers/Creating_a_content_recommendation_engine_with_multimedia_extractors.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/yHlfhdJ" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Creating_a_dataset_for_natural_language_processing_from_Wikipedia_articles.md
+++ b/docs/docs/answers/Creating_a_dataset_for_natural_language_processing_from_Wikipedia_articles.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/OI8dCsy" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Creating_a_development_database_for_testing_Indexifys_SQL_query_features.md
+++ b/docs/docs/answers/Creating_a_development_database_for_testing_Indexifys_SQL_query_features.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/cL2BMrZ" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Creating_a_digital_asset_management_system_with_key_frame_extraction_for_easy_browsing.md
+++ b/docs/docs/answers/Creating_a_digital_asset_management_system_with_key_frame_extraction_for_easy_browsing.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/4wgSOzx" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Creating_a_dynamic_FAQ_system_using_Indexify_to_index_and_retrieve_company_policies.md
+++ b/docs/docs/answers/Creating_a_dynamic_FAQ_system_using_Indexify_to_index_and_retrieve_company_policies.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/2aonrFe" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Creating_a_seamless_content_retrieval_system_with_Indexifys_indexing_APIs.md
+++ b/docs/docs/answers/Creating_a_seamless_content_retrieval_system_with_Indexifys_indexing_APIs.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/Kgm12Qp" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Creating_a_searchable_archive_of_academic_papers_and_extracting_references_automatically.md
+++ b/docs/docs/answers/Creating_a_searchable_archive_of_academic_papers_and_extracting_references_automatically.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/mS6b5F3" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Creating_a_semantic_search_index_with_Indexify_and_MiniLML6.md
+++ b/docs/docs/answers/Creating_a_semantic_search_index_with_Indexify_and_MiniLML6.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/rRD4DxI" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Creating_a_timeline_of_events_by_extracting_specific_information_from_Wikipedia_articles.md
+++ b/docs/docs/answers/Creating_a_timeline_of_events_by_extracting_specific_information_from_Wikipedia_articles.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/DM1JuMJ" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Creating_advanced_search_engines_for_digital_library_archives.md
+++ b/docs/docs/answers/Creating_advanced_search_engines_for_digital_library_archives.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/MqBpL7R" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Creating_an_advanced_video_search_engine_with_audio_and_key_frame_extraction.md
+++ b/docs/docs/answers/Creating_an_advanced_video_search_engine_with_audio_and_key_frame_extraction.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/UmfaBFm" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Creating_compact_robust_text_representations_with_MiniLML6_Sentence_Transformer.md
+++ b/docs/docs/answers/Creating_compact_robust_text_representations_with_MiniLML6_Sentence_Transformer.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/fabd3ID" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Creating_context_aware_customer_support_bots_with_Indexify.md
+++ b/docs/docs/answers/Creating_context_aware_customer_support_bots_with_Indexify.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/fCxZNIt" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Creating_contextaware_customer_support_bots_with_Indexify.md
+++ b/docs/docs/answers/Creating_contextaware_customer_support_bots_with_Indexify.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/fCxZNIt" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Creating_cross_lingual_semantic_search_applications_with_MPnet_embedding.md
+++ b/docs/docs/answers/Creating_cross_lingual_semantic_search_applications_with_MPnet_embedding.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/YxRGnFv" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Creating_crosslingual_semantic_search_applications_with_MPnet_embedding.md
+++ b/docs/docs/answers/Creating_crosslingual_semantic_search_applications_with_MPnet_embedding.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/YxRGnFv" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Creating_custom_PDF_text_and_data_extractors_with_Indexify.md
+++ b/docs/docs/answers/Creating_custom_PDF_text_and_data_extractors_with_Indexify.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/Rf5JsQ0" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Creating_custom_PDF_text_extractors_for_legal_document_analysis.md
+++ b/docs/docs/answers/Creating_custom_PDF_text_extractors_for_legal_document_analysis.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/LLWfQeL" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Creating_detailed_summaries_of_conference_keynotes_through_video_analysis.md
+++ b/docs/docs/answers/Creating_detailed_summaries_of_conference_keynotes_through_video_analysis.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/IAJKzPA" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Creating_dynamic_FAQs_using_Indexify_powered_semantic_search.md
+++ b/docs/docs/answers/Creating_dynamic_FAQs_using_Indexify_powered_semantic_search.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/riXSjvl" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Creating_dynamic_FAQs_using_Indexifypowered_semantic_search.md
+++ b/docs/docs/answers/Creating_dynamic_FAQs_using_Indexifypowered_semantic_search.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/riXSjvl" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Creating_dynamic_content_discovery_platforms_for_online_publishers_via_Haystack.md
+++ b/docs/docs/answers/Creating_dynamic_content_discovery_platforms_for_online_publishers_via_Haystack.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/ymWRrfL" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Creating_dynamic_data_applications_that_update_with_source_changes_using_Indexify.md
+++ b/docs/docs/answers/Creating_dynamic_data_applications_that_update_with_source_changes_using_Indexify.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/iNTVihe" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Creating_dynamic_photo_galleries_filtered_by_detected_objects.md
+++ b/docs/docs/answers/Creating_dynamic_photo_galleries_filtered_by_detected_objects.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/sdGswP0" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Creating_interactive_sports_archives_with_question_answering_capabilities.md
+++ b/docs/docs/answers/Creating_interactive_sports_archives_with_question_answering_capabilities.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/ZsnBNhC" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Creating_interactive_sports_archives_with_questionanswering_capabilities.md
+++ b/docs/docs/answers/Creating_interactive_sports_archives_with_questionanswering_capabilities.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/ZsnBNhC" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Creating_interactive_video_FAQ_sections_for_government_speeches.md
+++ b/docs/docs/answers/Creating_interactive_video_FAQ_sections_for_government_speeches.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/2FePPwr" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Creating_scalable_content_retrieval_systems_for_digital_libraries.md
+++ b/docs/docs/answers/Creating_scalable_content_retrieval_systems_for_digital_libraries.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/WiNdqwR" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Creating_searchable_archives_of_academic_PDFs_for_educational_platforms.md
+++ b/docs/docs/answers/Creating_searchable_archives_of_academic_PDFs_for_educational_platforms.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/mjO8wJ2" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Creating_searchable_podcast_archives_using_Whisper_based_audio_to_text_conversion.md
+++ b/docs/docs/answers/Creating_searchable_podcast_archives_using_Whisper_based_audio_to_text_conversion.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/7fGnqIc" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Creating_searchable_podcast_archives_using_Whisperbased_audio_to_text_conversion.md
+++ b/docs/docs/answers/Creating_searchable_podcast_archives_using_Whisperbased_audio_to_text_conversion.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/7fGnqIc" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Creating_searchable_podcast_archives_with_audio_transcription_and_embedding.md
+++ b/docs/docs/answers/Creating_searchable_podcast_archives_with_audio_transcription_and_embedding.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/NQ9k6FN" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Creating_secure_isolated_namespaces_for_confidential_corporate_documents.md
+++ b/docs/docs/answers/Creating_secure_isolated_namespaces_for_confidential_corporate_documents.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/mW1Ibv9" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Creating_smart_content_filters_with_Indexify_to_enhance_information_retrieval.md
+++ b/docs/docs/answers/Creating_smart_content_filters_with_Indexify_to_enhance_information_retrieval.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/7zw51K5" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Creating_smart_document_archives_with_searchable_PDF_content.md
+++ b/docs/docs/answers/Creating_smart_document_archives_with_searchable_PDF_content.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/UPeubUY" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Creating_voice_activated_search_for_podcasts_using_audio_indexing.md
+++ b/docs/docs/answers/Creating_voice_activated_search_for_podcasts_using_audio_indexing.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/5t5HnKF" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Creating_voiceactivated_search_for_podcasts_using_audio_indexing.md
+++ b/docs/docs/answers/Creating_voiceactivated_search_for_podcasts_using_audio_indexing.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/5t5HnKF" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Custom_search_engines_for_specialized_knowledge_bases_with_DSPy_integration.md
+++ b/docs/docs/answers/Custom_search_engines_for_specialized_knowledge_bases_with_DSPy_integration.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/THrXkVw" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Custom_video_content_retrieval_for_media_archives.md
+++ b/docs/docs/answers/Custom_video_content_retrieval_for_media_archives.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/DSvtfGR" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Customizing_Indexify_deployment_workflows_on_AWS_for_business_specific_needs.md
+++ b/docs/docs/answers/Customizing_Indexify_deployment_workflows_on_AWS_for_business_specific_needs.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/izLytsc" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Customizing_Indexify_deployment_workflows_on_AWS_for_businessspecific_needs.md
+++ b/docs/docs/answers/Customizing_Indexify_deployment_workflows_on_AWS_for_businessspecific_needs.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/izLytsc" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Customizing_Indexify_server_configurations_for_specialized_data_ingestion_workflows.md
+++ b/docs/docs/answers/Customizing_Indexify_server_configurations_for_specialized_data_ingestion_workflows.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/GJowAKK" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Customizing_content_extraction_and_indexing_for_niche_research_databases.md
+++ b/docs/docs/answers/Customizing_content_extraction_and_indexing_for_niche_research_databases.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/2TmaVuE" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Customizing_data_extraction_for_medical_record_analysis.md
+++ b/docs/docs/answers/Customizing_data_extraction_for_medical_record_analysis.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/1pUS7QQ" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Customizing_document_indexing_processes_with_Indexifys_robust_API_options.md
+++ b/docs/docs/answers/Customizing_document_indexing_processes_with_Indexifys_robust_API_options.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/NAbLnyg" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Customizing_log_levels_in_Indexify_to_fine_tune_service_diagnostics.md
+++ b/docs/docs/answers/Customizing_log_levels_in_Indexify_to_fine_tune_service_diagnostics.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/AoqnGrY" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Customizing_log_levels_in_Indexify_to_finetune_service_diagnostics.md
+++ b/docs/docs/answers/Customizing_log_levels_in_Indexify_to_finetune_service_diagnostics.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/AoqnGrY" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Customizing_network_settings_for_enhanced_Indexify_service_deployment.md
+++ b/docs/docs/answers/Customizing_network_settings_for_enhanced_Indexify_service_deployment.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/SGWS1D1" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Defining_extraction_policies_in_Indexify_for_targeted_content_processing.md
+++ b/docs/docs/answers/Defining_extraction_policies_in_Indexify_for_targeted_content_processing.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/NJqH1oW" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Deploying_Indexify_in_a_development_environment_with_custom_configurations.md
+++ b/docs/docs/answers/Deploying_Indexify_in_a_development_environment_with_custom_configurations.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/lyfKN8d" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Deploying_Indexify_on_AWS_with_EKS_for_scalable_data_indexing_solutions.md
+++ b/docs/docs/answers/Deploying_Indexify_on_AWS_with_EKS_for_scalable_data_indexing_solutions.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/ftM7uyM" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Deploying_cost_effective_accurate_image_retrieval_systems_for_digital_archives.md
+++ b/docs/docs/answers/Deploying_cost_effective_accurate_image_retrieval_systems_for_digital_archives.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/Uw1FJig" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Deploying_costeffective_accurate_image_retrieval_systems_for_digital_archives.md
+++ b/docs/docs/answers/Deploying_costeffective_accurate_image_retrieval_systems_for_digital_archives.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/Uw1FJig" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Deploying_real_time_fact_checking_tools_with_Indexify_embeddings.md
+++ b/docs/docs/answers/Deploying_real_time_fact_checking_tools_with_Indexify_embeddings.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/yv7NDOl" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Deploying_realtime_factchecking_tools_with_Indexify_embeddings.md
+++ b/docs/docs/answers/Deploying_realtime_factchecking_tools_with_Indexify_embeddings.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/yv7NDOl" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Designing_a_news_aggregator_with_custom_extractors_for_various_news_formats.md
+++ b/docs/docs/answers/Designing_a_news_aggregator_with_custom_extractors_for_various_news_formats.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/APLk6Ml" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Designing_interactive_tour_guides_with_Wikipedia_content_and_Indexify.md
+++ b/docs/docs/answers/Designing_interactive_tour_guides_with_Wikipedia_content_and_Indexify.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/2vUh3xO" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Developing_AI_powered_study_aids_with_contextual_content_retrieval.md
+++ b/docs/docs/answers/Developing_AI_powered_study_aids_with_contextual_content_retrieval.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/VMLHHHS" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Developing_AI_tutors_with_indexed_educational_videos_for_personalized_learning_paths.md
+++ b/docs/docs/answers/Developing_AI_tutors_with_indexed_educational_videos_for_personalized_learning_paths.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/oadURNU" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Developing_AIpowered_study_aids_with_contextual_content_retrieval.md
+++ b/docs/docs/answers/Developing_AIpowered_study_aids_with_contextual_content_retrieval.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/VMLHHHS" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Developing_a_custom_extractor_for_extracting_and_indexing_medical_imaging_metadata.md
+++ b/docs/docs/answers/Developing_a_custom_extractor_for_extracting_and_indexing_medical_imaging_metadata.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/gSsL2QU" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Developing_a_legal_document_analysis_tool_to_identify_and_extract_key_clauses.md
+++ b/docs/docs/answers/Developing_a_legal_document_analysis_tool_to_identify_and_extract_key_clauses.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/LhHLKlA" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Developing_a_personalized_video_recommendation_system_using_extracted_key_frames_and_audio.md
+++ b/docs/docs/answers/Developing_a_personalized_video_recommendation_system_using_extracted_key_frames_and_audio.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/LjeMBtn" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Developing_a_trivia_game_by_extracting_facts_from_Wikipedia_pages.md
+++ b/docs/docs/answers/Developing_a_trivia_game_by_extracting_facts_from_Wikipedia_pages.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/b6u0iBt" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Developing_advanced_data_processing_applications_without_relying_on_Kubernetes_or_Mesos.md
+++ b/docs/docs/answers/Developing_advanced_data_processing_applications_without_relying_on_Kubernetes_or_Mesos.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/CtIdTUk" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Developing_advanced_search_functionalities_in_web_apps_with_Indexifys_APIs.md
+++ b/docs/docs/answers/Developing_advanced_search_functionalities_in_web_apps_with_Indexifys_APIs.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/m4bKOnX" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Developing_an_automated_video_editing_tool_using_scene_detection_for_streamlined_workflows.md
+++ b/docs/docs/answers/Developing_an_automated_video_editing_tool_using_scene_detection_for_streamlined_workflows.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/qWp7AQS" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Developing_an_educational_content_platform_with_searchable_archives_powered_by_Indexify.md
+++ b/docs/docs/answers/Developing_an_educational_content_platform_with_searchable_archives_powered_by_Indexify.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/Dsd1TRO" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Developing_audio_content_extractors_for_podcast_transcription_and_analysis.md
+++ b/docs/docs/answers/Developing_audio_content_extractors_for_podcast_transcription_and_analysis.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/OtX8E98" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Developing_custom_extractors_for_Indexifys_data_transformation_workflows.md
+++ b/docs/docs/answers/Developing_custom_extractors_for_Indexifys_data_transformation_workflows.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/GPG5xxP" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Developing_educational_tools_for_sports_history_using_RAG_and_Indexify.md
+++ b/docs/docs/answers/Developing_educational_tools_for_sports_history_using_RAG_and_Indexify.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/w5B1sci" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Developing_interactive_history_bots_powered_by_Indexifys_embedding_capabilities.md
+++ b/docs/docs/answers/Developing_interactive_history_bots_powered_by_Indexifys_embedding_capabilities.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/ne44dCg" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Developing_personalized_content_recommendation_engines.md
+++ b/docs/docs/answers/Developing_personalized_content_recommendation_engines.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/kXyMQf8" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Developing_video_content_analysis_tools_for_climate_change_advocacy.md
+++ b/docs/docs/answers/Developing_video_content_analysis_tools_for_climate_change_advocacy.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/ZnxSjpT" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Driving_customer_engagement_with_personalized_content_recommendations.md
+++ b/docs/docs/answers/Driving_customer_engagement_with_personalized_content_recommendations.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/Qc98sYb" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Efficient_SEC_10K_document_processing_for_compliance_tracking.md
+++ b/docs/docs/answers/Efficient_SEC_10K_document_processing_for_compliance_tracking.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/4cCWKi7" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Efficient_SEC_10_K_document_processing_for_compliance_tracking.md
+++ b/docs/docs/answers/Efficient_SEC_10_K_document_processing_for_compliance_tracking.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/4cCWKi7" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Embedding_PDF_content_for_enhanced_document_retrieval_with_Indexify.md
+++ b/docs/docs/answers/Embedding_PDF_content_for_enhanced_document_retrieval_with_Indexify.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/GWXjY1U" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Embedding_extraction_for_enhancing_semantic_search_capabilities.md
+++ b/docs/docs/answers/Embedding_extraction_for_enhancing_semantic_search_capabilities.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/1a1TgB2" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Enabling_efficient_data_processing_with_Indexifys_Ingestion_Server.md
+++ b/docs/docs/answers/Enabling_efficient_data_processing_with_Indexifys_Ingestion_Server.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/2I5M0wA" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Enabling_intelligent_search_within_video_content_by_extracting_and_indexing_verbal_discussions.md
+++ b/docs/docs/answers/Enabling_intelligent_search_within_video_content_by_extracting_and_indexing_verbal_discussions.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/cRfjQC3" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Enabling_rich_media_search_capabilities_within_video_streaming_services.md
+++ b/docs/docs/answers/Enabling_rich_media_search_capabilities_within_video_streaming_services.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/g1haCJl" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Enabling_semantic_search_within_audio_books_and_lectures.md
+++ b/docs/docs/answers/Enabling_semantic_search_within_audio_books_and_lectures.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/9lIyWeZ" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Enabling_smart_document_search_in_TypeScript_applications.md
+++ b/docs/docs/answers/Enabling_smart_document_search_in_TypeScript_applications.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/TP4vFLc" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Enabling_smart_parking_solutions_through_live_vehicle_and_slot_detection.md
+++ b/docs/docs/answers/Enabling_smart_parking_solutions_through_live_vehicle_and_slot_detection.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/ruqm3Mo" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Enhancing_AI_training_sets_with_structured_data_extracted_from_Wikipedia.md
+++ b/docs/docs/answers/Enhancing_AI_training_sets_with_structured_data_extracted_from_Wikipedia.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/qwgufZh" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Enhancing_Data_Extraction_Workflows_with_Indexifys_Extraction_Policies_Interface.md
+++ b/docs/docs/answers/Enhancing_Data_Extraction_Workflows_with_Indexifys_Extraction_Policies_Interface.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/Apv4vuO" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Enhancing_Indexify_application_observability_with_OpenTelemetrys_logs_and_metrics.md
+++ b/docs/docs/answers/Enhancing_Indexify_application_observability_with_OpenTelemetrys_logs_and_metrics.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/KqvEzyh" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Enhancing_academic_research_by_automated_extraction_of_data_from_scholarly_articles.md
+++ b/docs/docs/answers/Enhancing_academic_research_by_automated_extraction_of_data_from_scholarly_articles.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/WzKtm01" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Enhancing_academic_research_with_specialized_data_extractors_from_scientific_articles.md
+++ b/docs/docs/answers/Enhancing_academic_research_with_specialized_data_extractors_from_scientific_articles.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/ujNr44k" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Enhancing_accessibility_of_audio_books_through_searchable_transcripts.md
+++ b/docs/docs/answers/Enhancing_accessibility_of_audio_books_through_searchable_transcripts.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/QrdO6nI" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Enhancing_accessibility_of_online_courses_through_transcript_indexing.md
+++ b/docs/docs/answers/Enhancing_accessibility_of_online_courses_through_transcript_indexing.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/9KpQeNP" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Enhancing_chatbot_intelligence_with_Indexifys_retriever_API_for_context_aware_responses.md
+++ b/docs/docs/answers/Enhancing_chatbot_intelligence_with_Indexifys_retriever_API_for_context_aware_responses.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/gChpGDM" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Enhancing_chatbot_intelligence_with_Indexifys_retriever_API_for_contextaware_responses.md
+++ b/docs/docs/answers/Enhancing_chatbot_intelligence_with_Indexifys_retriever_API_for_contextaware_responses.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/gChpGDM" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Enhancing_chatbots_with_deep_content_understanding_using_IndexifyRM.md
+++ b/docs/docs/answers/Enhancing_chatbots_with_deep_content_understanding_using_IndexifyRM.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/FFk1A5U" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Enhancing_content_discoverability_with_Indexifys_targeted_content_extraction.md
+++ b/docs/docs/answers/Enhancing_content_discoverability_with_Indexifys_targeted_content_extraction.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/Q1YfGuK" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Enhancing_content_discovery_in_digital_libraries_with_custom_PDF_indexing.md
+++ b/docs/docs/answers/Enhancing_content_discovery_in_digital_libraries_with_custom_PDF_indexing.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/heEJi6Q" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Enhancing_creative_project_management_with_searchable_digital_assets.md
+++ b/docs/docs/answers/Enhancing_creative_project_management_with_searchable_digital_assets.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/kXP5ETy" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Enhancing_customer_support_with_instant_retrieval_of_relevant_information_from_call_recordings.md
+++ b/docs/docs/answers/Enhancing_customer_support_with_instant_retrieval_of_relevant_information_from_call_recordings.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/P3Yy4Cg" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Enhancing_data_extraction_accuracy_with_detailed_metrics_analysis.md
+++ b/docs/docs/answers/Enhancing_data_extraction_accuracy_with_detailed_metrics_analysis.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/Z91Pi6U" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Enhancing_data_ingestion_and_transformation_using_Indexify_with_LlamaIndex_components.md
+++ b/docs/docs/answers/Enhancing_data_ingestion_and_transformation_using_Indexify_with_LlamaIndex_components.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/Ig6nfJp" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Enhancing_e_government_services_by_extracting_data_from_submitted_PDF_forms.md
+++ b/docs/docs/answers/Enhancing_e_government_services_by_extracting_data_from_submitted_PDF_forms.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/HzoanZy" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Enhancing_educational_platforms_with_searchable_video_archives_through_key_frame_indexing.md
+++ b/docs/docs/answers/Enhancing_educational_platforms_with_searchable_video_archives_through_key_frame_indexing.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/uNQC4WI" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Enhancing_egovernment_services_by_extracting_data_from_submitted_PDF_forms.md
+++ b/docs/docs/answers/Enhancing_egovernment_services_by_extracting_data_from_submitted_PDF_forms.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/HzoanZy" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Enhancing_interactive_learning_tools_with_image_based_question_answering_features.md
+++ b/docs/docs/answers/Enhancing_interactive_learning_tools_with_image_based_question_answering_features.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/HTHWVRa" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Enhancing_interactive_learning_tools_with_imagebased_question_answering_features.md
+++ b/docs/docs/answers/Enhancing_interactive_learning_tools_with_imagebased_question_answering_features.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/HTHWVRa" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Enhancing_journalist_interviews_with_searchable_transcriptions_from_audio_recordings.md
+++ b/docs/docs/answers/Enhancing_journalist_interviews_with_searchable_transcriptions_from_audio_recordings.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/zsHGlw4" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Enhancing_language_learning_apps_with_contextual_examples_retrieval.md
+++ b/docs/docs/answers/Enhancing_language_learning_apps_with_contextual_examples_retrieval.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/RJH04rU" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Enhancing_lecture_note_accessibility_with_automated_transcription_for_educational_institutions.md
+++ b/docs/docs/answers/Enhancing_lecture_note_accessibility_with_automated_transcription_for_educational_institutions.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/mJT7Cpe" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Enhancing_legal_document_analysis_by_extracting_key_entities_and_clauses.md
+++ b/docs/docs/answers/Enhancing_legal_document_analysis_by_extracting_key_entities_and_clauses.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/cJBn93r" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Enhancing_legal_document_discovery_processes_through_Haystack_indexing.md
+++ b/docs/docs/answers/Enhancing_legal_document_discovery_processes_through_Haystack_indexing.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/XZ7Zw0X" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Enhancing_media_monitoring_platforms_by_indexing_broadcast_video_in_real_time.md
+++ b/docs/docs/answers/Enhancing_media_monitoring_platforms_by_indexing_broadcast_video_in_real_time.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/O2MZVTs" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Enhancing_media_monitoring_platforms_by_indexing_broadcast_video_in_realtime.md
+++ b/docs/docs/answers/Enhancing_media_monitoring_platforms_by_indexing_broadcast_video_in_realtime.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/O2MZVTs" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Enhancing_media_monitoring_with_automated_video_transcript_analysis.md
+++ b/docs/docs/answers/Enhancing_media_monitoring_with_automated_video_transcript_analysis.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/Jd98ess" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Enhancing_scholarly_article_recommendations_with_SciBERT_uncased_embedding.md
+++ b/docs/docs/answers/Enhancing_scholarly_article_recommendations_with_SciBERT_uncased_embedding.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/BtVOXJD" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Enhancing_search_in_video_archives_with_automatic_audio_to_text_transcription.md
+++ b/docs/docs/answers/Enhancing_search_in_video_archives_with_automatic_audio_to_text_transcription.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/yfjzLGJ" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Enhancing_security_surveillance_with_YOLO_based_real_time_object_detection.md
+++ b/docs/docs/answers/Enhancing_security_surveillance_with_YOLO_based_real_time_object_detection.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/IBldUGR" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Enhancing_security_surveillance_with_YOLObased_realtime_object_detection.md
+++ b/docs/docs/answers/Enhancing_security_surveillance_with_YOLObased_realtime_object_detection.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/IBldUGR" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Enhancing_sports_analytics_by_extracting_key_moments_from_game_footage_for_highlights.md
+++ b/docs/docs/answers/Enhancing_sports_analytics_by_extracting_key_moments_from_game_footage_for_highlights.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/FxshNdW" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Enhancing_sports_journalism_with_quick_access_to_athlete_career_data.md
+++ b/docs/docs/answers/Enhancing_sports_journalism_with_quick_access_to_athlete_career_data.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/7c8RLsY" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Enhancing_trivia_game_development_with_Indexify_RAG_integrations.md
+++ b/docs/docs/answers/Enhancing_trivia_game_development_with_Indexify_RAG_integrations.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/L1BQodl" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Enhancing_user_experience_with_dynamic_content_discovery_through_Indexifys_search_APIs.md
+++ b/docs/docs/answers/Enhancing_user_experience_with_dynamic_content_discovery_through_Indexifys_search_APIs.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/brO3i6K" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Enhancing_user_experience_with_semantic_search_in_digital_libraries.md
+++ b/docs/docs/answers/Enhancing_user_experience_with_semantic_search_in_digital_libraries.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/8MgO12Q" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Enhancing_visual_search_capabilities_for_e_commerce_platforms.md
+++ b/docs/docs/answers/Enhancing_visual_search_capabilities_for_e_commerce_platforms.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/2FSLldy" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Enhancing_visual_search_capabilities_for_ecommerce_platforms.md
+++ b/docs/docs/answers/Enhancing_visual_search_capabilities_for_ecommerce_platforms.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/2FSLldy" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Enriching_online_learning_materials_with_Wikipedia_content_extraction.md
+++ b/docs/docs/answers/Enriching_online_learning_materials_with_Wikipedia_content_extraction.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/M9l4FAL" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Ensuring_High_Availability_with_Proper_Network_Configuration_in_Indexify.md
+++ b/docs/docs/answers/Ensuring_High_Availability_with_Proper_Network_Configuration_in_Indexify.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/L7F1Ecz" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Ensuring_data_durability_by_monitoring_content_bytes_uploaded.md
+++ b/docs/docs/answers/Ensuring_data_durability_by_monitoring_content_bytes_uploaded.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/2TC8GNv" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Ensuring_high_availability_of_Indexify_services_with_EKS_on_AWS.md
+++ b/docs/docs/answers/Ensuring_high_availability_of_Indexify_services_with_EKS_on_AWS.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/8lInHqb" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Establishing_a_knowledge_base_for_customer_support_documentation.md
+++ b/docs/docs/answers/Establishing_a_knowledge_base_for_customer_support_documentation.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/1uIBLOR" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Establishing_a_local_Indexify_server_for_developmental_testing.md
+++ b/docs/docs/answers/Establishing_a_local_Indexify_server_for_developmental_testing.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/BIcXVK9" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Expediting_research_through_efficient_indexing_of_academic_papers.md
+++ b/docs/docs/answers/Expediting_research_through_efficient_indexing_of_academic_papers.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/25wwwVo" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Exploring_Detailed_Content_Information_with_Indexifys_Viewing_Features.md
+++ b/docs/docs/answers/Exploring_Detailed_Content_Information_with_Indexifys_Viewing_Features.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/tzXeGFl" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Exploring_Indexifys_API_capabilities_through_its_interactive_Swagger_UI.md
+++ b/docs/docs/answers/Exploring_Indexifys_API_capabilities_through_its_interactive_Swagger_UI.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/danKK7Y" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Extending_the_Indexify_platform_with_custom_data_extraction_models.md
+++ b/docs/docs/answers/Extending_the_Indexify_platform_with_custom_data_extraction_models.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/jboC7xw" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Extracting_and_indexing_recipe_information_from_PDF_cookbooks_for_a_culinary_app.md
+++ b/docs/docs/answers/Extracting_and_indexing_recipe_information_from_PDF_cookbooks_for_a_culinary_app.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/9fMMljL" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Extracting_data_from_PDF_reports_for_dynamic_data_visualization_projects.md
+++ b/docs/docs/answers/Extracting_data_from_PDF_reports_for_dynamic_data_visualization_projects.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/x1SbKu3" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Extracting_structured_data_from_PDF_invoices_for_automated_accounting.md
+++ b/docs/docs/answers/Extracting_structured_data_from_PDF_invoices_for_automated_accounting.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/NRfakIb" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Extracting_structured_data_from_invoices_for_easy_financial_analysis.md
+++ b/docs/docs/answers/Extracting_structured_data_from_invoices_for_easy_financial_analysis.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/uJpP81x" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Facilitating_automated_metadata_generation_for_historical_video_archives.md
+++ b/docs/docs/answers/Facilitating_automated_metadata_generation_for_historical_video_archives.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/gHOZne3" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Facilitating_competitive_analysis_through_automated_extraction_of_industry_reports.md
+++ b/docs/docs/answers/Facilitating_competitive_analysis_through_automated_extraction_of_industry_reports.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/4vgT0vw" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Facilitating_content_moderation_by_extracting_and_analyzing_textual_data_from_images.md
+++ b/docs/docs/answers/Facilitating_content_moderation_by_extracting_and_analyzing_textual_data_from_images.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/ocbjiPy" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Facilitating_discovery_of_multimedia_content_through_vector_indexing.md
+++ b/docs/docs/answers/Facilitating_discovery_of_multimedia_content_through_vector_indexing.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/3xuAcij" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Facilitating_easier_image_selection_for_marketing_materials_using_visual_queries.md
+++ b/docs/docs/answers/Facilitating_easier_image_selection_for_marketing_materials_using_visual_queries.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/S4sL8tO" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Facilitating_efficient_content_discovery_through_namespace_based_data_organization.md
+++ b/docs/docs/answers/Facilitating_efficient_content_discovery_through_namespace_based_data_organization.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/ltYA0ma" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Facilitating_efficient_content_discovery_through_namespacebased_data_organization.md
+++ b/docs/docs/answers/Facilitating_efficient_content_discovery_through_namespacebased_data_organization.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/ltYA0ma" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Facilitating_efficient_patient_record_retrieval_in_healthcare_systems_using_Haystack.md
+++ b/docs/docs/answers/Facilitating_efficient_patient_record_retrieval_in_healthcare_systems_using_Haystack.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/9DQjldm" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Facilitating_language_learning_with_transcribed_and_indexed_audio_exercises.md
+++ b/docs/docs/answers/Facilitating_language_learning_with_transcribed_and_indexed_audio_exercises.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/bId0kkE" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Facilitating_precise_data_extraction_from_medical_records_using_Indexify_with_LangChain.md
+++ b/docs/docs/answers/Facilitating_precise_data_extraction_from_medical_records_using_Indexify_with_LangChain.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/4LXoT40" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Facilitating_research_by_indexing_and_making_scientific_papers_searchable.md
+++ b/docs/docs/answers/Facilitating_research_by_indexing_and_making_scientific_papers_searchable.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/0Ca1wZR" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Facilitating_sports_analytics_with_embedded_data_extraction_and_indexing.md
+++ b/docs/docs/answers/Facilitating_sports_analytics_with_embedded_data_extraction_and_indexing.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/wLL7ZY8" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Facilitating_wildlife_research_with_automated_animal_detection_in_camera_trap_images.md
+++ b/docs/docs/answers/Facilitating_wildlife_research_with_automated_animal_detection_in_camera_trap_images.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/Vv6ux6k" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Generating_quick_similarity_searches_for_English_texts_with_E5_embedding.md
+++ b/docs/docs/answers/Generating_quick_similarity_searches_for_English_texts_with_E5_embedding.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/Ca1u3h3" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Generating_summaries_for_long_audio_files_through_chunked_transcription_embedding.md
+++ b/docs/docs/answers/Generating_summaries_for_long_audio_files_through_chunked_transcription_embedding.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/4PwbGLp" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Generating_summary_texts_from_Wikipedia_articles_for_educational_platforms.md
+++ b/docs/docs/answers/Generating_summary_texts_from_Wikipedia_articles_for_educational_platforms.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/OLelj68" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Implementing_AI_powered_extractors_for_media_monitoring_from_PDF_sources.md
+++ b/docs/docs/answers/Implementing_AI_powered_extractors_for_media_monitoring_from_PDF_sources.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/HMGc5vi" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Implementing_AIpowered_extractors_for_media_monitoring_from_PDF_sources.md
+++ b/docs/docs/answers/Implementing_AIpowered_extractors_for_media_monitoring_from_PDF_sources.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/HMGc5vi" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Implementing_Indexify_extraction_policies_for_targeted_marketing_intelligence_gathering.md
+++ b/docs/docs/answers/Implementing_Indexify_extraction_policies_for_targeted_marketing_intelligence_gathering.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/Rnt3Q2r" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Implementing_a_face_recognition_based_security_system_for_surveillance_footage.md
+++ b/docs/docs/answers/Implementing_a_face_recognition_based_security_system_for_surveillance_footage.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/bmrDupw" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Implementing_a_facerecognition_based_security_system_for_surveillance_footage.md
+++ b/docs/docs/answers/Implementing_a_facerecognition_based_security_system_for_surveillance_footage.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/bmrDupw" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Implementing_a_knowledge_base_for_customer_support_with_Indexify_powered_retrievals.md
+++ b/docs/docs/answers/Implementing_a_knowledge_base_for_customer_support_with_Indexify_powered_retrievals.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/kDu3F8G" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Implementing_a_knowledge_base_for_customer_support_with_Indexifypowered_retrievals.md
+++ b/docs/docs/answers/Implementing_a_knowledge_base_for_customer_support_with_Indexifypowered_retrievals.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/kDu3F8G" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Implementing_conversational_AI_with_contextual_understanding_using_ColBERT.md
+++ b/docs/docs/answers/Implementing_conversational_AI_with_contextual_understanding_using_ColBERT.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/0SKr8UJ" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Implementing_custom_extractors_for_real_time_social_media_sentiment_analysis.md
+++ b/docs/docs/answers/Implementing_custom_extractors_for_real_time_social_media_sentiment_analysis.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/1KDmmcm" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Implementing_custom_extractors_for_realtime_social_media_sentiment_analysis.md
+++ b/docs/docs/answers/Implementing_custom_extractors_for_realtime_social_media_sentiment_analysis.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/1KDmmcm" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Implementing_educational_tools_using_RAG_and_Wikipedia_content.md
+++ b/docs/docs/answers/Implementing_educational_tools_using_RAG_and_Wikipedia_content.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/D2KmtFz" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Implementing_efficient_knowledge_base_search_systems_with_Indexify_and_Haystack.md
+++ b/docs/docs/answers/Implementing_efficient_knowledge_base_search_systems_with_Indexify_and_Haystack.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/tu5FOQH" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Implementing_real_time_monitoring_dashboards_for_Indexify_services_with_Grafana.md
+++ b/docs/docs/answers/Implementing_real_time_monitoring_dashboards_for_Indexify_services_with_Grafana.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/1vqBccA" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Implementing_realtime_monitoring_dashboards_for_Indexify_services_with_Grafana.md
+++ b/docs/docs/answers/Implementing_realtime_monitoring_dashboards_for_Indexify_services_with_Grafana.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/1vqBccA" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Implementing_robust_data_deletion_and_incremental_compute_with_Indexify_for_dynamic_datasets.md
+++ b/docs/docs/answers/Implementing_robust_data_deletion_and_incremental_compute_with_Indexify_for_dynamic_datasets.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/tMmfrYy" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Implementing_semantic_search_in_video_archives_for_faster_research.md
+++ b/docs/docs/answers/Implementing_semantic_search_in_video_archives_for_faster_research.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/QOm8dj8" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Implementing_smart_content_recommendations_with_semantic_search_on_extracted_embeddings.md
+++ b/docs/docs/answers/Implementing_smart_content_recommendations_with_semantic_search_on_extracted_embeddings.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/NNRqc2N" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Implementing_targeted_content_deletion_in_knowledge_bases_and_databases.md
+++ b/docs/docs/answers/Implementing_targeted_content_deletion_in_knowledge_bases_and_databases.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/leddY5D" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Improving_content_extraction_processes_through_task_progress_monitoring.md
+++ b/docs/docs/answers/Improving_content_extraction_processes_through_task_progress_monitoring.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/Qd3MWFe" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Improving_customer_service_with_rapid_audio_ticket_transcriptions_using_Whisper_ASR.md
+++ b/docs/docs/answers/Improving_customer_service_with_rapid_audio_ticket_transcriptions_using_Whisper_ASR.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/kWy6g0Y" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Improving_customer_support_systems_with_indexed_call_transcriptions.md
+++ b/docs/docs/answers/Improving_customer_support_systems_with_indexed_call_transcriptions.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/YbHxieu" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Improving_customer_support_with_instant_access_to_knowledge_bases.md
+++ b/docs/docs/answers/Improving_customer_support_with_instant_access_to_knowledge_bases.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/bGgsuxO" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Improving_customer_support_with_searchable_archives_of_meeting_transcriptions.md
+++ b/docs/docs/answers/Improving_customer_support_with_searchable_archives_of_meeting_transcriptions.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/rO4bnMQ" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Improving_e_commerce_user_experience_with_image_text_search_enhancements.md
+++ b/docs/docs/answers/Improving_e_commerce_user_experience_with_image_text_search_enhancements.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/xwqLGra" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Improving_ecommerce_user_experience_with_imagetext_search_enhancements.md
+++ b/docs/docs/answers/Improving_ecommerce_user_experience_with_imagetext_search_enhancements.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/xwqLGra" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Improving_issue_tracking_by_indexing_software_documentation_with_Haystack.md
+++ b/docs/docs/answers/Improving_issue_tracking_by_indexing_software_documentation_with_Haystack.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/x3Tb0LW" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Improving_news_aggregation_apps_with_automatic_tagging_and_indexing_of_articles.md
+++ b/docs/docs/answers/Improving_news_aggregation_apps_with_automatic_tagging_and_indexing_of_articles.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/Qr7LhWN" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Improving_news_aggregation_platforms_with_automated_article_text_extraction.md
+++ b/docs/docs/answers/Improving_news_aggregation_platforms_with_automated_article_text_extraction.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/X6YaPMQ" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Improving_news_aggregation_with_real_time_extraction_and_indexing_of_articles.md
+++ b/docs/docs/answers/Improving_news_aggregation_with_real_time_extraction_and_indexing_of_articles.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/QeeSgFx" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Improving_news_aggregation_with_realtime_extraction_and_indexing_of_articles.md
+++ b/docs/docs/answers/Improving_news_aggregation_with_realtime_extraction_and_indexing_of_articles.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/QeeSgFx" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Improving_online_research_with_metadata_driven_search_capabilities.md
+++ b/docs/docs/answers/Improving_online_research_with_metadata_driven_search_capabilities.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/TMABjCe" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Improving_online_research_with_metadatadriven_search_capabilities.md
+++ b/docs/docs/answers/Improving_online_research_with_metadatadriven_search_capabilities.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/TMABjCe" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Improving_research_efficiency_by_indexing_academic_papers_with_Indexify_and_querying_with_LangChain.md
+++ b/docs/docs/answers/Improving_research_efficiency_by_indexing_academic_papers_with_Indexify_and_querying_with_LangChain.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/63Qc7lG" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Improving_surveillance_footage_analysis_with_object_specific_search_functionality.md
+++ b/docs/docs/answers/Improving_surveillance_footage_analysis_with_object_specific_search_functionality.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/vK4iM5y" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Improving_surveillance_footage_analysis_with_objectspecific_search_functionality.md
+++ b/docs/docs/answers/Improving_surveillance_footage_analysis_with_objectspecific_search_functionality.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/vK4iM5y" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Incorporating_Indexifys_APIs_for_efficient_multimedia_content_indexing_in_digital_libraries.md
+++ b/docs/docs/answers/Incorporating_Indexifys_APIs_for_efficient_multimedia_content_indexing_in_digital_libraries.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/yvvbAYv" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Increasing_the_reliability_of_Indexify_operations_with_EKS_managed_Kubernetes_clusters.md
+++ b/docs/docs/answers/Increasing_the_reliability_of_Indexify_operations_with_EKS_managed_Kubernetes_clusters.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/k0qQuZM" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Increasing_the_reliability_of_Indexify_operations_with_EKSmanaged_Kubernetes_clusters.md
+++ b/docs/docs/answers/Increasing_the_reliability_of_Indexify_operations_with_EKSmanaged_Kubernetes_clusters.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/k0qQuZM" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Indexing_and_extracting_data_from_medical_research_papers_for_a_healthcare_database.md
+++ b/docs/docs/answers/Indexing_and_extracting_data_from_medical_research_papers_for_a_healthcare_database.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/UBt6Nxn" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Indexing_and_querying_image_collections_with_SQL_for_faster_access.md
+++ b/docs/docs/answers/Indexing_and_querying_image_collections_with_SQL_for_faster_access.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/J9r1Vdm" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Indexing_healthcare_benefits_documents_for_better_insurance_management.md
+++ b/docs/docs/answers/Indexing_healthcare_benefits_documents_for_better_insurance_management.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/b80Rr6o" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Indexing_historical_archives_for_quick_retrieval_in_educational_institutions.md
+++ b/docs/docs/answers/Indexing_historical_archives_for_quick_retrieval_in_educational_institutions.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/fY9TP4G" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Initializing_Indexify_with_CLI_for_Quick_Start_Configuration.md
+++ b/docs/docs/answers/Initializing_Indexify_with_CLI_for_Quick_Start_Configuration.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/uVsDEzF" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Initializing_a_new_Indexify_project_with_sample_configurations.md
+++ b/docs/docs/answers/Initializing_a_new_Indexify_project_with_sample_configurations.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/aotJZlp" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Inspecting_Extractors_and_Their_Outputs_in_Indexifys_UI.md
+++ b/docs/docs/answers/Inspecting_Extractors_and_Their_Outputs_in_Indexifys_UI.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/xUB0aQB" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Installing_Indexify_clients_for_Python_and_TypeScript_developers.md
+++ b/docs/docs/answers/Installing_Indexify_clients_for_Python_and_TypeScript_developers.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/qLx9m4o" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Integrating_Indexify_deployment_with_CICD_pipelines_for_seamless_updates_and_releases.md
+++ b/docs/docs/answers/Integrating_Indexify_deployment_with_CICD_pipelines_for_seamless_updates_and_releases.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/n2U5WRV" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Integrating_Indexify_for_comprehensive_data_transformation_and_extraction_in_AI_projects.md
+++ b/docs/docs/answers/Integrating_Indexify_for_comprehensive_data_transformation_and_extraction_in_AI_projects.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/IIpYXVI" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Integrating_Indexify_with_LangChain_for_advanced_document_search_capabilities.md
+++ b/docs/docs/answers/Integrating_Indexify_with_LangChain_for_advanced_document_search_capabilities.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/S3jnXVC" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Integrating_Indexify_with_Qdrant_VectorDB_for_advanced_search_features.md
+++ b/docs/docs/answers/Integrating_Indexify_with_Qdrant_VectorDB_for_advanced_search_features.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/yVT6rJC" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Integrating_Indexifys_indexing_services_into_custom_applications_via_REST_APIs.md
+++ b/docs/docs/answers/Integrating_Indexifys_indexing_services_into_custom_applications_via_REST_APIs.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/ukQzb6x" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Integrating_real_time_audio_transcriptions_into_web_applications.md
+++ b/docs/docs/answers/Integrating_real_time_audio_transcriptions_into_web_applications.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/vbOilq6" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Integrating_realtime_audio_transcriptions_into_web_applications.md
+++ b/docs/docs/answers/Integrating_realtime_audio_transcriptions_into_web_applications.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/vbOilq6" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Leveraging_Indexify_for_asynchronous_reliable_data_extraction_and_processing_workflows.md
+++ b/docs/docs/answers/Leveraging_Indexify_for_asynchronous_reliable_data_extraction_and_processing_workflows.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/mKJNskl" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Leveraging_Indexify_for_efficient_content_management_in_digital_archives.md
+++ b/docs/docs/answers/Leveraging_Indexify_for_efficient_content_management_in_digital_archives.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/9cwvGNA" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Leveraging_Indexify_for_sentiment_analysis_in_customer_feedback.md
+++ b/docs/docs/answers/Leveraging_Indexify_for_sentiment_analysis_in_customer_feedback.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/EOiLAyE" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Leveraging_Indexifys_APIs_for_real_time_text_and_file_analysis_in_enterprise_solutions.md
+++ b/docs/docs/answers/Leveraging_Indexifys_APIs_for_real_time_text_and_file_analysis_in_enterprise_solutions.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/Xc4blRt" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Leveraging_Indexifys_APIs_for_realtime_text_and_file_analysis_in_enterprise_solutions.md
+++ b/docs/docs/answers/Leveraging_Indexifys_APIs_for_realtime_text_and_file_analysis_in_enterprise_solutions.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/Xc4blRt" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Leveraging_Indexifys_UI_for_Streamlined_Content_Ingestion_Management.md
+++ b/docs/docs/answers/Leveraging_Indexifys_UI_for_Streamlined_Content_Ingestion_Management.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/sMnKIM7" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Managing_Extraction_Policies_through_Indexifys_Intuitive_UI.md
+++ b/docs/docs/answers/Managing_Extraction_Policies_through_Indexifys_Intuitive_UI.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/62sTDAC" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Managing_sensitive_health_records_with_strict_access_controls.md
+++ b/docs/docs/answers/Managing_sensitive_health_records_with_strict_access_controls.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/YjZTi3H" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Maximizing_resource_utilization_by_monitoring_tasks_in_progress.md
+++ b/docs/docs/answers/Maximizing_resource_utilization_by_monitoring_tasks_in_progress.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/jTP5hIy" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Measuring_efficiency_of_content_upload_and_extraction_workflows.md
+++ b/docs/docs/answers/Measuring_efficiency_of_content_upload_and_extraction_workflows.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/nNKNQWP" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Monitoring_Indexify_cluster_health_and_performance_with_Prometheus.md
+++ b/docs/docs/answers/Monitoring_Indexify_cluster_health_and_performance_with_Prometheus.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/Tm6J3ox" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Monitoring_Indexify_deployment_performance_with_OpenTelemetry_integration.md
+++ b/docs/docs/answers/Monitoring_Indexify_deployment_performance_with_OpenTelemetry_integration.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/LoH3HVF" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Monitoring_and_managing_the_performance_of_Indexify_deployments_on_AWS_EKS.md
+++ b/docs/docs/answers/Monitoring_and_managing_the_performance_of_Indexify_deployments_on_AWS_EKS.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/hdsj5c9" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Navigating_Indexifys_UI_for_Effective_Debugging_and_Visualization.md
+++ b/docs/docs/answers/Navigating_Indexifys_UI_for_Effective_Debugging_and_Visualization.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/pOAlyCI" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Optimizing_AI_workflows_with_Indexify_over_Spark_for_faster_task_scheduling.md
+++ b/docs/docs/answers/Optimizing_AI_workflows_with_Indexify_over_Spark_for_faster_task_scheduling.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/kb6L4Pl" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Optimizing_API_server_setup_for_application_data_ingestion.md
+++ b/docs/docs/answers/Optimizing_API_server_setup_for_application_data_ingestion.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/MnhrSnk" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Optimizing_Indexify_service_performance_through_detailed_log_analysis_in_Jaeger.md
+++ b/docs/docs/answers/Optimizing_Indexify_service_performance_through_detailed_log_analysis_in_Jaeger.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/vkhrEEg" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Optimizing_Indexifys_performance_through_Rust_compiler_tools.md
+++ b/docs/docs/answers/Optimizing_Indexifys_performance_through_Rust_compiler_tools.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/7spdvYl" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Optimizing_Search_and_Filter_Strategies_using_Indexifys_Content_Section.md
+++ b/docs/docs/answers/Optimizing_Search_and_Filter_Strategies_using_Indexifys_Content_Section.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/bUhSMJt" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Optimizing_asset_management_in_digital_asset_management_systems.md
+++ b/docs/docs/answers/Optimizing_asset_management_in_digital_asset_management_systems.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/Z4EmPqG" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Optimizing_content_discovery_for_digital_libraries_with_OpenAI_Embedding.md
+++ b/docs/docs/answers/Optimizing_content_discovery_for_digital_libraries_with_OpenAI_Embedding.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/aq6bJzt" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Optimizing_content_ingestion_workflows_by_analyzing_upload_metrics.md
+++ b/docs/docs/answers/Optimizing_content_ingestion_workflows_by_analyzing_upload_metrics.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/bi6Xjp8" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Optimizing_data_ingestion_workflows_with_Indexifys_Coordinator_Server.md
+++ b/docs/docs/answers/Optimizing_data_ingestion_workflows_with_Indexifys_Coordinator_Server.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/skivtES" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Optimizing_e_commerce_platforms_by_extracting_product_details_from_PDF_catalogs.md
+++ b/docs/docs/answers/Optimizing_e_commerce_platforms_by_extracting_product_details_from_PDF_catalogs.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/yPZSvtq" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Optimizing_e_learning_platforms_with_searchable_lecture_archives.md
+++ b/docs/docs/answers/Optimizing_e_learning_platforms_with_searchable_lecture_archives.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/3pqMoEv" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Optimizing_ecommerce_platforms_by_extracting_product_details_from_PDF_catalogs.md
+++ b/docs/docs/answers/Optimizing_ecommerce_platforms_by_extracting_product_details_from_PDF_catalogs.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/yPZSvtq" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Optimizing_elearning_platforms_with_searchable_lecture_archives.md
+++ b/docs/docs/answers/Optimizing_elearning_platforms_with_searchable_lecture_archives.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/3pqMoEv" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Optimizing_internal_wiki_search_functionality_with_Haystack_and_Indexify.md
+++ b/docs/docs/answers/Optimizing_internal_wiki_search_functionality_with_Haystack_and_Indexify.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/8Vy9zEg" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Optimizing_retail_inventory_with_visual_searches_for_object_detection_in_images.md
+++ b/docs/docs/answers/Optimizing_retail_inventory_with_visual_searches_for_object_detection_in_images.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/bIZ4GCn" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Optimizing_retail_shelf_management_with_AI_driven_product_identification.md
+++ b/docs/docs/answers/Optimizing_retail_shelf_management_with_AI_driven_product_identification.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/mEnUPvn" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Optimizing_retail_shelf_management_with_AIdriven_product_identification.md
+++ b/docs/docs/answers/Optimizing_retail_shelf_management_with_AIdriven_product_identification.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/mEnUPvn" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Optimizing_search_engines_with_Indexify_by_structured_content_tagging.md
+++ b/docs/docs/answers/Optimizing_search_engines_with_Indexify_by_structured_content_tagging.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/RdVl8we" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Optimizing_the_cost_of_Indexify_deployments_on_AWS_using_Terraform_automation.md
+++ b/docs/docs/answers/Optimizing_the_cost_of_Indexify_deployments_on_AWS_using_Terraform_automation.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/LymxfWk" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Packaging_and_deploying_custom_extractors_for_specialized_content_analysis.md
+++ b/docs/docs/answers/Packaging_and_deploying_custom_extractors_for_specialized_content_analysis.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/3J1krIn" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Powering_long_form_text_analysis_with_Jinas_embedding_model.md
+++ b/docs/docs/answers/Powering_long_form_text_analysis_with_Jinas_embedding_model.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/ZToKEOl" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Powering_longform_text_analysis_with_Jinas_embedding_model.md
+++ b/docs/docs/answers/Powering_longform_text_analysis_with_Jinas_embedding_model.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/ZToKEOl" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Processing_legal_documents_for_quick_reference_in_law_firms.md
+++ b/docs/docs/answers/Processing_legal_documents_for_quick_reference_in_law_firms.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/nJk4zSk" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Producing_rich_metadata_for_audio_content_libraries.md
+++ b/docs/docs/answers/Producing_rich_metadata_for_audio_content_libraries.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/d0aQNEq" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Querying_and_Visualizing_Content_with_Indexifys_Indexes_Section.md
+++ b/docs/docs/answers/Querying_and_Visualizing_Content_with_Indexifys_Indexes_Section.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/hjBMx6s" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Rapid_legal_document_retrieval_through_semantic_search_for_law_firms.md
+++ b/docs/docs/answers/Rapid_legal_document_retrieval_through_semantic_search_for_law_firms.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/GLXw43L" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Refining_Indexify_cluster_operations_based_on_tasks_completed_metrics.md
+++ b/docs/docs/answers/Refining_Indexify_cluster_operations_based_on_tasks_completed_metrics.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/Vx9kzLs" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Running_Indexify_in_development_mode_for_quick_testing_and_prototyping.md
+++ b/docs/docs/answers/Running_Indexify_in_development_mode_for_quick_testing_and_prototyping.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/weiWJA0" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Running_Indexify_integration_tests_for_quality_assurance.md
+++ b/docs/docs/answers/Running_Indexify_integration_tests_for_quality_assurance.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/XGQ11BI" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Scaling_Indexify_deployments_by_tracking_online_executors.md
+++ b/docs/docs/answers/Scaling_Indexify_deployments_by_tracking_online_executors.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/KBPwTCw" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Securing_Indexify_deployments_in_AWS_EKS_with_best_practices_guide.md
+++ b/docs/docs/answers/Securing_Indexify_deployments_in_AWS_EKS_with_best_practices_guide.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/fsM6xvL" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Securing_Indexifys_API_Server_with_SSL_Configuration.md
+++ b/docs/docs/answers/Securing_Indexifys_API_Server_with_SSL_Configuration.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/wPzs0eh" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Separating_ingestion_and_coordination_duties_on_Indexify_for_scalable_data_handling.md
+++ b/docs/docs/answers/Separating_ingestion_and_coordination_duties_on_Indexify_for_scalable_data_handling.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/X9WM1gF" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Setting_up_Indexify_Vector_Index_Storage_for_efficient_search_capabilities.md
+++ b/docs/docs/answers/Setting_up_Indexify_Vector_Index_Storage_for_efficient_search_capabilities.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/UVTTPau" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Setting_up_Indexifys_ingesting_and_coordination_servers_for_data_processing.md
+++ b/docs/docs/answers/Setting_up_Indexifys_ingesting_and_coordination_servers_for_data_processing.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/MN8c6kx" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Setting_up_a_local_Indexify_server_for_content_ingestion.md
+++ b/docs/docs/answers/Setting_up_a_local_Indexify_server_for_content_ingestion.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/Wf289d5" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Setting_up_a_local_development_environment_for_Indexify.md
+++ b/docs/docs/answers/Setting_up_a_local_development_environment_for_Indexify.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/qCdrZXI" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Setting_up_comprehensive_monitoring_for_Indexify_applications_with_Prometheus_and_Grafana.md
+++ b/docs/docs/answers/Setting_up_comprehensive_monitoring_for_Indexify_applications_with_Prometheus_and_Grafana.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/0TRVTh7" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Simplifying_the_setup_of_Indexify_servers_for_new_users.md
+++ b/docs/docs/answers/Simplifying_the_setup_of_Indexify_servers_for_new_users.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/XGDdgUM" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Speeding_up_contract_review_processes_with_specialized_PDF_extractors.md
+++ b/docs/docs/answers/Speeding_up_contract_review_processes_with_specialized_PDF_extractors.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/Mx4Ga0t" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Streamlining_AI_infrastructure_with_Indexifys_fault_tolerant_distributed_orchestration_engine.md
+++ b/docs/docs/answers/Streamlining_AI_infrastructure_with_Indexifys_fault_tolerant_distributed_orchestration_engine.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/DGCOlFm" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Streamlining_AI_infrastructure_with_Indexifys_faulttolerant_distributed_orchestration_engine.md
+++ b/docs/docs/answers/Streamlining_AI_infrastructure_with_Indexifys_faulttolerant_distributed_orchestration_engine.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/DGCOlFm" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Streamlining_Indexify_deployments_on_cloud_with_Terraform_for_enhanced_productivity.md
+++ b/docs/docs/answers/Streamlining_Indexify_deployments_on_cloud_with_Terraform_for_enhanced_productivity.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/Xdw1XZL" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Streamlining_content_creation_by_extracting_and_repurposing_video_captions.md
+++ b/docs/docs/answers/Streamlining_content_creation_by_extracting_and_repurposing_video_captions.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/MD7L4uW" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Streamlining_content_ingestion_for_news_aggregation_services.md
+++ b/docs/docs/answers/Streamlining_content_ingestion_for_news_aggregation_services.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/tXlW86Z" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Streamlining_content_moderation_for_audio_platforms_with_transcription_analysis.md
+++ b/docs/docs/answers/Streamlining_content_moderation_for_audio_platforms_with_transcription_analysis.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/BRGxNnS" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Streamlining_content_updates_and_deletions_in_sports_databases.md
+++ b/docs/docs/answers/Streamlining_content_updates_and_deletions_in_sports_databases.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/HTXbPkh" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Streamlining_data_ingestion_and_indexing_processes_in_multi_source_environments.md
+++ b/docs/docs/answers/Streamlining_data_ingestion_and_indexing_processes_in_multi_source_environments.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/v2p7iHZ" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Streamlining_data_ingestion_and_indexing_processes_in_multisource_environments.md
+++ b/docs/docs/answers/Streamlining_data_ingestion_and_indexing_processes_in_multisource_environments.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/v2p7iHZ" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Streamlining_database_queries_with_SQL_on_metadata_from_images.md
+++ b/docs/docs/answers/Streamlining_database_queries_with_SQL_on_metadata_from_images.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/1gI51l1" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Streamlining_document_retrieval_in_corporate_knowledge_bases.md
+++ b/docs/docs/answers/Streamlining_document_retrieval_in_corporate_knowledge_bases.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/FTWvJa9" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Streamlining_document_search_in_corporate_environments_with_Haystack_integration.md
+++ b/docs/docs/answers/Streamlining_document_search_in_corporate_environments_with_Haystack_integration.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/ldnwNWC" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Streamlining_e_discovery_by_extracting_and_indexing_legal_document_contents.md
+++ b/docs/docs/answers/Streamlining_e_discovery_by_extracting_and_indexing_legal_document_contents.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/lvn4Mfw" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Streamlining_ediscovery_by_extracting_and_indexing_legal_document_contents.md
+++ b/docs/docs/answers/Streamlining_ediscovery_by_extracting_and_indexing_legal_document_contents.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/lvn4Mfw" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Streamlining_factory_automation_with_machinery_and_component_visual_inspection.md
+++ b/docs/docs/answers/Streamlining_factory_automation_with_machinery_and_component_visual_inspection.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/qnnjhcs" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Streamlining_legal_document_analysis_with_tailored_PDF_extractors.md
+++ b/docs/docs/answers/Streamlining_legal_document_analysis_with_tailored_PDF_extractors.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/2PIhs4w" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Streamlining_legal_document_search_and_retrieval_systems.md
+++ b/docs/docs/answers/Streamlining_legal_document_search_and_retrieval_systems.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/T6VRydi" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Streamlining_legal_documentation_by_transcribing_courtroom_audio_with_Indexify.md
+++ b/docs/docs/answers/Streamlining_legal_documentation_by_transcribing_courtroom_audio_with_Indexify.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/erIDGhp" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Streamlining_medical_research_with_indexed_and_searchable_clinical_trial_documents.md
+++ b/docs/docs/answers/Streamlining_medical_research_with_indexed_and_searchable_clinical_trial_documents.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/JswGK38" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Streamlining_stock_image_retrieval_with_advanced_filtering_options.md
+++ b/docs/docs/answers/Streamlining_stock_image_retrieval_with_advanced_filtering_options.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/T39XLYc" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Streamlining_the_process_of_PDF_data_extraction_for_research_projects.md
+++ b/docs/docs/answers/Streamlining_the_process_of_PDF_data_extraction_for_research_projects.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/uRLFVti" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Streamlining_your_data_pipeline_with_Indexifys_server_CLI.md
+++ b/docs/docs/answers/Streamlining_your_data_pipeline_with_Indexifys_server_CLI.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/eM46WD2" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Supporting_academic_research_through_precise_image_dataset_curation.md
+++ b/docs/docs/answers/Supporting_academic_research_through_precise_image_dataset_curation.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/syPIY5T" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Transcribing_historical_oral_archives_for_digital_preservation_and_search.md
+++ b/docs/docs/answers/Transcribing_historical_oral_archives_for_digital_preservation_and_search.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/bEaH2RE" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Transforming_car_rental_agreements_into_digital_formats_for_quicker_access.md
+++ b/docs/docs/answers/Transforming_car_rental_agreements_into_digital_formats_for_quicker_access.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/Bl6oUOa" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Troubleshooting_Indexify_service_issues_with_flamegraphs_in_Jaeger.md
+++ b/docs/docs/answers/Troubleshooting_Indexify_service_issues_with_flamegraphs_in_Jaeger.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/Qy0ttEy" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Troubleshooting_Indexify_tasks_with_errored_tasks_metrics.md
+++ b/docs/docs/answers/Troubleshooting_Indexify_tasks_with_errored_tasks_metrics.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/Np3pt15" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Tweaking_Cache_Settings_in_Indexify_for_Performance_Optimization.md
+++ b/docs/docs/answers/Tweaking_Cache_Settings_in_Indexify_for_Performance_Optimization.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/CsalMrc" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Understanding_Content_Relationships_with_Indexifys_Content_Graph_Visualization.md
+++ b/docs/docs/answers/Understanding_Content_Relationships_with_Indexifys_Content_Graph_Visualization.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/rducPcE" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Upgrading_research_paper_search_capabilities_in_digital_libraries_with_Haystack.md
+++ b/docs/docs/answers/Upgrading_research_paper_search_capabilities_in_digital_libraries_with_Haystack.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/Fs0ja3l" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Upgrading_security_systems_with_real_time_object_detection_in_video_streams.md
+++ b/docs/docs/answers/Upgrading_security_systems_with_real_time_object_detection_in_video_streams.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/os3MFar" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Upgrading_security_systems_with_realtime_object_detection_in_video_streams.md
+++ b/docs/docs/answers/Upgrading_security_systems_with_realtime_object_detection_in_video_streams.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/os3MFar" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Uploading_and_indexing_large_datasets_for_academic_research_projects.md
+++ b/docs/docs/answers/Uploading_and_indexing_large_datasets_for_academic_research_projects.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/uU7eR1S" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Using_Indexify_for_Langchain_based_Retrieval_Augmented_Generation_RAG_applications.md
+++ b/docs/docs/answers/Using_Indexify_for_Langchain_based_Retrieval_Augmented_Generation_RAG_applications.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/Fel12D0" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Using_Indexify_for_Langchainbased_RetrievalAugmented_Generation_RAG_applications.md
+++ b/docs/docs/answers/Using_Indexify_for_Langchainbased_RetrievalAugmented_Generation_RAG_applications.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/Fel12D0" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Using_Indexifys_compute_engine_for_efficient_generative_AI_application_development.md
+++ b/docs/docs/answers/Using_Indexifys_compute_engine_for_efficient_generative_AI_application_development.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/SpoAVE5" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Using_OpenAI_CLIP_for_multimodal_product_search_in_e_commerce.md
+++ b/docs/docs/answers/Using_OpenAI_CLIP_for_multimodal_product_search_in_e_commerce.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/pktSZFE" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Using_OpenAI_CLIP_for_multimodal_product_search_in_ecommerce.md
+++ b/docs/docs/answers/Using_OpenAI_CLIP_for_multimodal_product_search_in_ecommerce.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/pktSZFE" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Using_RAG_for_generating_specific_athlete_profiles_from_unstructured_data.md
+++ b/docs/docs/answers/Using_RAG_for_generating_specific_athlete_profiles_from_unstructured_data.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/vDzhoCs" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Using_Rust_and_Python_to_extend_Indexifys_capabilities.md
+++ b/docs/docs/answers/Using_Rust_and_Python_to_extend_Indexifys_capabilities.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/0RKjWcv" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Using_chained_extraction_policies_for_complex_document_analysis_workflows.md
+++ b/docs/docs/answers/Using_chained_extraction_policies_for_complex_document_analysis_workflows.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/b1Cyxvm" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Utilizing_Indexifys_Search_Functionality_for_Efficient_Content_Retrieval.md
+++ b/docs/docs/answers/Utilizing_Indexifys_Search_Functionality_for_Efficient_Content_Retrieval.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/Y9BjZCy" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/answers/Visualizing_Indexify_service_operation_using_Jaeger_for_trace_analysis.md
+++ b/docs/docs/answers/Visualizing_Indexify_service_operation_using_Jaeger_for_trace_analysis.md
@@ -1,0 +1,4 @@
+#
+<iframe id="indexifybot" src="https://indexify.cortexclick.com/chat/Yc6lbX9" width="1000" height="1000"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> <script>
+                            iFrameResize({}, '#indexifybot')
+                        </script>

--- a/docs/docs/ask.md
+++ b/docs/docs/ask.md
@@ -1,0 +1,5 @@
+#
+<iframe src="https://indexify.cortexclick.com" height="1000" width="1000" id="indexifybot"></iframe> <script referrerpolicy="no-referrer" crossorigin="anonymous" integrity="sha512-+bpyZqiNr/4QlUd6YnrAeLXzgooA1HKN5yUagHgPSMACPZgj8bkpCyZezPtDy5XbviRm4w8Z1RhfuWyoWaeCyg==" src="https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.9/iframeResizer.min.js"></script> 
+<script>
+    iFrameResize({}, '#indexifybot')
+</script>

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -30,6 +30,7 @@ nav:
     - Getting Started: 'getting_started.md'
     - Key Concepts: 'concepts.md'
     - Comparisons: 'comparisons.md'
+  - Ask Indexify: ask.md
   - CLI and UI:
     - User Interface: 'ui.md'
     - Extractor CLI: 'extractor_cli.md'


### PR DESCRIPTION
This PR integrates Cortex Click into the Indexify website. First it adds a new path under `/ask` that contains the chatbot:

<img width="1470" alt="image" src="https://github.com/tensorlakeai/indexify/assets/2553171/0c613b4a-9d1b-4c75-95e2-7f7e4983386c">

Second, it publishes the 300 blog posts under `/answers/{post-title}`:

<img width="1500" alt="image" src="https://github.com/tensorlakeai/indexify/assets/2553171/5146ff56-854a-48a3-a76b-319deb82d7e3">

The `ask` page is available via the top nav header. Happy to rename or reorder it if you have opinions on this. The individual posts are not exposed via any nav, but are in the sitemap and can be indexed by google. 

Cortex Click pages are embedded via a simple `iframe`. `mkdocs` does not have a public API, so any page on the site need to be a checked in markdown file. 

I didn't have the necessary public API available to turn this into a public github action or script, as I had to use private APIs and credentials. Given that, I've committed the script that generated these pages to a repo in my org, and can rerun it ad-hoc for the time being if we need to publish more posts. Once I finish the public API to list published pages with the necessary metadata (title, etc), I'll circle back and turn this into a build step so that new pages are fetched and generated at build time. 
