### PR TITLE
Change The Way Content Id Is Generated

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -146,6 +146,7 @@ pub struct ExtractionPolicyResponse {
 
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
 pub struct Text {
+    pub id: Option<String>,
     pub text: String,
     #[serde(default)]
     pub labels: HashMap<String, String>,
@@ -440,6 +441,13 @@ impl From<internal_api::Feature> for Feature {
             data: feature.data,
         }
     }
+}
+
+#[serde_as]
+#[derive(Debug, Serialize, Deserialize, Clone, ToSchema)]
+pub struct ContentWithId {
+    pub id: String,
+    pub content: Content,
 }
 
 #[serde_as]

--- a/src/coordinator.rs
+++ b/src/coordinator.rs
@@ -8,7 +8,11 @@ use anyhow::{anyhow, Ok, Result};
 use indexify_internal_api as internal_api;
 use indexify_proto::indexify_coordinator;
 use internal_api::{
-    ContentMetadataId, GarbageCollectionTask, OutputSchema, StateChange, StructuredDataSchema,
+    ContentMetadataId,
+    GarbageCollectionTask,
+    OutputSchema,
+    StateChange,
+    StructuredDataSchema,
 };
 use jsonschema::JSONSchema;
 use tokio::sync::{broadcast, watch::Receiver};

--- a/src/coordinator.rs
+++ b/src/coordinator.rs
@@ -1812,7 +1812,6 @@ mod tests {
         .into_iter()
         .collect();
         assert_eq!(old_tree_ids, old_tree_ids_expected);
-
         let new_tree_ids = new_content_tree
             .iter()
             .map(|c| c.id.id.clone())
@@ -1826,6 +1825,16 @@ mod tests {
         .into_iter()
         .collect();
         assert_eq!(new_tree_ids, new_tree_ids_expected);
+
+        //  check the reverse index invariants
+        let old_tree_children = coordinator.shared_state.state_machine.get_content_children(
+            &indexify_internal_api::ContentMetadataId::new_with_version("test_parent_id", 1),
+        );
+        let new_tree_children = coordinator.shared_state.state_machine.get_content_children(
+            &indexify_internal_api::ContentMetadataId::new_with_version("test_parent_id", 2),
+        );
+        assert_eq!(old_tree_children.len(), 2);
+        assert_eq!(new_tree_children.len(), 3);
 
         //  running the scheduler should garbage collect the old tree
         coordinator.run_scheduler().await?;

--- a/src/coordinator.rs
+++ b/src/coordinator.rs
@@ -1570,7 +1570,7 @@ mod tests {
     }
 
     #[tokio::test]
-    // #[tracing_test::traced_test]
+    #[tracing_test::traced_test]
     async fn test_content_update() -> Result<(), anyhow::Error> {
         let (coordinator, _) = setup_coordinator().await;
 
@@ -1650,10 +1650,7 @@ mod tests {
             .await?;
         coordinator.run_scheduler().await?;
         let all_tasks = coordinator.shared_state.list_all_unfinished_tasks().await?;
-        println!(
-            "Tasks after creating the first version of the root node {:#?}",
-            parent_content
-        );
+        assert_eq!(all_tasks.len(), 1);
         for mut task in all_tasks {
             task.outcome = internal_api::TaskOutcome::Success;
             coordinator

--- a/src/data_manager.rs
+++ b/src/data_manager.rs
@@ -25,7 +25,9 @@ use crate::{
     grpc_helper::GrpcHelper,
     metadata_storage::{
         query_engine::{run_query, StructuredDataRow},
-        ExtractedMetadata, MetadataReaderTS, MetadataStorageTS,
+        ExtractedMetadata,
+        MetadataReaderTS,
+        MetadataStorageTS,
     },
     vector_index::{ScoredText, VectorIndexManager},
 };
@@ -468,7 +470,7 @@ impl DataManager {
 
     /// Checks if the given string is a valid hexadecimal.
     pub fn is_hex_string(s: &str) -> bool {
-        s.chars().all(|c| c.is_digit(16))
+        s.chars().all(|c| c.is_ascii_hexdigit())
     }
 
     async fn write_content_bytes(

--- a/src/data_manager.rs
+++ b/src/data_manager.rs
@@ -25,7 +25,9 @@ use crate::{
     grpc_helper::GrpcHelper,
     metadata_storage::{
         query_engine::{run_query, StructuredDataRow},
-        ExtractedMetadata, MetadataReaderTS, MetadataStorageTS,
+        ExtractedMetadata,
+        MetadataReaderTS,
+        MetadataStorageTS,
     },
     vector_index::{ScoredText, VectorIndexManager},
 };

--- a/src/data_manager.rs
+++ b/src/data_manager.rs
@@ -25,9 +25,7 @@ use crate::{
     grpc_helper::GrpcHelper,
     metadata_storage::{
         query_engine::{run_query, StructuredDataRow},
-        ExtractedMetadata,
-        MetadataReaderTS,
-        MetadataStorageTS,
+        ExtractedMetadata, MetadataReaderTS, MetadataStorageTS,
     },
     vector_index::{ScoredText, VectorIndexManager},
 };
@@ -466,6 +464,11 @@ impl DataManager {
         let id = nanoid!(16);
         id.hash(&mut s);
         format!("{:x}", s.finish())
+    }
+
+    /// Checks if the given string is a valid hexadecimal.
+    pub fn is_hex_string(s: &str) -> bool {
+        s.chars().all(|c| c.is_digit(16))
     }
 
     async fn write_content_bytes(

--- a/src/data_manager.rs
+++ b/src/data_manager.rs
@@ -1,7 +1,7 @@
 use std::{
-    collections::{hash_map::DefaultHasher, HashMap},
+    collections::HashMap,
     fmt,
-    hash::{Hash, Hasher},
+    hash::{DefaultHasher, Hash, Hasher},
     str::FromStr,
     sync::Arc,
     time::SystemTime,
@@ -25,9 +25,7 @@ use crate::{
     grpc_helper::GrpcHelper,
     metadata_storage::{
         query_engine::{run_query, StructuredDataRow},
-        ExtractedMetadata,
-        MetadataReaderTS,
-        MetadataStorageTS,
+        ExtractedMetadata, MetadataReaderTS, MetadataStorageTS,
     },
     vector_index::{ScoredText, VectorIndexManager},
 };
@@ -251,8 +249,13 @@ impl DataManager {
     }
 
     #[tracing::instrument(skip(self, content_list))]
-    pub async fn add_texts(&self, namespace: &str, content_list: Vec<api::Content>) -> Result<()> {
-        for text in content_list {
+    pub async fn add_texts(
+        &self,
+        namespace: &str,
+        content_list: Vec<api::ContentWithId>,
+    ) -> Result<()> {
+        for content_with_id in content_list {
+            let text = content_with_id.content;
             let stream = futures::stream::once(async { Ok(Bytes::from(text.bytes)) });
             let content_metadata = self
                 .write_content_bytes(
@@ -263,7 +266,7 @@ impl DataManager {
                     None,
                     None,
                     "ingestion",
-                    None,
+                    Some(&content_with_id.id),
                 )
                 .await?;
 
@@ -456,13 +459,10 @@ impl DataManager {
         file_name.map(|f| f.to_string()).unwrap_or(nanoid!())
     }
 
-    pub fn make_id(namespace: &str, parent_id: &Option<String>, content_hash: &str) -> String {
+    pub fn make_id() -> String {
         let mut s = DefaultHasher::new();
-        namespace.hash(&mut s);
-        if let Some(parent_id) = &parent_id {
-            parent_id.hash(&mut s);
-        }
-        content_hash.hash(&mut s);
+        let id = nanoid!(16);
+        id.hash(&mut s);
         format!("{:x}", s.finish())
     }
 
@@ -505,7 +505,7 @@ impl DataManager {
             .map(|(k, v)| (k, v.to_string()))
             .collect();
 
-        let mut id = DataManager::make_id(namespace, &parent_id, &content_hash);
+        let mut id = DataManager::make_id();
         if original_content_id.is_some() {
             id = original_content_id.unwrap().to_string();
         }

--- a/src/ingest_extracted_content.rs
+++ b/src/ingest_extracted_content.rs
@@ -173,11 +173,7 @@ impl IngestExtractedContentState {
                 let metadata = self.ingest_metadata.as_ref().unwrap();
                 let hash_result = frame_state.hasher.clone().finalize();
                 let content_hash = format!("{:x}", hash_result);
-                let id = DataManager::make_id(
-                    &metadata.namespace,
-                    &Some(metadata.parent_content_id.clone()),
-                    &content_hash,
-                );
+                let id = DataManager::make_id();
                 let content_metadata = indexify_coordinator::ContentMetadata {
                     id: id.clone(),
                     file_name: frame_state.file_name.clone(),

--- a/src/ingest_extracted_content.rs
+++ b/src/ingest_extracted_content.rs
@@ -9,18 +9,13 @@ use sha2::{
         core_api::{CoreWrapper, CtVariableCoreWrapper},
         typenum::{UInt, UTerm},
     },
-    Digest,
-    OidSha256,
-    Sha256,
-    Sha256VarCore,
+    Digest, OidSha256, Sha256, Sha256VarCore,
 };
 use tokio::io::AsyncWriteExt;
 use tracing::info;
 
 use crate::{
-    api::*,
-    blob_storage::StoragePartWriter,
-    data_manager::DataManager,
+    api::*, blob_storage::StoragePartWriter, data_manager::DataManager,
     server::NamespaceEndpointState,
 };
 
@@ -169,7 +164,6 @@ impl IngestExtractedContentState {
             "received finish multipart content for task: {}",
             self.ingest_metadata.as_ref().unwrap().task_id
         );
-        // let mut ret_id = None;
         match &mut self.frame_state {
             FrameState::New => Err(anyhow!(
                 "received finish content without any content frames"

--- a/src/ingest_extracted_content.rs
+++ b/src/ingest_extracted_content.rs
@@ -9,13 +9,18 @@ use sha2::{
         core_api::{CoreWrapper, CtVariableCoreWrapper},
         typenum::{UInt, UTerm},
     },
-    Digest, OidSha256, Sha256, Sha256VarCore,
+    Digest,
+    OidSha256,
+    Sha256,
+    Sha256VarCore,
 };
 use tokio::io::AsyncWriteExt;
 use tracing::info;
 
 use crate::{
-    api::*, blob_storage::StoragePartWriter, data_manager::DataManager,
+    api::*,
+    blob_storage::StoragePartWriter,
+    data_manager::DataManager,
     server::NamespaceEndpointState,
 };
 

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -619,6 +619,12 @@ pub mod metadata_storage {
         pub metadata_deleted: Histogram<f64>,
     }
 
+    impl Default for Metrics {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
+
     impl Metrics {
         pub fn new() -> Metrics {
             let meter = opentelemetry::global::meter("indexify-index");
@@ -663,6 +669,12 @@ pub mod vector_storage {
         pub vector_delete: Histogram<f64>,
     }
 
+    impl Default for Metrics {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
+
     impl Metrics {
         pub fn new() -> Metrics {
             let meter = opentelemetry::global::meter("indexify-index");
@@ -697,6 +709,12 @@ pub mod state_machine {
     #[derive(Debug)]
     pub struct Metrics {
         pub state_machine_apply: Histogram<f64>,
+    }
+
+    impl Default for Metrics {
+        fn default() -> Self {
+            Self::new()
+        }
     }
 
     impl Metrics {

--- a/src/server.rs
+++ b/src/server.rs
@@ -7,9 +7,7 @@ use axum::{
     http::StatusCode,
     response::{IntoResponse, Response},
     routing::{delete, get, post, put},
-    Extension,
-    Json,
-    Router,
+    Extension, Json, Router,
 };
 use axum_otel_metrics::HttpMetricsLayerBuilder;
 use axum_server::Handle;
@@ -18,10 +16,7 @@ use axum_typed_websockets::WebSocketUpgrade;
 use hyper::{header::CONTENT_TYPE, Method};
 use indexify_internal_api as internal_api;
 use indexify_proto::indexify_coordinator::{
-    self,
-    GcTaskAcknowledgement,
-    ListStateChangesRequest,
-    ListTasksRequest,
+    self, GcTaskAcknowledgement, ListStateChangesRequest, ListTasksRequest,
 };
 use prometheus::Encoder;
 use rust_embed::RustEmbed;
@@ -565,14 +560,33 @@ async fn add_texts(
     State(state): State<NamespaceEndpointState>,
     Json(payload): Json<TextAddRequest>,
 ) -> Result<Json<TextAdditionResponse>, IndexifyAPIError> {
+    for document in &payload.documents {
+        if let Some(id) = &document.id {
+            let retrieved_content = state
+                .data_manager
+                .get_content_metadata(&namespace, vec![id.clone()])
+                .await
+                .map_err(IndexifyAPIError::internal_error)?;
+            if !retrieved_content.is_empty() {
+                return Err(IndexifyAPIError::new(
+                    StatusCode::BAD_REQUEST,
+                    &format!("content with the provided id {} already exists", id),
+                ));
+            }
+        }
+    }
+
     let content = payload
         .documents
         .iter()
-        .map(|d| api::Content {
-            content_type: mime::TEXT_PLAIN.to_string(),
-            bytes: d.text.as_bytes().to_vec(),
-            labels: d.labels.clone(),
-            features: vec![],
+        .map(|d| api::ContentWithId {
+            id: d.id.clone().unwrap_or_else(|| DataManager::make_id()),
+            content: api::Content {
+                content_type: mime::TEXT_PLAIN.to_string(),
+                bytes: d.text.as_bytes().to_vec(),
+                labels: d.labels.clone(),
+                features: vec![],
+            },
         })
         .collect();
     state
@@ -781,8 +795,27 @@ async fn download_content(
 async fn upload_file(
     Path(namespace): Path<String>,
     State(state): State<NamespaceEndpointState>,
+    Query(params): Query<HashMap<String, String>>,
     mut files: Multipart,
 ) -> Result<(), IndexifyAPIError> {
+    let id = params
+        .get("id")
+        .cloned()
+        .unwrap_or_else(|| DataManager::make_id());
+
+    //  check if the id already exists for content metadata
+    let retrieved_content = state
+        .data_manager
+        .get_content_metadata(&namespace, vec![id.clone()])
+        .await
+        .map_err(IndexifyAPIError::internal_error)?;
+    if retrieved_content.len() != 0 {
+        return Err(IndexifyAPIError::new(
+            StatusCode::BAD_REQUEST,
+            "content with the provided id already exists",
+        ));
+    }
+
     while let Some(file) = files.next_field().await.unwrap() {
         let name = file
             .file_name()
@@ -809,7 +842,7 @@ async fn upload_file(
         let stream = file.map(|res| res.map_err(|err| anyhow::anyhow!(err)));
         let content_metadata = state
             .data_manager
-            .upload_file(&namespace, stream, &name, content_mime, None)
+            .upload_file(&namespace, stream, &name, content_mime, Some(&id))
             .await
             .map_err(|e| {
                 IndexifyAPIError::new(

--- a/src/server.rs
+++ b/src/server.rs
@@ -7,7 +7,9 @@ use axum::{
     http::StatusCode,
     response::{IntoResponse, Response},
     routing::{delete, get, post, put},
-    Extension, Json, Router,
+    Extension,
+    Json,
+    Router,
 };
 use axum_otel_metrics::HttpMetricsLayerBuilder;
 use axum_server::Handle;
@@ -16,7 +18,10 @@ use axum_typed_websockets::WebSocketUpgrade;
 use hyper::{header::CONTENT_TYPE, Method};
 use indexify_internal_api as internal_api;
 use indexify_proto::indexify_coordinator::{
-    self, GcTaskAcknowledgement, ListStateChangesRequest, ListTasksRequest,
+    self,
+    GcTaskAcknowledgement,
+    ListStateChangesRequest,
+    ListTasksRequest,
 };
 use prometheus::Encoder;
 use rust_embed::RustEmbed;

--- a/src/server.rs
+++ b/src/server.rs
@@ -7,7 +7,9 @@ use axum::{
     http::StatusCode,
     response::{IntoResponse, Response},
     routing::{delete, get, post, put},
-    Extension, Json, Router,
+    Extension,
+    Json,
+    Router,
 };
 use axum_otel_metrics::HttpMetricsLayerBuilder;
 use axum_server::Handle;
@@ -16,7 +18,10 @@ use axum_typed_websockets::WebSocketUpgrade;
 use hyper::{header::CONTENT_TYPE, Method};
 use indexify_internal_api as internal_api;
 use indexify_proto::indexify_coordinator::{
-    self, GcTaskAcknowledgement, ListStateChangesRequest, ListTasksRequest,
+    self,
+    GcTaskAcknowledgement,
+    ListStateChangesRequest,
+    ListTasksRequest,
 };
 use prometheus::Encoder;
 use rust_embed::RustEmbed;
@@ -580,7 +585,7 @@ async fn add_texts(
         .documents
         .iter()
         .map(|d| api::ContentWithId {
-            id: d.id.clone().unwrap_or_else(|| DataManager::make_id()),
+            id: d.id.clone().unwrap_or_else(DataManager::make_id),
             content: api::Content {
                 content_type: mime::TEXT_PLAIN.to_string(),
                 bytes: d.text.as_bytes().to_vec(),
@@ -801,7 +806,7 @@ async fn upload_file(
     let id = params
         .get("id")
         .cloned()
-        .unwrap_or_else(|| DataManager::make_id());
+        .unwrap_or_else(DataManager::make_id);
 
     //  check if the id already exists for content metadata
     let retrieved_content = state
@@ -809,7 +814,7 @@ async fn upload_file(
         .get_content_metadata(&namespace, vec![id.clone()])
         .await
         .map_err(IndexifyAPIError::internal_error)?;
-    if retrieved_content.len() != 0 {
+    if !retrieved_content.is_empty() {
         return Err(IndexifyAPIError::new(
             StatusCode::BAD_REQUEST,
             "content with the provided id already exists",

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -20,16 +20,12 @@ use network::Network;
 use openraft::{
     self,
     error::{InitializeError, RaftError},
-    BasicNode,
-    TokioRuntime,
+    BasicNode, TokioRuntime,
 };
 use serde::Serialize;
 use store::{
     requests::{RequestPayload, StateChangeProcessed, StateMachineUpdateRequest},
-    ExecutorId,
-    ExecutorIdRef,
-    Response,
-    TaskId,
+    ExecutorId, ExecutorIdRef, Response, TaskId,
 };
 use tokio::{
     sync::{
@@ -401,8 +397,9 @@ impl App {
             //  Check whether the sources match. Make an additional check in case the
             // content has  a source which is an extraction policy id instead of
             // a name
-            if extraction_policy.content_source != content_metadata.source &&
-                self.get_extraction_policy(&content_metadata.source)
+            if extraction_policy.content_source != content_metadata.source
+                && self
+                    .get_extraction_policy(&content_metadata.source)
                     .await
                     .map_or(true, |retrieved_extraction_policy| {
                         extraction_policy.content_source != retrieved_extraction_policy.name
@@ -505,8 +502,8 @@ impl App {
         for content in content_list {
             //  Check whether the sources match. Make an additional check in case the
             // content has a source which is an extraction policy id instead of a name
-            if content.source != extraction_policy.content_source &&
-                self.get_extraction_policy(&content.source).await.map_or(
+            if content.source != extraction_policy.content_source
+                && self.get_extraction_policy(&content.source).await.map_or(
                     true,
                     |retrieved_extraction_policy| {
                         extraction_policy.content_source != retrieved_extraction_policy.name
@@ -916,131 +913,144 @@ impl App {
             .map(|c| (c.id.id.to_string(), c))
             .collect();
 
+        let mut new_content: Vec<internal_api::ContentMetadata> = Vec::new();
+        let mut content_to_update: Vec<internal_api::ContentMetadata> = Vec::new();
         let mut identical_content: Vec<internal_api::ContentMetadata> = Vec::new();
-        let mut content_to_be_updated: Vec<internal_api::ContentMetadata> = Vec::new();
-        let mut new_incoming_content: Vec<internal_api::ContentMetadata> = Vec::new();
 
-        for new_content in content_metadata {
-            if let Some(existing_content) = existing_content_map.get(&new_content.id.id.to_string())
+        for incoming_content in content_metadata {
+            if let Some(existing_content) =
+                existing_content_map.get(&incoming_content.id.id.to_string())
             {
-                //  some existing piece of content
-                if existing_content.hash != new_content.hash {
-                    //  the content has been updated
-                    let mut new_content = new_content.clone();
-                    new_content.id.version = existing_content.id.version + 1;
-                    content_to_be_updated.push(new_content);
+                if existing_content.hash != incoming_content.hash {
+                    //  this is a root node that is being updated
+                    let mut incoming_content = incoming_content.clone();
+                    incoming_content.id.version += 1;
+                    content_to_update.push(incoming_content);
                 } else {
-                    //  the content has not changed
-                    identical_content.push(new_content);
+                    tracing::warn!("Content with the same id and hash has been received");
                 }
-            } else {
-                //  this is fresh content
-                new_incoming_content.push(new_content);
+                continue;
             }
-        }
+            //  this is not some root node being updated
 
-        //  handle identical content
-        if !identical_content.is_empty() {
-            //  If the content is identical, find the latest version of the parent and flip
-            // the content node in the db with the same id to point to the new parent
-            let mut content_to_write = Vec::new();
-            for content in identical_content {
-                let latest_version_of_parent = self
-                    .state_machine
-                    .get_latest_version_of_content(&content.parent_id.id)
-                    .map_err(|e| {
-                        anyhow!(
-                            "Unable to get latest version of content {}: {}",
-                            content.parent_id,
-                            e
-                        )
-                    })?;
-                if latest_version_of_parent.is_none() {
-                    continue;
-                }
-                let latest_version_of_parent = latest_version_of_parent.unwrap();
-                let mut old_node = existing_content_map
-                    .get(&content.id.id.to_string())
-                    .unwrap()
-                    .clone();
-                old_node.parent_id = ContentMetadataId::new_with_version(
-                    &content.parent_id.id,
+            //  if the parent doesn't exist, create the content
+            if incoming_content.parent_id.id.is_empty() {
+                new_content.push(incoming_content);
+                continue;
+            }
+
+            //  find the latest version of the parent
+            let latest_version_of_parent = self
+                .state_machine
+                .get_latest_version_of_content(&incoming_content.parent_id.id)
+                .map_err(|e| {
+                    anyhow!(
+                        "Unable to get latest version of content {}: {}",
+                        incoming_content.parent_id,
+                        e
+                    )
+                })?;
+            if latest_version_of_parent.is_none() {
+                return Err(anyhow!(
+                    "Parent content with id {} not found",
+                    incoming_content.parent_id.id
+                ));
+            }
+            let latest_version_of_parent = latest_version_of_parent.unwrap();
+
+            //  if the latest version of the parent is the first version, create the content
+            if latest_version_of_parent == 1 {
+                new_content.push(incoming_content);
+                continue;
+            }
+
+            //  if the parent predecessor cannot be found or has no children, create the content
+            let parent_prev_version_id = ContentMetadataId::new_with_version(
+                &incoming_content.parent_id.id,
+                latest_version_of_parent - 1,
+            );
+            let parent_prev_version_tree = self
+                .state_machine
+                .get_content_tree_metadata_with_version(&parent_prev_version_id)
+                .map_err(|e| {
+                    anyhow!(
+                        "Unable to get content tree metadata with id {}: {}",
+                        parent_prev_version_id,
+                        e
+                    )
+                })?;
+            if parent_prev_version_tree.len() <= 1 {
+                let mut content = incoming_content.clone();
+                content.parent_id = ContentMetadataId::new_with_version(
+                    &incoming_content.parent_id.id,
                     latest_version_of_parent,
                 );
-                content_to_write.push(old_node);
+                new_content.push(content);
+                continue;
             }
+
+            //  compare the hashes of the predecessor's children to the incoming content's hash - if there is a match, flip the pointers because this is identical content
+            let content_with_matching_hash = parent_prev_version_tree
+                .iter()
+                .find(|content| content.hash == incoming_content.hash);
+            if content_with_matching_hash.is_none() {
+                let mut content = incoming_content.clone();
+                content.parent_id = ContentMetadataId::new_with_version(
+                    &incoming_content.parent_id.id,
+                    latest_version_of_parent,
+                );
+                new_content.push(content);
+                continue;
+            }
+
+            let mut content = incoming_content.clone();
+            content.parent_id = ContentMetadataId::new_with_version(
+                &incoming_content.parent_id.id,
+                latest_version_of_parent,
+            );
+            identical_content.push(content);
+        }
+
+        //  write the identical content
+        if !identical_content.is_empty() {
             let req = StateMachineUpdateRequest {
-                payload: RequestPayload::UpdateContent {
-                    content_metadata: content_to_write,
+                payload: RequestPayload::CreateContent {
+                    content_metadata: identical_content,
                 },
                 new_state_changes: vec![],
                 state_changes_processed: vec![],
             };
             self.forwardable_raft.client_write(req).await.map_err(|e| {
                 anyhow!(
-                    "unable to update identical content metadata: {}",
+                    "unable to create identical content metadata: {}",
                     e.to_string()
                 )
             })?;
         }
 
-        //  write the updated content
+        //  write the new and updated content
         let mut state_changes = Vec::new();
-        let mut content_to_write = content_to_be_updated.clone();
-        content_to_write.extend(new_incoming_content.clone());
+        let mut content_to_write = content_to_update.clone();
+        content_to_write.extend(new_content);
 
-        let mut updated_contents_to_write = Vec::new();
-
-        for mut content in content_to_write {
-            if !content.parent_id.id.is_empty() {
-                // Retrieve the latest version of the parent content
-                match self
-                    .state_machine
-                    .get_latest_version_of_content(&content.parent_id.id)
-                {
-                    Ok(Some(latest_version)) => {
-                        content.parent_id.version = latest_version;
-                    }
-                    Ok(None) => {
-                        // Error out if no parent is found
-                        tracing::error!(
-                            "Parent content with id {} not found",
-                            content.parent_id.id
-                        );
-                        return Err(anyhow!(
-                            "Parent content with id {} not found",
-                            content.parent_id.id
-                        ));
-                    }
-                    Err(e) => {
-                        return Err(e);
-                    }
-                }
-            }
-            updated_contents_to_write.push(content);
-        }
-
-        for content in &updated_contents_to_write {
+        for content in &content_to_write {
             state_changes.push(StateChange::new(
                 content.id.to_string(),
                 internal_api::ChangeType::NewContent,
                 timestamp_secs(),
             ));
         }
-
         let req = StateMachineUpdateRequest {
             payload: RequestPayload::CreateContent {
-                content_metadata: updated_contents_to_write,
+                content_metadata: content_to_write,
             },
             new_state_changes: state_changes,
             state_changes_processed: vec![],
         };
-        let _ = self.forwardable_raft.client_write(req).await.map_err(|e| {
-            anyhow!(
-                "unable to create updated content metadata: {}",
-                e.to_string()
-            )
-        })?;
+        self.forwardable_raft
+            .client_write(req)
+            .await
+            .map_err(|e| anyhow!("unable to create new content metadata: {}", e.to_string()))?;
 
         Ok(())
     }
@@ -1460,8 +1470,7 @@ mod tests {
         state::{
             store::{
                 requests::{RequestPayload, StateMachineUpdateRequest},
-                ExecutorId,
-                TaskId,
+                ExecutorId, TaskId,
             },
             App,
         },
@@ -1573,19 +1582,11 @@ mod tests {
 
     /// Test to determine that assigning a task to an executor works correctly
     #[tokio::test]
-    #[tracing_test::traced_test]
+    // #[tracing_test::traced_test]
     async fn test_write_read_task_assignment() -> Result<(), anyhow::Error> {
         let cluster = RaftTestCluster::new(1, None).await?;
         cluster.initialize(Duration::from_secs(2)).await?;
         let node = cluster.get_raft_node(0)?;
-
-        let content = ContentMetadata {
-            id: ContentMetadataId::new("content_id"),
-            ..Default::default()
-        };
-        node.create_content_batch(vec![content.clone()]).await?;
-
-        tokio::time::sleep(Duration::from_secs(1)).await;
 
         //  First create a task and ensure it's written
         let content = ContentMetadata {
@@ -1742,9 +1743,9 @@ mod tests {
         let read_back = |node: Arc<App>| async move {
             match node.tasks_for_executor("executor_id", None).await {
                 Ok(tasks_vec)
-                    if tasks_vec.len() == 1 &&
-                        tasks_vec.first().unwrap().id == "task_id" &&
-                        tasks_vec.first().unwrap().outcome == TaskOutcome::Unknown =>
+                    if tasks_vec.len() == 1
+                        && tasks_vec.first().unwrap().id == "task_id"
+                        && tasks_vec.first().unwrap().outcome == TaskOutcome::Unknown =>
                 {
                     Ok(true)
                 }

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -20,12 +20,16 @@ use network::Network;
 use openraft::{
     self,
     error::{InitializeError, RaftError},
-    BasicNode, TokioRuntime,
+    BasicNode,
+    TokioRuntime,
 };
 use serde::Serialize;
 use store::{
     requests::{RequestPayload, StateChangeProcessed, StateMachineUpdateRequest},
-    ExecutorId, ExecutorIdRef, Response, TaskId,
+    ExecutorId,
+    ExecutorIdRef,
+    Response,
+    TaskId,
 };
 use tokio::{
     sync::{
@@ -397,9 +401,8 @@ impl App {
             //  Check whether the sources match. Make an additional check in case the
             // content has  a source which is an extraction policy id instead of
             // a name
-            if extraction_policy.content_source != content_metadata.source
-                && self
-                    .get_extraction_policy(&content_metadata.source)
+            if extraction_policy.content_source != content_metadata.source &&
+                self.get_extraction_policy(&content_metadata.source)
                     .await
                     .map_or(true, |retrieved_extraction_policy| {
                         extraction_policy.content_source != retrieved_extraction_policy.name
@@ -502,8 +505,8 @@ impl App {
         for content in content_list {
             //  Check whether the sources match. Make an additional check in case the
             // content has a source which is an extraction policy id instead of a name
-            if content.source != extraction_policy.content_source
-                && self.get_extraction_policy(&content.source).await.map_or(
+            if content.source != extraction_policy.content_source &&
+                self.get_extraction_policy(&content.source).await.map_or(
                     true,
                     |retrieved_extraction_policy| {
                         extraction_policy.content_source != retrieved_extraction_policy.name
@@ -964,7 +967,8 @@ impl App {
                 continue;
             }
 
-            //  if the parent predecessor cannot be found or has no children, create the content
+            //  if the parent predecessor cannot be found or has no children, create the
+            // content
             let parent_prev_version_id = ContentMetadataId::new_with_version(
                 &incoming_content.parent_id.id,
                 latest_version_of_parent - 1,
@@ -989,7 +993,9 @@ impl App {
                 continue;
             }
 
-            //  compare the hashes of the predecessor's children to the incoming content's hash - if there is a match, flip the pointers because this is identical content
+            //  compare the hashes of the predecessor's children to the incoming content's
+            // hash - if there is a match, flip the pointers because this is identical
+            // content
             let content_with_matching_hash = parent_prev_version_tree
                 .iter()
                 .find(|content| content.hash == incoming_content.hash);
@@ -1470,7 +1476,8 @@ mod tests {
         state::{
             store::{
                 requests::{RequestPayload, StateMachineUpdateRequest},
-                ExecutorId, TaskId,
+                ExecutorId,
+                TaskId,
             },
             App,
         },
@@ -1743,9 +1750,9 @@ mod tests {
         let read_back = |node: Arc<App>| async move {
             match node.tasks_for_executor("executor_id", None).await {
                 Ok(tasks_vec)
-                    if tasks_vec.len() == 1
-                        && tasks_vec.first().unwrap().id == "task_id"
-                        && tasks_vec.first().unwrap().outcome == TaskOutcome::Unknown =>
+                    if tasks_vec.len() == 1 &&
+                        tasks_vec.first().unwrap().id == "task_id" &&
+                        tasks_vec.first().unwrap().outcome == TaskOutcome::Unknown =>
                 {
                     Ok(true)
                 }

--- a/src/state/store/state_machine_objects.rs
+++ b/src/state/store/state_machine_objects.rs
@@ -16,16 +16,8 @@ use tracing::{error, warn};
 use super::{
     requests::{RequestPayload, StateChangeProcessed, StateMachineUpdateRequest},
     serializer::JsonEncode,
-    ExecutorId,
-    ExtractionPolicyId,
-    ExtractorName,
-    JsonEncoder,
-    NamespaceName,
-    SchemaId,
-    StateChangeId,
-    StateMachineColumns,
-    StateMachineError,
-    TaskId,
+    ExecutorId, ExtractionPolicyId, ExtractorName, JsonEncoder, NamespaceName, SchemaId,
+    StateChangeId, StateMachineColumns, StateMachineError, TaskId,
 };
 use crate::state::NodeId;
 
@@ -1269,7 +1261,6 @@ impl IndexifyState {
                 self.set_content(db, &txn, content_metadata)?;
             }
             RequestPayload::UpdateContent { content_metadata } => {
-                //  TODO: update the content
                 self.set_content(db, &txn, content_metadata)?;
             }
             RequestPayload::TombstoneContentTree {

--- a/src/state/store/state_machine_objects.rs
+++ b/src/state/store/state_machine_objects.rs
@@ -16,8 +16,16 @@ use tracing::{error, warn};
 use super::{
     requests::{RequestPayload, StateChangeProcessed, StateMachineUpdateRequest},
     serializer::JsonEncode,
-    ExecutorId, ExtractionPolicyId, ExtractorName, JsonEncoder, NamespaceName, SchemaId,
-    StateChangeId, StateMachineColumns, StateMachineError, TaskId,
+    ExecutorId,
+    ExtractionPolicyId,
+    ExtractorName,
+    JsonEncoder,
+    NamespaceName,
+    SchemaId,
+    StateChangeId,
+    StateMachineColumns,
+    StateMachineError,
+    TaskId,
 };
 use crate::state::NodeId;
 

--- a/src/vectordbs/lancedb.rs
+++ b/src/vectordbs/lancedb.rs
@@ -174,7 +174,7 @@ impl VectorDb for LanceDb {
             let values = chunks.iter().map(|c| {
                 let metadata = c.metadata.as_object().unwrap();
                 let value = metadata.get(field.name());
-                value.map(|v| to_column(v))
+                value.map(to_column)
             });
             let array = values.collect::<StringArray>();
             arrays.push(Arc::new(array));

--- a/src/vectordbs/lancedb.rs
+++ b/src/vectordbs/lancedb.rs
@@ -6,8 +6,14 @@ use std::{
 
 use anyhow::{anyhow, Result};
 use arrow_array::{
-    cast::as_string_array, types::Float32Type, Array, FixedSizeListArray, PrimitiveArray,
-    RecordBatch, RecordBatchIterator, StringArray,
+    cast::as_string_array,
+    types::Float32Type,
+    Array,
+    FixedSizeListArray,
+    PrimitiveArray,
+    RecordBatch,
+    RecordBatchIterator,
+    StringArray,
 };
 use arrow_schema::{DataType, Field, Schema};
 use async_trait::async_trait;
@@ -16,7 +22,8 @@ use lance::dataset::BatchUDF;
 use lancedb::{
     query::{ExecutableQuery, QueryBase},
     table::NewColumnTransform,
-    Connection, Table,
+    Connection,
+    Table,
 };
 use tracing;
 

--- a/src/vectordbs/lancedb.rs
+++ b/src/vectordbs/lancedb.rs
@@ -6,14 +6,8 @@ use std::{
 
 use anyhow::{anyhow, Result};
 use arrow_array::{
-    cast::as_string_array,
-    types::Float32Type,
-    Array,
-    FixedSizeListArray,
-    PrimitiveArray,
-    RecordBatch,
-    RecordBatchIterator,
-    StringArray,
+    cast::as_string_array, types::Float32Type, Array, FixedSizeListArray, PrimitiveArray,
+    RecordBatch, RecordBatchIterator, StringArray,
 };
 use arrow_schema::{DataType, Field, Schema};
 use async_trait::async_trait;
@@ -22,8 +16,7 @@ use lance::dataset::BatchUDF;
 use lancedb::{
     query::{ExecutableQuery, QueryBase},
     table::NewColumnTransform,
-    Connection,
-    Table,
+    Connection, Table,
 };
 use tracing;
 
@@ -415,7 +408,7 @@ mod tests {
     }
 
     fn make_id() -> String {
-        DataManager::make_id("namespace", &None, &nanoid::nanoid!())
+        DataManager::make_id()
     }
 
     #[tokio::test]

--- a/src/vectordbs/pg_vector.rs
+++ b/src/vectordbs/pg_vector.rs
@@ -243,7 +243,7 @@ mod tests {
     }
 
     fn make_id() -> String {
-        DataManager::make_id("namespace", &None, &nanoid::nanoid!())
+        DataManager::make_id()
     }
 
     #[tokio::test]

--- a/src/vectordbs/qdrant.rs
+++ b/src/vectordbs/qdrant.rs
@@ -3,10 +3,21 @@ use async_trait::async_trait;
 use qdrant_client::{
     client::{QdrantClient, QdrantClientConfig},
     qdrant::{
-        point_id::PointIdOptions::Num, points_selector::PointsSelectorOneOf,
-        vectors::VectorsOptions, vectors_config::Config, with_payload_selector::SelectorOptions,
-        CreateCollection, Distance, PointId, PointStruct, PointsIdsList, PointsSelector,
-        SearchPoints, VectorParams, VectorsConfig, WithPayloadSelector,
+        point_id::PointIdOptions::Num,
+        points_selector::PointsSelectorOneOf,
+        vectors::VectorsOptions,
+        vectors_config::Config,
+        with_payload_selector::SelectorOptions,
+        CreateCollection,
+        Distance,
+        PointId,
+        PointStruct,
+        PointsIdsList,
+        PointsSelector,
+        SearchPoints,
+        VectorParams,
+        VectorsConfig,
+        WithPayloadSelector,
     },
 };
 

--- a/src/vectordbs/qdrant.rs
+++ b/src/vectordbs/qdrant.rs
@@ -3,21 +3,10 @@ use async_trait::async_trait;
 use qdrant_client::{
     client::{QdrantClient, QdrantClientConfig},
     qdrant::{
-        point_id::PointIdOptions::Num,
-        points_selector::PointsSelectorOneOf,
-        vectors::VectorsOptions,
-        vectors_config::Config,
-        with_payload_selector::SelectorOptions,
-        CreateCollection,
-        Distance,
-        PointId,
-        PointStruct,
-        PointsIdsList,
-        PointsSelector,
-        SearchPoints,
-        VectorParams,
-        VectorsConfig,
-        WithPayloadSelector,
+        point_id::PointIdOptions::Num, points_selector::PointsSelectorOneOf,
+        vectors::VectorsOptions, vectors_config::Config, with_payload_selector::SelectorOptions,
+        CreateCollection, Distance, PointId, PointStruct, PointsIdsList, PointsSelector,
+        SearchPoints, VectorParams, VectorsConfig, WithPayloadSelector,
     },
 };
 
@@ -309,7 +298,7 @@ mod tests {
     }
 
     fn make_id() -> String {
-        DataManager::make_id("namespace", &None, &nanoid::nanoid!())
+        DataManager::make_id()
     }
 
     #[tokio::test]


### PR DESCRIPTION
## This PR

* changes the way content id is generated on the ingestion server. The client is allowed to pass in an id and if not specified, the server will generate one using `nanoid`
* changes the merge algorithm used for updating content. Now, when a new piece of content is passed in, all children of the previous version are fetched and compared against. If any hashes match, the content is created with no state changes