### PR TITLE
add script remove tmp/indexify to make local-dev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,7 @@ help: ## Show help message for each target
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
 local-dev: ## Run local development environment
+	rm -rf /tmp/indexify*
 	docker stop indexify-local-postgres || true
 	docker run --rm -p 5432:5432 --name=indexify-local-postgres -e POSTGRES_PASSWORD=postgres -e POSTGRES_DB=indexify -d ankane/pgvector
 	timeout 90s bash -c "until docker exec indexify-local-postgres pg_isready ; do sleep 5 ; done"


### PR DESCRIPTION
This PR adds a script to the Makefile to remove existing Indexify configuration and articles in the system to streamline the test process.

```make
local-dev:
    rm -rf /tmp/indexify*
    ...
```
