### PR TITLE
new ingest extracted content test reset config state

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,7 @@ help: ## Show help message for each target
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
 local-dev: ## Run local development environment
+	rm -rf /tmp/indexify*
 	docker stop indexify-local-postgres || true
 	docker run --rm -p 5432:5432 --name=indexify-local-postgres -e POSTGRES_PASSWORD=postgres -e POSTGRES_DB=indexify -d ankane/pgvector
 	timeout 90s bash -c "until docker exec indexify-local-postgres pg_isready ; do sleep 5 ; done"

--- a/src/ingest_extracted_content.rs
+++ b/src/ingest_extracted_content.rs
@@ -391,6 +391,7 @@ mod tests {
 
         async fn new() -> TestCoordinator {
             let config = make_test_config();
+            let _ = std::fs::remove_dir_all(config.state_store.clone().path.unwrap());
             let coordinator =
                 crate::coordinator_service::CoordinatorServer::new(Arc::new(config.clone()))
                     .await


### PR DESCRIPTION
This PR resolves the issue where previous tests interfere with the tests of `ingest_extracted_content` resulting in a failed test. This PR removes previous tests state (`/tmp/indexify-state`) file to prevent this.