### PR TITLE
add more metrics

### DIFF
--- a/src/cmd/coordinator.rs
+++ b/src/cmd/coordinator.rs
@@ -22,7 +22,8 @@ impl Args {
                 config_path, e
             )
         });
-        let coordinator = CoordinatorServer::new(Arc::new(config))
+        let registry = Arc::new(crate::metrics::init_provider());
+        let coordinator = CoordinatorServer::new(Arc::new(config), registry)
             .await
             .expect("failed to create coordinator server");
         coordinator.run().await.expect("failed to run coordinator");

--- a/src/coordinator.rs
+++ b/src/coordinator.rs
@@ -23,6 +23,7 @@ use crate::{
     coordinator_filters::*,
     forwardable_coordinator::ForwardableCoordinator,
     garbage_collector::GarbageCollector,
+    metrics::Timer,
     scheduler::Scheduler,
     state::{RaftMetrics, SharedState},
     task_allocator::TaskAllocator,
@@ -437,6 +438,8 @@ impl Coordinator {
 
     #[tracing::instrument(skip(self))]
     pub async fn run_scheduler(&self) -> Result<()> {
+        let _timer = Timer::start(&self.shared_state.metrics.scheduler_invocations);
+
         let state_changes = self.shared_state.unprocessed_state_change_events().await?;
         for change in state_changes {
             info!(
@@ -558,6 +561,7 @@ mod tests {
             None,
             garbage_collector.clone(),
             &config.coordinator_addr,
+            Arc::new(crate::metrics::init_provider()),
         )
         .await
         .unwrap();

--- a/src/ingest_extracted_content.rs
+++ b/src/ingest_extracted_content.rs
@@ -391,10 +391,13 @@ mod tests {
 
         async fn new() -> TestCoordinator {
             let config = make_test_config();
-            let coordinator =
-                crate::coordinator_service::CoordinatorServer::new(Arc::new(config.clone()))
-                    .await
-                    .expect("failed to create coordinator server");
+            let registry = Arc::new(crate::metrics::init_provider());
+            let coordinator = crate::coordinator_service::CoordinatorServer::new(
+                Arc::new(config.clone()),
+                registry,
+            )
+            .await
+            .expect("failed to create coordinator server");
             let handle = tokio::spawn(async move {
                 coordinator.run().await.unwrap();
             });
@@ -433,6 +436,7 @@ mod tests {
             data_manager: data_manager.clone(),
             coordinator_client: coordinator_client.clone(),
             content_reader: Arc::new(ContentReader::new()),
+            registry: Arc::new(metrics::init_provider()),
             metrics: Arc::new(metrics::server::Metrics::new()),
         };
         Ok(namespace_endpoint_state)

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -306,15 +306,27 @@ pub mod raft_metrics {
     }
 }
 
+use opentelemetry_sdk::metrics::SdkMeterProvider;
+
+pub fn init_provider() -> prometheus::Registry {
+    println!("Initializing metrics provider");
+    let registry = prometheus::Registry::new();
+    let exporter = opentelemetry_prometheus::exporter()
+        .with_registry(registry.clone())
+        .build();
+    let mut provider = SdkMeterProvider::builder();
+    if let Ok(exporter) = exporter {
+        provider = provider.with_reader(exporter);
+    };
+    opentelemetry::global::set_meter_provider(provider.build());
+    registry
+}
+
 pub mod server {
-    use opentelemetry::metrics::{Counter, MeterProvider};
-    use opentelemetry_sdk::metrics::SdkMeterProvider;
-    use prometheus::Registry;
+    use opentelemetry::metrics::Counter;
 
     #[derive(Debug)]
     pub struct Metrics {
-        pub registry: Registry,
-        pub provider: SdkMeterProvider,
         pub node_content_uploads: Counter<u64>,
         pub node_content_bytes_uploaded: Counter<u64>,
         pub node_content_extracted: Counter<u64>,
@@ -329,17 +341,7 @@ pub mod server {
 
     impl Metrics {
         pub fn new() -> Metrics {
-            let registry = Registry::new();
-            let exporter = opentelemetry_prometheus::exporter()
-                .with_registry(registry.clone())
-                .build();
-            let mut provider = SdkMeterProvider::builder();
-            if let Ok(exporter) = exporter {
-                provider = provider.with_reader(exporter);
-            };
-            let provider = provider.build();
-
-            let meter = provider.meter("indexify-server");
+            let meter = opentelemetry::global::meter("indexify-server");
             let node_content_uploads = meter
                 .u64_counter("indexify.server.node_content_uploads")
                 .with_description("Number of contents uploaded on this node")
@@ -357,8 +359,6 @@ pub mod server {
                 .with_description("Number of bytes extracted on this node")
                 .init();
             Metrics {
-                registry,
-                provider,
                 node_content_uploads,
                 node_content_bytes_uploaded,
                 node_content_extracted,
@@ -368,19 +368,56 @@ pub mod server {
     }
 }
 
+use opentelemetry::{
+    metrics::{Counter, Histogram},
+    KeyValue,
+};
+
+pub trait TimerUpdate {
+    fn add(&self, duration: Duration, labels: &[KeyValue]);
+}
+
+impl TimerUpdate for Counter<f64> {
+    fn add(&self, duration: Duration, labels: &[KeyValue]) {
+        self.add(duration.as_secs_f64(), labels);
+    }
+}
+
+impl TimerUpdate for Histogram<f64> {
+    fn add(&self, duration: Duration, labels: &[KeyValue]) {
+        self.record(duration.as_secs_f64(), labels);
+    }
+}
+
+pub struct Timer<'a, T: TimerUpdate + Sync> {
+    start: Instant,
+    metric: &'a T,
+}
+
+impl<'a, T: TimerUpdate + Sync> Timer<'a, T> {
+    pub fn start(metric: &'a T) -> Self {
+        Self {
+            start: Instant::now(),
+            metric,
+        }
+    }
+}
+
+impl<'a, T: TimerUpdate + Sync> Drop for Timer<'a, T> {
+    fn drop(&mut self) {
+        self.metric.add(self.start.elapsed(), &[]);
+    }
+}
+
 pub mod coordinator {
     use std::sync::{Arc, Mutex};
 
-    use opentelemetry::metrics::{MeterProvider, ObservableCounter, ObservableGauge};
-    use opentelemetry_sdk::metrics::SdkMeterProvider;
-    use prometheus::Registry;
+    use opentelemetry::metrics::{Histogram, ObservableCounter, ObservableGauge};
 
     use crate::state::store::StateMachineStore;
 
     #[derive(Debug)]
     pub struct Metrics {
-        pub registry: Registry,
-        pub provider: SdkMeterProvider,
         pub tasks_completed: ObservableCounter<u64>,
         pub tasks_errored: ObservableCounter<u64>,
         pub tasks_in_progress: ObservableGauge<u64>,
@@ -389,21 +426,12 @@ pub mod coordinator {
         pub content_bytes_uploaded: ObservableCounter<u64>,
         pub content_extracted: ObservableCounter<u64>,
         pub content_extracted_bytes: ObservableCounter<u64>,
+        pub scheduler_invocations: Histogram<f64>,
     }
 
     impl Metrics {
         pub fn new(app: Arc<StateMachineStore>) -> Metrics {
-            let registry = Registry::new();
-            let exporter = opentelemetry_prometheus::exporter()
-                .with_registry(registry.clone())
-                .build();
-            let mut provider = SdkMeterProvider::builder();
-            if let Ok(exporter) = exporter {
-                provider = provider.with_reader(exporter);
-            };
-            let provider = provider.build();
-
-            let meter = provider.meter("indexify-coordinator");
+            let meter = opentelemetry::global::meter("indexify-coordinator");
 
             let prev_value = Arc::new(Mutex::new(0));
             let tasks_completed = meter
@@ -560,9 +588,12 @@ pub mod coordinator {
                 .with_description("Number of bytes extracted")
                 .init();
 
+            let scheduler_invocations = meter
+                .f64_histogram("indexify.coordinator.scheduler_invocations")
+                .with_description("Scheduler invocation latencies in seconds")
+                .init();
+
             Metrics {
-                registry,
-                provider,
                 tasks_completed,
                 tasks_errored,
                 tasks_in_progress,
@@ -571,6 +602,114 @@ pub mod coordinator {
                 content_bytes_uploaded,
                 content_extracted,
                 content_extracted_bytes,
+                scheduler_invocations,
+            }
+        }
+    }
+}
+
+pub mod metadata_storage {
+    use opentelemetry::metrics::Histogram;
+
+    #[derive(Debug)]
+    pub struct Metrics {
+        pub metadata_read: Histogram<f64>,
+        pub metadata_added: Histogram<f64>,
+        pub metadata_updated: Histogram<f64>,
+        pub metadata_deleted: Histogram<f64>,
+    }
+
+    impl Metrics {
+        pub fn new() -> Metrics {
+            let meter = opentelemetry::global::meter("indexify-index");
+
+            let metadata_read = meter
+                .f64_histogram("indexify.metadata_read")
+                .with_description("Metadata read latencies in seconds")
+                .init();
+
+            let metadata_added = meter
+                .f64_histogram("indexify.metadata_added")
+                .with_description("Metadata add latencies in seconds")
+                .init();
+
+            let metadata_updated = meter
+                .f64_histogram("indexify.metadata_updated")
+                .with_description("Metadata update latencies in seconds")
+                .init();
+
+            let metadata_deleted = meter
+                .f64_histogram("indexify.metadata_deleted")
+                .with_description("Metadata delete latencies in seconds")
+                .init();
+
+            Metrics {
+                metadata_read,
+                metadata_added,
+                metadata_updated,
+                metadata_deleted,
+            }
+        }
+    }
+}
+
+pub mod vector_storage {
+    use opentelemetry::metrics::Histogram;
+
+    #[derive(Debug)]
+    pub struct Metrics {
+        pub vector_upsert: Histogram<f64>,
+        pub vector_metadata_update: Histogram<f64>,
+        pub vector_delete: Histogram<f64>,
+    }
+
+    impl Metrics {
+        pub fn new() -> Metrics {
+            let meter = opentelemetry::global::meter("indexify-index");
+
+            let vector_upsert = meter
+                .f64_histogram("indexify.vector_added")
+                .with_description("Vector update/insert latencies in seconds")
+                .init();
+
+            let vector_metadata_update = meter
+                .f64_histogram("indexify.vector_metadata_update")
+                .with_description("Vector metadata update latencies in seconds")
+                .init();
+
+            let vector_deleted = meter
+                .f64_histogram("indexify.vector_deleted")
+                .with_description("Vector delete latencies in seconds")
+                .init();
+
+            Metrics {
+                vector_metadata_update,
+                vector_upsert,
+                vector_delete: vector_deleted,
+            }
+        }
+    }
+}
+
+pub mod state_machine {
+    use opentelemetry::metrics::Histogram;
+
+    #[derive(Debug)]
+    pub struct Metrics {
+        pub state_machine_apply: Histogram<f64>,
+    }
+
+    impl Metrics {
+        pub fn new() -> Metrics {
+            let meter = opentelemetry::global::meter("indexify-state-machine");
+
+            let state_machine_apply = meter
+                .f64_histogram("indexify.state_machine_apply")
+                .with_description("State machine apply changes latencies in seconds")
+                .init();
+
+            Metrics {
+                state_machine_apply,
             }
         }
     }

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -127,6 +127,7 @@ pub struct App {
     pub node_addr: String,
     pub state_machine: Arc<StateMachineStore>,
     pub garbage_collector: Arc<GarbageCollector>,
+    pub registry: Arc<prometheus::Registry>,
     pub metrics: Metrics,
 }
 
@@ -141,6 +142,7 @@ impl App {
         overrides: Option<RaftConfigOverrides>,
         garbage_collector: Arc<GarbageCollector>,
         coordinator_addr: &str,
+        registry: Arc<prometheus::Registry>,
     ) -> Result<Arc<Self>> {
         let mut raft_config = openraft::Config {
             heartbeat_interval: 500,
@@ -237,6 +239,7 @@ impl App {
             node_addr: format!("{}:{}", server_config.listen_if, server_config.raft_port),
             state_machine,
             garbage_collector,
+            registry,
             metrics,
         });
 

--- a/src/state/store/mod.rs
+++ b/src/state/store/mod.rs
@@ -45,7 +45,10 @@ use self::{
     state_machine_objects::{IndexifyState, IndexifyStateSnapshot},
 };
 use super::{typ, NodeId, SnapshotData, TypeConfig};
-use crate::utils::OptionInspectNone;
+use crate::{
+    metrics::{state_machine::Metrics, Timer},
+    utils::OptionInspectNone,
+};
 
 pub type NamespaceName = String;
 pub type TaskId = String;
@@ -126,8 +129,6 @@ pub struct StateMachineData {
     /// State built from applying the raft log
     pub indexify_state: IndexifyState,
 
-    pub metrics: Mutex<crate::state::store::state_machine_objects::Metrics>,
-
     state_change_tx: Arc<tokio::sync::watch::Sender<StateChange>>,
 
     gc_tasks_tx: broadcast::Sender<indexify_internal_api::GarbageCollectionTask>,
@@ -143,6 +144,8 @@ pub struct StateMachineStore {
     pub state_change_rx: tokio::sync::watch::Receiver<StateChange>,
 
     snapshot_file_path: PathBuf,
+
+    metrics: Metrics,
 }
 
 impl StateMachineStore {
@@ -157,7 +160,6 @@ impl StateMachineStore {
                 last_applied_log_id: RwLock::new(None),
                 last_membership: RwLock::new(StoredMembership::default()),
                 indexify_state: IndexifyState::default(),
-                metrics: Mutex::new(crate::state::store::state_machine_objects::Metrics::default()),
                 state_change_tx: Arc::new(tx),
                 gc_tasks_tx,
             },
@@ -165,6 +167,7 @@ impl StateMachineStore {
             db,
             state_change_rx: rx,
             snapshot_file_path,
+            metrics: Metrics::new(),
         };
 
         let snapshot = sm.get_current_snapshot_()?;
@@ -572,6 +575,7 @@ impl RaftStateMachine<TypeConfig> for Arc<StateMachineStore> {
         I: IntoIterator<Item = typ::Entry> + OptionalSend,
         I::IntoIter: OptionalSend,
     {
+        let _timer = Timer::start(&self.metrics.state_machine_apply);
         let entries = entries.into_iter();
         let mut replies = Vec::with_capacity(entries.size_hint().0);
         let mut change_events: Vec<StateChange> = Vec::new();

--- a/src/task_allocator/planner/load_aware_distributor.rs
+++ b/src/task_allocator/planner/load_aware_distributor.rs
@@ -386,6 +386,7 @@ mod tests {
             None,
             Arc::clone(&garbage_collector),
             &config.coordinator_addr,
+            Arc::new(crate::metrics::init_provider()),
         )
         .await
         .unwrap();
@@ -420,6 +421,7 @@ mod tests {
             None,
             Arc::clone(&garbage_collector),
             &config.coordinator_addr,
+            Arc::new(crate::metrics::init_provider()),
         )
         .await
         .unwrap();
@@ -466,6 +468,7 @@ mod tests {
             None,
             Arc::clone(&garbage_collector),
             &config.coordinator_addr,
+            Arc::new(crate::metrics::init_provider()),
         )
         .await
         .unwrap();
@@ -702,6 +705,7 @@ mod tests {
             None,
             Arc::clone(&garbage_collector),
             &config.coordinator_addr,
+            Arc::new(crate::metrics::init_provider()),
         )
         .await
         .unwrap();

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -182,6 +182,7 @@ impl RaftTestCluster {
                 overrides.clone(),
                 Arc::clone(&garbage_collector),
                 &config.coordinator_addr,
+                Arc::new(crate::metrics::init_provider()),
             )
             .await?;
             let coordinator_client = CoordinatorClient::new(&config.coordinator_addr);


### PR DESCRIPTION
Use global metrics registry to avoid modifiying initialization code everywhere.
Add metrics for scheduler, state machine updates, metadata and vector updates.