### PR TITLE
remove hashing of frame count

### DIFF
--- a/src/ingest_extracted_content.rs
+++ b/src/ingest_extracted_content.rs
@@ -37,7 +37,6 @@ struct Writing {
             OidSha256,
         >,
     >,
-    frame_count: u64,
 }
 
 #[derive(Debug)]
@@ -102,7 +101,6 @@ impl IngestExtractedContentState {
             file_size: 0,
             writer,
             hasher: Sha256::new(),
-            frame_count: 0,
         });
         Ok(())
     }
@@ -139,11 +137,8 @@ impl IngestExtractedContentState {
                 "received content frame without starting multipart content"
             )),
             FrameState::Writing(frame_state) => {
-                let frame_index_bytes = frame_state.frame_count.to_le_bytes(); //  NOTE: doing this so hash is consistent independent of platform
                 frame_state.file_size += payload.bytes.len() as u64;
-                frame_state.hasher.update(frame_index_bytes);
                 frame_state.hasher.update(&payload.bytes);
-                frame_state.frame_count += 1;
                 frame_state
                     .writer
                     .writer


### PR DESCRIPTION
Shouldn't include the frame count in the hash, there is no requirement on the client to send exactly the same size of the frames.