### PR TITLE
update mkdocs config to generate sitemap

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -1,4 +1,5 @@
 site_name: ""
+site_url: https://getindexify.ai/
 
 repo_url: https://github.com/tensorlakeai/indexify
 repo_name: tensorlakeai/indexify


### PR DESCRIPTION
Current indexify sitemap does is not properly generated. The sitemap is how google knows what content to index and serve for a given domain. 

Stack overflow suggests that you need to set the `site_url` property in the `mkdocs.yml` config file: https://stackoverflow.com/questions/59120869/mkdocs-get-full-sitemap

This PR makes that change. I wasn't able to test this locally due to a build error, but will test via the generated vercel preview.