### PR TITLE
handle errors during ingest extracted content

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -514,7 +514,10 @@ pub enum IngestExtractedContent {
 }
 
 #[derive(Debug, Serialize, Deserialize, ToSchema, Clone)]
-pub struct IngestExtractedContentResponse {}
+pub enum IngestExtractedContentResponse {
+    Success,
+    Error(String),
+}
 
 #[derive(Debug, Serialize, Deserialize, ToSchema, Clone)]
 pub struct BeginExtractedContentIngest {


### PR DESCRIPTION
If any error occurred during extracted content ingest, propagate it back to the client.