### PR TITLE
remove duplicated fields

### DIFF
--- a/crates/indexify_proto/src/indexify_coordinator.rs
+++ b/crates/indexify_proto/src/indexify_coordinator.rs
@@ -37,10 +37,6 @@ pub struct UpdateTaskRequest {
     pub outcome: i32,
     #[prost(message, repeated, tag = "4")]
     pub content_list: ::prost::alloc::vec::Vec<ContentMetadata>,
-    #[prost(string, tag = "5")]
-    pub content_id: ::prost::alloc::string::String,
-    #[prost(string, tag = "6")]
-    pub extraction_policy_name: ::prost::alloc::string::String,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/protos/coordinator_service.proto
+++ b/protos/coordinator_service.proto
@@ -90,8 +90,6 @@ message UpdateTaskRequest {
     string task_id = 2;
     TaskOutcome outcome = 3;
     repeated ContentMetadata content_list = 4;
-    string content_id = 5;
-    string extraction_policy_name = 6;
 }
 
 message ListStateChangesRequest {

--- a/src/api.rs
+++ b/src/api.rs
@@ -521,14 +521,8 @@ pub struct IngestExtractedContentResponse {}
 #[derive(Debug, Serialize, Deserialize, ToSchema, Clone)]
 pub struct BeginExtractedContentIngest {
     pub task_id: String,
-    pub namespace: String,
-    pub output_to_index_table_mapping: HashMap<String, String>,
-    pub parent_content_id: String,
     pub executor_id: String,
     pub task_outcome: internal_api::TaskOutcome,
-    pub extraction_policy: String,
-    pub extractor: String,
-    pub index_tables: Vec<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, ToSchema, Clone)]

--- a/src/ingest_extracted_content.rs
+++ b/src/ingest_extracted_content.rs
@@ -131,6 +131,7 @@ impl ContentStateWriting {
     ) -> Result<String> {
         let mut labels = self.content_metadata().labels.clone();
         let root_content_id = self.content_metadata().root_content_id.clone();
+        let parent_id = self.content_metadata().id.clone();
         match &mut self.frame_state {
             FrameState::New => Err(anyhow!(
                 "received finish content without any content frames"
@@ -144,14 +145,14 @@ impl ContentStateWriting {
                 let content_metadata = indexify_coordinator::ContentMetadata {
                     id: id.clone(),
                     file_name: frame_state.file_name.clone(),
-                    parent_id: self.ingest_metadata.parent_content_id.clone(),
+                    parent_id,
                     root_content_id,
-                    namespace: self.ingest_metadata.namespace.clone(),
+                    namespace: self.task.namespace.clone(),
                     mime: payload.content_type,
                     size_bytes: frame_state.file_size,
                     storage_url: frame_state.writer.url.clone(),
                     labels,
-                    source: self.ingest_metadata.extraction_policy.clone(),
+                    source: self.task.extraction_policy_id.clone(),
                     created_at: frame_state.created_at,
                     hash: content_hash,
                     extraction_policy_ids: HashMap::new(),
@@ -160,8 +161,9 @@ impl ContentStateWriting {
                     .data_manager
                     .create_content_and_write_features(
                         &content_metadata,
-                        &self.ingest_metadata,
+                        &self.task.extractor,
                         payload.features,
+                        &self.task.output_index_mapping,
                     )
                     .await?;
                 state.metrics.node_content_extracted.add(1, &[]);
@@ -183,12 +185,11 @@ impl ContentStateWriting {
         state
             .data_manager
             .write_existing_content_features(
-                &self.ingest_metadata.extractor,
-                &self.ingest_metadata.extraction_policy,
+                &self.task.extractor,
                 self.content_metadata(),
                 payload.features,
-                &self.ingest_metadata.output_to_index_table_mapping,
-                &self.ingest_metadata.index_tables,
+                &self.task.output_index_mapping,
+                &self.task.index_tables,
             )
             .await
     }
@@ -213,19 +214,14 @@ impl IngestExtractedContentState {
     }
 
     async fn begin(&mut self, payload: BeginExtractedContentIngest) -> Result<()> {
-        info!(
-            "beginning extraction ingest for task: {} index_tables: {}",
-            payload.task_id,
-            payload.index_tables.join(",")
-        );
+        info!("beginning extraction ingest for task: {}", payload.task_id);
         let task = self
             .state
             .coordinator_client
             .get_task(&payload.task_id)
             .await?
             .ok_or(anyhow!("task not found"))?;
-        self.content_state =
-            ContentState::Writing(ContentStateWriting::new(payload.clone(), task)?);
+        self.content_state = ContentState::Writing(ContentStateWriting::new(payload, task)?);
         Ok(())
     }
 
@@ -369,6 +365,19 @@ mod tests {
         config
     }
 
+    fn make_test_task(task_id: &str, content_metadata: &ContentMetadata) -> Task {
+        let mut task = Task::new(task_id, &content_metadata);
+        task.output_index_table_mapping = vec![
+            ("name1".to_string(), "test_index1".to_string()),
+            ("name2".to_string(), "test_index2".to_string()),
+        ]
+        .into_iter()
+        .collect();
+        task.extractor = "test".to_string();
+        task.index_tables = vec!["test_index1".to_string()];
+        task
+    }
+
     struct TestCoordinator {
         coordinator: Arc<Coordinator>,
         handle: JoinHandle<()>,
@@ -428,7 +437,7 @@ mod tests {
                 .await
                 .unwrap();
             test_coordinator
-                .create_task(Task::new("test", &content_metadata))
+                .create_task(make_test_task("test", &content_metadata))
                 .await
                 .unwrap();
             test_coordinator
@@ -517,14 +526,8 @@ mod tests {
         let mut ingest_state = IngestExtractedContentState::new(state);
         let payload = BeginExtractedContentIngest {
             task_id: "test".to_string(),
-            namespace: "test".to_string(),
-            parent_content_id: "".to_string(),
-            extraction_policy: "test".to_string(),
-            extractor: "test".to_string(),
-            output_to_index_table_mapping: HashMap::new(),
             executor_id: "test".to_string(),
             task_outcome: TaskOutcome::Success,
-            index_tables: vec!["test".to_string()],
         };
         ingest_state.begin(payload.clone()).await.unwrap();
         let new_payload = if let ContentState::Writing(s) = &ingest_state.content_state {
@@ -533,14 +536,6 @@ mod tests {
             panic!("content_state should be Writing");
         };
         assert_eq!(new_payload.task_id, payload.task_id);
-        assert_eq!(new_payload.namespace, payload.namespace);
-        assert_eq!(new_payload.parent_content_id, payload.parent_content_id);
-        assert_eq!(new_payload.extraction_policy, payload.extraction_policy);
-        assert_eq!(new_payload.extractor, payload.extractor);
-        assert_eq!(
-            new_payload.output_to_index_table_mapping,
-            payload.output_to_index_table_mapping
-        );
         assert_eq!(new_payload.executor_id, payload.executor_id);
         assert_eq!(new_payload.task_outcome, payload.task_outcome);
 
@@ -607,12 +602,6 @@ mod tests {
         let coordinator = TestCoordinator::new().await;
 
         let mut ingest_state = IngestExtractedContentState::new(state.clone());
-        let output_mappings: HashMap<String, String> = vec![
-            ("name1".to_string(), "test_index1".to_string()),
-            ("name2".to_string(), "test_index2".to_string()),
-        ]
-        .into_iter()
-        .collect();
 
         let schema = indexify_internal_api::EmbeddingSchema {
             dim: 3,
@@ -636,14 +625,8 @@ mod tests {
 
         let payload = BeginExtractedContentIngest {
             task_id: "test".to_string(),
-            namespace: "test".to_string(),
-            parent_content_id: "".to_string(),
-            extraction_policy: "test".to_string(),
-            extractor: "test".to_string(),
-            output_to_index_table_mapping: output_mappings.clone(),
             executor_id: "test".to_string(),
             task_outcome: TaskOutcome::Success,
-            index_tables: vec!["test_index1".to_string()],
         };
 
         ingest_state.begin(payload.clone()).await.unwrap();
@@ -691,21 +674,15 @@ mod tests {
             .await
             .unwrap();
         coordinator
-            .create_task(Task::new("test_1", content_metadata.first().unwrap()))
+            .create_task(make_test_task("test_1", content_metadata.first().unwrap()))
             .await
             .unwrap();
         assert_eq!(content_metadata.first().unwrap().root_content_id, "1");
 
         let payload = BeginExtractedContentIngest {
             task_id: "test_1".to_string(),
-            namespace: "test".to_string(),
-            parent_content_id: "".to_string(),
-            extraction_policy: "test".to_string(),
-            extractor: "test".to_string(),
-            output_to_index_table_mapping: output_mappings,
             executor_id: "test".to_string(),
             task_outcome: TaskOutcome::Success,
-            index_tables: vec!["test_index1".to_string()],
         };
 
         let mut ingest_state = IngestExtractedContentState::new(state.clone());
@@ -750,12 +727,6 @@ mod tests {
         let coordinator = TestCoordinator::new().await;
 
         let mut ingest_state = IngestExtractedContentState::new(state.clone());
-        let output_mappings: HashMap<String, String> = vec![
-            ("name1".to_string(), "test_index1".to_string()),
-            ("name2".to_string(), "test_index2".to_string()),
-        ]
-        .into_iter()
-        .collect();
 
         let schema = indexify_internal_api::EmbeddingSchema {
             dim: 3,
@@ -779,14 +750,8 @@ mod tests {
 
         let payload = BeginExtractedContentIngest {
             task_id: "test".to_string(),
-            namespace: "test".to_string(),
-            parent_content_id: "".to_string(),
-            extraction_policy: "test".to_string(),
-            extractor: "test".to_string(),
-            output_to_index_table_mapping: output_mappings.clone(),
             executor_id: "test".to_string(),
             task_outcome: TaskOutcome::Success,
-            index_tables: vec!["test_index1".to_string()],
         };
 
         ingest_state.begin(payload.clone()).await.unwrap();
@@ -816,20 +781,14 @@ mod tests {
             .await
             .unwrap();
         coordinator
-            .create_task(Task::new("test_1", content_metadata.first().unwrap()))
+            .create_task(make_test_task("test_1", content_metadata.first().unwrap()))
             .await
             .unwrap();
 
         let payload = BeginExtractedContentIngest {
             task_id: "test_1".to_string(),
-            namespace: "test".to_string(),
-            parent_content_id: "".to_string(),
-            extraction_policy: "test".to_string(),
-            extractor: "test".to_string(),
-            output_to_index_table_mapping: output_mappings,
             executor_id: "test".to_string(),
             task_outcome: TaskOutcome::Success,
-            index_tables: vec!["test_index1".to_string()],
         };
 
         let mut ingest_state = IngestExtractedContentState::new(state.clone());

--- a/src/metadata_storage/mod.rs
+++ b/src/metadata_storage/mod.rs
@@ -25,7 +25,6 @@ pub struct ExtractedMetadata {
     pub content_source: String,
     pub metadata: serde_json::Value,
     pub extractor_name: String,
-    pub extraction_policy: String,
 }
 
 impl ExtractedMetadata {
@@ -35,7 +34,6 @@ impl ExtractedMetadata {
         content_source: &str,
         metadata: serde_json::Value,
         extractor_name: &str,
-        extraction_policy: &str,
     ) -> Self {
         Self {
             id: nanoid!(16),
@@ -44,7 +42,6 @@ impl ExtractedMetadata {
             content_source: content_source.into(),
             metadata,
             extractor_name: extractor_name.into(),
-            extraction_policy: extraction_policy.into(),
         }
     }
 }
@@ -133,7 +130,6 @@ async fn test_metadata_storage(index_manager: MetadataStorageTS) {
         content_source: "test_content_source".into(),
         metadata: serde_json::json!({"test": "test"}),
         extractor_name: "test_extractor".into(),
-        extraction_policy: "test_extractor_policy".into(),
     };
     index_manager
         .add_metadata(namespace, metadata.clone())

--- a/src/metadata_storage/postgres.rs
+++ b/src/metadata_storage/postgres.rs
@@ -56,7 +56,6 @@ impl MetadataStorage for PostgresIndexManager {
             id TEXT PRIMARY KEY,
             namespace TEXT,
             extractor TEXT,
-            extractor_policy TEXT,
             content_source TEXT,
             index_name TEXT,
             data JSONB,
@@ -88,12 +87,11 @@ impl MetadataStorage for PostgresIndexManager {
                 .store(true, std::sync::atomic::Ordering::Relaxed);
         }
         let table_name = PostgresIndexName::new(&table_name(namespace));
-        let query = format!("INSERT INTO \"{table_name}\" (id, namespace, extractor, extractor_policy, content_source, index_name, data, content_id, parent_content_id, created_at) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10) ON CONFLICT (id) DO UPDATE SET data = EXCLUDED.data;");
+        let query = format!("INSERT INTO \"{table_name}\" (id, namespace, extractor, content_source, index_name, data, content_id, parent_content_id, created_at) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9) ON CONFLICT (id) DO UPDATE SET data = EXCLUDED.data;");
         let _ = sqlx::query(&query)
             .bind(metadata.id)
             .bind(namespace)
             .bind(metadata.extractor_name)
-            .bind(metadata.extraction_policy)
             .bind(metadata.content_source)
             .bind(table_name.to_string())
             .bind(metadata.metadata)

--- a/src/metadata_storage/query_engine.rs
+++ b/src/metadata_storage/query_engine.rs
@@ -235,7 +235,6 @@ mod tests {
             "test_content_source",
             json!({"name": "diptanu", "role": "founder"}),
             "test_extractor",
-            "test_extractor_policy",
         );
         let meta2 = ExtractedMetadata::new(
             "test_content_id",
@@ -243,7 +242,6 @@ mod tests {
             "test_content_source",
             json!({"name": "lucas", "role": "engineer"}),
             "test_extractor",
-            "test_extractor_policy",
         );
         let meta3 = ExtractedMetadata::new(
             "test_content_id",
@@ -251,7 +249,6 @@ mod tests {
             "test_content_source",
             json!({"name": "zaid", "role": "engineer"}),
             "test_extractor",
-            "test_extractor_policy",
         );
         index_manager.add_metadata(ns, meta1).await.unwrap();
         index_manager.add_metadata(ns, meta2).await.unwrap();

--- a/src/metadata_storage/sqlite.rs
+++ b/src/metadata_storage/sqlite.rs
@@ -47,7 +47,6 @@ impl MetadataStorage for SqliteIndexManager {
             id TEXT PRIMARY KEY,
             namespace TEXT,
             extractor TEXT,
-            extractor_policy_name TEXT,
             content_source TEXT,
             index_name TEXT,
             data JSONB,
@@ -85,10 +84,10 @@ impl MetadataStorage for SqliteIndexManager {
         let query = format!(
             "
             INSERT INTO {index_name} (
-                id, namespace, extractor, extractor_policy_name,
+                id, namespace, extractor,
                 content_source, index_name, data, content_id,
                 parent_content_id, created_at
-            ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+            ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
             ON CONFLICT (id) DO UPDATE SET data = EXCLUDED.data;
         "
         );
@@ -96,7 +95,6 @@ impl MetadataStorage for SqliteIndexManager {
             .bind(metadata.id)
             .bind(namespace)
             .bind(metadata.extractor_name)
-            .bind(metadata.extraction_policy)
             .bind(metadata.content_source)
             .bind(index_name.to_string())
             .bind(metadata.metadata)

--- a/src/metadata_storage/sqlx.rs
+++ b/src/metadata_storage/sqlx.rs
@@ -17,11 +17,10 @@ where
 {
     let id: String = row.get(0);
     let extractor: String = row.get(2);
-    let extraction_policy: String = row.get(3);
-    let content_source: String = row.get(4);
-    let data: serde_json::Value = row.get(6);
-    let content_id: String = row.get(7);
-    let parent_content_id: String = row.get(8);
+    let content_source: String = row.get(3);
+    let data: serde_json::Value = row.get(5);
+    let content_id: String = row.get(6);
+    let parent_content_id: String = row.get(7);
     ExtractedMetadata {
         id,
         content_id,
@@ -29,7 +28,6 @@ where
         content_source,
         metadata: data,
         extractor_name: extractor,
-        extraction_policy,
     }
 }
 


### PR DESCRIPTION
Remove BeginExtractedContentIngest fields that were duplicated from Task and replace their usages with task references.

Remove 'extractor_policy' from metadata, it had the same value as 'source'.

Remove unused fields from task updates.