### PR TITLE
add support for tracing propagation across grpc calls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1175,7 +1175,7 @@ dependencies = [
  "http-body 1.0.0",
  "opentelemetry 0.21.0",
  "opentelemetry-prometheus 0.14.1",
- "opentelemetry-semantic-conventions",
+ "opentelemetry-semantic-conventions 0.13.0",
  "opentelemetry_sdk 0.21.2",
  "pin-project-lite",
  "prometheus",
@@ -1237,7 +1237,7 @@ dependencies = [
  "pin-project-lite",
  "tower",
  "tracing",
- "tracing-opentelemetry",
+ "tracing-opentelemetry 0.22.0",
  "tracing-opentelemetry-instrumentation-sdk",
 ]
 
@@ -1267,6 +1267,12 @@ dependencies = [
  "object",
  "rustc-demangle",
 ]
+
+[[package]]
+name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
@@ -1328,7 +1334,7 @@ dependencies = [
  "bitflags 2.5.0",
  "cexpr",
  "clang-sys",
- "itertools",
+ "itertools 0.12.1",
  "lazy_static",
  "lazycell",
  "log",
@@ -2046,7 +2052,7 @@ dependencies = [
  "half",
  "hashbrown 0.14.3",
  "indexmap 2.2.6",
- "itertools",
+ "itertools 0.12.1",
  "log",
  "num_cpus",
  "object_store",
@@ -2163,7 +2169,7 @@ dependencies = [
  "datafusion-expr",
  "datafusion-physical-expr",
  "hashbrown 0.14.3",
- "itertools",
+ "itertools 0.12.1",
  "log",
  "regex-syntax 0.8.3",
 ]
@@ -2192,7 +2198,7 @@ dependencies = [
  "hashbrown 0.14.3",
  "hex",
  "indexmap 2.2.6",
- "itertools",
+ "itertools 0.12.1",
  "log",
  "md-5",
  "paste",
@@ -2225,7 +2231,7 @@ dependencies = [
  "half",
  "hashbrown 0.14.3",
  "indexmap 2.2.6",
- "itertools",
+ "itertools 0.12.1",
  "log",
  "once_cell",
  "parking_lot",
@@ -2258,9 +2264,9 @@ dependencies = [
  "async-recursion",
  "chrono",
  "datafusion",
- "itertools",
+ "itertools 0.12.1",
  "object_store",
- "prost",
+ "prost 0.12.4",
  "prost-types",
  "substrait",
 ]
@@ -2879,7 +2885,7 @@ dependencies = [
  "hex",
  "im-rc",
  "iter-enum",
- "itertools",
+ "itertools 0.12.1",
  "md-5",
  "ordered-float 4.2.0",
  "rand",
@@ -3327,11 +3333,12 @@ dependencies = [
  "futures",
  "gluesql",
  "hostname",
+ "http 1.1.0",
  "hyper 1.2.0",
  "hyper-util",
  "indexify_internal_api",
  "indexify_proto",
- "itertools",
+ "itertools 0.12.1",
  "jsonschema",
  "lance",
  "lancedb",
@@ -3345,7 +3352,11 @@ dependencies = [
  "openraft",
  "opensearch",
  "opentelemetry 0.22.0",
+ "opentelemetry-datadog",
+ "opentelemetry-otlp",
  "opentelemetry-prometheus 0.15.0",
+ "opentelemetry-stdout",
+ "opentelemetry-tonic",
  "opentelemetry_sdk 0.22.1",
  "pgvector",
  "pin-project-lite",
@@ -3375,12 +3386,13 @@ dependencies = [
  "tokio-rustls 0.26.0",
  "tokio-stream",
  "tokio-util",
- "tonic",
+ "tonic 0.11.0",
  "tonic-build",
  "tower",
  "tower-http",
  "tracing",
  "tracing-core",
+ "tracing-opentelemetry 0.23.0",
  "tracing-subscriber",
  "tracing-test",
  "tracing-unwrap",
@@ -3414,9 +3426,9 @@ dependencies = [
 name = "indexify_proto"
 version = "0.1.0"
 dependencies = [
- "prost",
+ "prost 0.12.4",
  "serde",
- "tonic",
+ "tonic 0.11.0",
 ]
 
 [[package]]
@@ -3495,6 +3507,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9afe8eb02c890a1731dffecae2a39a235ef45be79341460f25aea267e1de072f"
 dependencies = [
  "derive_utils 0.14.1",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -3594,7 +3624,7 @@ dependencies = [
  "datafusion-physical-expr",
  "futures",
  "half",
- "itertools",
+ "itertools 0.12.1",
  "lance-arrow",
  "lance-core",
  "lance-datafusion",
@@ -3612,7 +3642,7 @@ dependencies = [
  "object_store",
  "ordered-float 3.9.2",
  "pin-project",
- "prost",
+ "prost 0.12.4",
  "prost-build",
  "rand",
  "roaring",
@@ -3668,7 +3698,7 @@ dependencies = [
  "moka 0.11.3",
  "object_store",
  "pin-project",
- "prost",
+ "prost 0.12.4",
  "rand",
  "roaring",
  "serde_json",
@@ -3698,7 +3728,7 @@ dependencies = [
  "futures",
  "lance-arrow",
  "lance-core",
- "prost",
+ "prost 0.12.4",
  "snafu",
  "tokio",
 ]
@@ -3740,7 +3770,7 @@ dependencies = [
  "num-traits",
  "num_cpus",
  "object_store",
- "prost",
+ "prost 0.12.4",
  "prost-build",
  "roaring",
  "snafu",
@@ -3768,7 +3798,7 @@ dependencies = [
  "datafusion-sql",
  "futures",
  "half",
- "itertools",
+ "itertools 0.12.1",
  "lance-arrow",
  "lance-core",
  "lance-datafusion",
@@ -3781,7 +3811,7 @@ dependencies = [
  "num-traits",
  "num_cpus",
  "object_store",
- "prost",
+ "prost 0.12.4",
  "prost-build",
  "rand",
  "roaring",
@@ -3822,7 +3852,7 @@ dependencies = [
  "num_cpus",
  "object_store",
  "pin-project",
- "prost",
+ "prost 0.12.4",
  "prost-build",
  "shellexpand",
  "snafu",
@@ -3879,7 +3909,7 @@ dependencies = [
  "lazy_static",
  "log",
  "object_store",
- "prost",
+ "prost 0.12.4",
  "prost-build",
  "prost-types",
  "rand",
@@ -4601,7 +4631,7 @@ dependencies = [
  "futures",
  "humantime",
  "hyper 0.14.28",
- "itertools",
+ "itertools 0.12.1",
  "md-5",
  "parking_lot",
  "percent-encoding",
@@ -4674,6 +4704,25 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "opentelemetry"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6105e89802af13fdf48c49d7646d3b533a70e536d818aae7e78ba0433d01acb8"
+dependencies = [
+ "async-trait",
+ "crossbeam-channel",
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "js-sys",
+ "lazy_static",
+ "percent-encoding",
+ "pin-project",
+ "rand",
+ "thiserror",
+]
+
+[[package]]
+name = "opentelemetry"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e32339a5dc40459130b3bd269e9892439f55b33e772d2a9d402a789baaf4e8a"
@@ -4704,6 +4753,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry-datadog"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "157dbb3739d0a29158aae6c94a43aa842e1f07e6205992ca92a32005e4e77c5d"
+dependencies = [
+ "futures-core",
+ "http 0.2.12",
+ "indexmap 2.2.6",
+ "itertools 0.11.0",
+ "once_cell",
+ "opentelemetry 0.22.0",
+ "opentelemetry-http",
+ "opentelemetry-semantic-conventions 0.14.0",
+ "opentelemetry_sdk 0.22.1",
+ "rmp",
+ "thiserror",
+ "url",
+]
+
+[[package]]
+name = "opentelemetry-http"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7690dc77bf776713848c4faa6501157469017eaf332baccd4eb1cea928743d94"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http 0.2.12",
+ "opentelemetry 0.22.0",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a016b8d9495c639af2145ac22387dcb88e44118e45320d9238fbf4e7889abcb"
+dependencies = [
+ "async-trait",
+ "futures-core",
+ "http 0.2.12",
+ "opentelemetry 0.22.0",
+ "opentelemetry-http",
+ "opentelemetry-proto",
+ "opentelemetry-semantic-conventions 0.14.0",
+ "opentelemetry_sdk 0.22.1",
+ "prost 0.12.4",
+ "thiserror",
+ "tokio",
+ "tonic 0.11.0",
+]
+
+[[package]]
 name = "opentelemetry-prometheus"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4730,12 +4831,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry-proto"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a8fddc9b68f5b80dae9d6f510b88e02396f006ad48cac349411fbecc80caae4"
+dependencies = [
+ "opentelemetry 0.22.0",
+ "opentelemetry_sdk 0.22.1",
+ "prost 0.12.4",
+ "tonic 0.11.0",
+]
+
+[[package]]
 name = "opentelemetry-semantic-conventions"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f5774f1ef1f982ef2a447f6ee04ec383981a3ab99c8e77a1a7b30182e65bbc84"
 dependencies = [
  "opentelemetry 0.21.0",
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9ab5bd6c42fb9349dcf28af2ba9a0667f697f9bdcca045d39f2cec5543e2910"
+
+[[package]]
+name = "opentelemetry-stdout"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bdf28b381f23afcd150afc0b38a4183dd321fc96320c1554752b6b761648f78"
+dependencies = [
+ "async-trait",
+ "chrono",
+ "futures-util",
+ "opentelemetry 0.22.0",
+ "opentelemetry_sdk 0.22.1",
+ "ordered-float 4.2.0",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "opentelemetry-tonic"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c83072b9ea4ec7cf40453965ed876dfb0c92b24f1f54eea52f02518137e9ee50"
+dependencies = [
+ "opentelemetry 0.17.0",
+ "tonic 0.8.3",
+ "tracing",
+ "tracing-opentelemetry 0.17.4",
 ]
 
 [[package]]
@@ -4777,7 +4925,10 @@ dependencies = [
  "ordered-float 4.2.0",
  "percent-encoding",
  "rand",
+ "serde_json",
  "thiserror",
+ "tokio",
+ "tokio-stream",
 ]
 
 [[package]]
@@ -5206,12 +5357,22 @@ dependencies = [
 
 [[package]]
 name = "prost"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
+dependencies = [
+ "bytes",
+ "prost-derive 0.11.9",
+]
+
+[[package]]
+name = "prost"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0f5d036824e4761737860779c906171497f6d55681139d8312388f8fe398922"
 dependencies = [
  "bytes",
- "prost-derive",
+ "prost-derive 0.12.4",
 ]
 
 [[package]]
@@ -5222,17 +5383,30 @@ checksum = "80b776a1b2dc779f5ee0641f8ade0125bc1298dd41a9a0c16d8bd57b42d222b1"
 dependencies = [
  "bytes",
  "heck 0.5.0",
- "itertools",
+ "itertools 0.12.1",
  "log",
  "multimap",
  "once_cell",
  "petgraph",
  "prettyplease",
- "prost",
+ "prost 0.12.4",
  "prost-types",
  "regex",
  "syn 2.0.58",
  "tempfile",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
+dependencies = [
+ "anyhow",
+ "itertools 0.10.5",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -5242,7 +5416,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19de2de2a00075bf566bee3bd4db014b11587e84184d3f7a791bc17f1a8e9e48"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.58",
@@ -5254,7 +5428,7 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3235c33eb02c1f1e212abdbe34c78b264b038fb58ca612664343271e36e55ffe"
 dependencies = [
- "prost",
+ "prost 0.12.4",
 ]
 
 [[package]]
@@ -5302,12 +5476,12 @@ checksum = "3f99a77fdc9b1ef9ce9ab9edcdd3e56e6977475faf633598f1a37066c87be4b7"
 dependencies = [
  "anyhow",
  "futures-util",
- "prost",
+ "prost 0.12.4",
  "prost-types",
  "reqwest 0.12.4",
  "serde",
  "serde_json",
- "tonic",
+ "tonic 0.11.0",
 ]
 
 [[package]]
@@ -5685,6 +5859,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "rmp"
+version = "0.8.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "228ed7c16fa39782c3b3468e974aec2795e9089153cd08ee2e9aefb3613334c4"
+dependencies = [
+ "byteorder",
+ "num-traits",
+ "paste",
 ]
 
 [[package]]
@@ -6411,7 +6596,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce81b7bd7c4493975347ef60d8c7e8b742d4694f4c49f93e0a12ea263938176c"
 dependencies = [
- "itertools",
+ "itertools 0.12.1",
  "nom",
  "unicode_categories",
 ]
@@ -6722,7 +6907,7 @@ dependencies = [
  "git2",
  "heck 0.4.1",
  "prettyplease",
- "prost",
+ "prost 0.12.4",
  "prost-build",
  "prost-types",
  "schemars",
@@ -7104,6 +7289,38 @@ dependencies = [
 
 [[package]]
 name = "tonic"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f219fad3b929bef19b1f86fbc0358d35daed8f2cac972037ac0dc10bbb8d5fb"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "axum 0.6.20",
+ "base64 0.13.1",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "h2 0.3.26",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.28",
+ "hyper-timeout",
+ "percent-encoding",
+ "pin-project",
+ "prost 0.11.9",
+ "prost-derive 0.11.9",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+ "tracing-futures",
+]
+
+[[package]]
+name = "tonic"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76c4eb7a4e9ef9d4763600161f12f5070b92a578e1b634db88a6887844c91a13"
@@ -7121,7 +7338,7 @@ dependencies = [
  "hyper-timeout",
  "percent-encoding",
  "pin-project",
- "prost",
+ "prost 0.12.4",
  "rustls-native-certs 0.7.0",
  "rustls-pemfile 2.1.1",
  "rustls-pki-types",
@@ -7181,6 +7398,7 @@ dependencies = [
  "pin-project-lite",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -7240,6 +7458,17 @@ dependencies = [
 
 [[package]]
 name = "tracing-log"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f751112709b4e791d8ce53e32c4ed2d353565a795ce84da2285393f41557bdf2"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-log"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
@@ -7247,6 +7476,20 @@ dependencies = [
  "log",
  "once_cell",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-opentelemetry"
+version = "0.17.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbbe89715c1dbbb790059e2565353978564924ee85017b5fff365c872ff6721f"
+dependencies = [
+ "once_cell",
+ "opentelemetry 0.17.0",
+ "tracing",
+ "tracing-core",
+ "tracing-log 0.1.4",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -7262,9 +7505,29 @@ dependencies = [
  "smallvec",
  "tracing",
  "tracing-core",
- "tracing-log",
+ "tracing-log 0.2.0",
  "tracing-subscriber",
- "web-time",
+ "web-time 0.2.4",
+]
+
+[[package]]
+name = "tracing-opentelemetry"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9be14ba1bbe4ab79e9229f7f89fab8d120b865859f10527f31c033e599d2284"
+dependencies = [
+ "async-trait",
+ "futures-util",
+ "js-sys",
+ "once_cell",
+ "opentelemetry 0.22.0",
+ "opentelemetry_sdk 0.22.1",
+ "smallvec",
+ "tracing",
+ "tracing-core",
+ "tracing-log 0.2.0",
+ "tracing-subscriber",
+ "web-time 1.1.0",
 ]
 
 [[package]]
@@ -7276,7 +7539,7 @@ dependencies = [
  "http 1.1.0",
  "opentelemetry 0.21.0",
  "tracing",
- "tracing-opentelemetry",
+ "tracing-opentelemetry 0.22.0",
 ]
 
 [[package]]
@@ -7294,7 +7557,7 @@ dependencies = [
  "thread_local",
  "tracing",
  "tracing-core",
- "tracing-log",
+ "tracing-log 0.2.0",
 ]
 
 [[package]]
@@ -7798,6 +8061,16 @@ name = "web-time"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa30049b1c872b72c89866d458eae9f20380ab280ffd1b1e18df2d3e2d98cfe0"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,8 +101,8 @@ tokio-stream = { version = "0.1", features = ["sync"] }
 tokio-rustls = { version = "0.26" }
 tokio-util = {version ="0.7.10"}
 tower = { version = "0.4" }
-tower-http = { version = "0.5.1", default_features = false, features = [
-    "cors",
+tower-http = { version = "0.5.1", default-features = false, features = [
+    "cors", "trace"
 ] }
 tracing = { version = "0.1", features = ["log"] }
 tracing-core = "0.1"
@@ -121,6 +121,11 @@ walkdir = { version = "2" }
 vectordb = {version = "0.4.10" }
 lance = {version = "0.10.6", default_features=false}
 gluesql = { git = "https://github.com/gluesql/gluesql.git", rev = "07dd839", default_features = false }
+tracing-opentelemetry = { version = "0.23.0", features = ["async-trait", "futures-util"] }
+opentelemetry-otlp = { version = "0.15.0", features = ["http-proto", "grpc-tonic"] }
+opentelemetry-tonic = "0.1.0"
+http = "1.1.0"
+opentelemetry-stdout = { version = "0.3.0", features = ["logs", "trace"] }
 
 [dependencies]
 anyerror = { workspace = true }
@@ -206,7 +211,12 @@ sha2 = "0.10.8"
 lancedb = {version = "0.4.15", default_features = false}
 opentelemetry-prometheus = "0.15"
 prometheus = "0.13"
-opentelemetry_sdk = { version = "0.22", features = ["metrics"] }
+opentelemetry_sdk = { version = "0.22", features = ["metrics", "rt-tokio"] }
+tracing-opentelemetry = { workspace = true }
+opentelemetry-otlp = { workspace = true }
+opentelemetry-tonic = { workspace = true }
+http = { workspace = true }
+opentelemetry-stdout = { workspace = true }
 
 [dev-dependencies]
 tracing-test = { version = "0.2", features = ["no-env-filter"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,6 +126,7 @@ opentelemetry-otlp = { version = "0.15.0", features = ["http-proto", "grpc-tonic
 opentelemetry-tonic = "0.1.0"
 http = "1.1.0"
 opentelemetry-stdout = { version = "0.3.0", features = ["logs", "trace"] }
+opentelemetry-datadog = "0.10.0"
 
 [dependencies]
 anyerror = { workspace = true }
@@ -217,6 +218,7 @@ opentelemetry-otlp = { workspace = true }
 opentelemetry-tonic = { workspace = true }
 http = { workspace = true }
 opentelemetry-stdout = { workspace = true }
+opentelemetry-datadog = { workspace = true }
 
 [dev-dependencies]
 tracing-test = { version = "0.2", features = ["no-env-filter"] }

--- a/src/server.rs
+++ b/src/server.rs
@@ -292,7 +292,8 @@ impl Server {
             .layer(metrics)
             .layer(Extension(caches))
             .layer(cors)
-            .layer(DefaultBodyLimit::disable());
+            .layer(DefaultBodyLimit::disable())
+            .layer(tower_http::trace::TraceLayer::new_for_http());
 
         let handle = Handle::new();
 


### PR DESCRIPTION
Support opentelemetry context propagation across grpc calls. Add tracing for http requests. Add support for enabling tracing.