### PR TITLE
remove unnecessary hash conversions

### DIFF
--- a/crates/indexify_proto/src/indexify_coordinator.rs
+++ b/crates/indexify_proto/src/indexify_coordinator.rs
@@ -8,11 +8,8 @@ pub struct GetContentMetadataRequest {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetContentMetadataResponse {
-    #[prost(map = "string, message", tag = "1")]
-    pub content_list: ::std::collections::HashMap<
-        ::prost::alloc::string::String,
-        ContentMetadata,
-    >,
+    #[prost(message, repeated, tag = "1")]
+    pub content_list: ::prost::alloc::vec::Vec<ContentMetadata>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/protos/coordinator_service.proto
+++ b/protos/coordinator_service.proto
@@ -70,7 +70,7 @@ message GetContentMetadataRequest {
 }
 
 message GetContentMetadataResponse {
-    map<string, ContentMetadata> content_list = 1;
+    repeated ContentMetadata content_list = 1;
 }
 
 message GetContentTreeMetadataRequest {

--- a/src/coordinator_service.rs
+++ b/src/coordinator_service.rs
@@ -649,18 +649,14 @@ impl CoordinatorService for CoordinatorServiceServer {
         req: Request<GetContentMetadataRequest>,
     ) -> Result<Response<indexify_coordinator::GetContentMetadataResponse>, Status> {
         let req = req.into_inner();
-        let content_metadata_list = self
+        let content_list = self
             .coordinator
             .get_content_metadata(req.content_list)
             .await
             .map_err(|e| tonic::Status::aborted(e.to_string()))?;
-        let content_metadata = content_metadata_list
-            .iter()
-            .map(|c| (c.id.id.clone(), c.clone().into()))
-            .collect::<HashMap<String, indexify_coordinator::ContentMetadata>>();
         Ok(Response::new(
             indexify_coordinator::GetContentMetadataResponse {
-                content_list: content_metadata,
+                content_list: content_list.into_iter().map(Into::into).collect(),
             },
         ))
     }

--- a/src/data_manager.rs
+++ b/src/data_manager.rs
@@ -379,13 +379,9 @@ impl DataManager {
             .get()
             .await?
             .get_content_metadata(req)
-            .await?;
-        let content_metadata_list = response.into_inner().content_list;
-        let mut content_list = Vec::new();
-        for c in content_metadata_list.values().cloned() {
-            content_list.push(c.into())
-        }
-        Ok(content_list)
+            .await?
+            .into_inner();
+        Ok(response.content_list.into_iter().map(Into::into).collect())
     }
 
     pub async fn get_content_tree_metadata(


### PR DESCRIPTION
get_content_metadata() rpc was defined to return hash though every caller just wanted a vector. Remove unnecessary hash creation.