### PR TITLE
remove namespace argument

### DIFF
--- a/src/coordinator.rs
+++ b/src/coordinator.rs
@@ -449,7 +449,6 @@ impl Coordinator {
             .await?;
         self.shared_state
             .tombstone_content_batch_with_version(
-                &content_metadata.namespace,
                 &[content_metadata.id.clone()],
                 vec![StateChangeProcessed {
                     state_change_id: change.id.clone(),
@@ -508,13 +507,9 @@ impl Coordinator {
         Ok(())
     }
 
-    pub async fn tombstone_content_metadatas(
-        &self,
-        namespace: &str,
-        content_ids: &[String],
-    ) -> Result<()> {
+    pub async fn tombstone_content_metadatas(&self, content_ids: &[String]) -> Result<()> {
         self.shared_state
-            .tombstone_content_batch(namespace, content_ids)
+            .tombstone_content_batch(content_ids)
             .await?;
         Ok(())
     }
@@ -1318,10 +1313,7 @@ mod tests {
             .await?;
 
         coordinator
-            .tombstone_content_metadatas(
-                DEFAULT_TEST_NAMESPACE,
-                &[parent_content.id.clone(), parent_content_2.id.clone()],
-            )
+            .tombstone_content_metadatas(&[parent_content.id.clone(), parent_content_2.id.clone()])
             .await?;
 
         //  Check that content has been correctly tombstoned
@@ -1453,7 +1445,7 @@ mod tests {
 
         coordinator
             .shared_state
-            .tombstone_content_batch(DEFAULT_TEST_NAMESPACE, &[parent_content.id])
+            .tombstone_content_batch(&[parent_content.id])
             .await?;
 
         //  after tombstone
@@ -1630,7 +1622,7 @@ mod tests {
 
         //  create a state change for tombstoning the content tree
         coordinator
-            .tombstone_content_metadatas(&parent_content.namespace, &[parent_content.id])
+            .tombstone_content_metadatas(&[parent_content.id])
             .await?;
 
         coordinator.run_scheduler().await?;

--- a/src/coordinator_service.rs
+++ b/src/coordinator_service.rs
@@ -153,10 +153,9 @@ impl CoordinatorService for CoordinatorServiceServer {
         request: tonic::Request<TombstoneContentRequest>,
     ) -> Result<tonic::Response<TombstoneContentResponse>, tonic::Status> {
         let req = request.into_inner();
-        let namespace = req.namespace;
         let content_ids = req.content_ids;
         self.coordinator
-            .tombstone_content_metadatas(&namespace, &content_ids)
+            .tombstone_content_metadatas(&content_ids)
             .await
             .map_err(|e| tonic::Status::aborted(e.to_string()))?;
         Ok(tonic::Response::new(TombstoneContentResponse {}))

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -1064,7 +1064,6 @@ impl App {
     /// get the latest version of each content id and tombstone that one
     pub async fn tombstone_content_batch(
         &self,
-        namespace: &str,
         content_ids: &[String],
     ) -> Result<(), anyhow::Error> {
         let mut updated_content_ids = Vec::new();
@@ -1086,7 +1085,7 @@ impl App {
             updated_content_ids.push(id.clone());
         }
 
-        self.tombstone_content_batch_with_version(namespace, &updated_content_ids, vec![])
+        self.tombstone_content_batch_with_version(&updated_content_ids, vec![])
             .await?;
 
         Ok(())
@@ -1094,7 +1093,6 @@ impl App {
 
     pub async fn tombstone_content_batch_with_version(
         &self,
-        namespace: &str,
         content_ids: &[ContentMetadataId],
         state_changes_processed: Vec<StateChangeProcessed>,
     ) -> Result<(), anyhow::Error> {
@@ -1125,7 +1123,6 @@ impl App {
         }
         let req = StateMachineUpdateRequest {
             payload: RequestPayload::TombstoneContentTree {
-                namespace: namespace.to_string(),
                 content_metadata: updated_content,
             },
             new_state_changes: state_changes,

--- a/src/state/store/requests.rs
+++ b/src/state/store/requests.rs
@@ -62,7 +62,6 @@ pub enum RequestPayload {
         content_metadata: Vec<internal_api::ContentMetadata>,
     },
     TombstoneContentTree {
-        namespace: String,
         content_metadata: Vec<internal_api::ContentMetadata>,
     },
     CreateExtractionPolicy {

--- a/src/state/store/state_machine_objects.rs
+++ b/src/state/store/state_machine_objects.rs
@@ -1287,10 +1287,7 @@ impl IndexifyState {
             RequestPayload::UpdateContent { content_metadata } => {
                 self.set_content(db, &txn, content_metadata)?;
             }
-            RequestPayload::TombstoneContentTree {
-                namespace: _,
-                content_metadata,
-            } => {
+            RequestPayload::TombstoneContentTree { content_metadata } => {
                 self.tombstone_content_tree(db, &txn, content_metadata)?;
             }
             RequestPayload::CreateExtractionPolicy {


### PR DESCRIPTION
Namespace field in TombstoneContentTree was ignored, remove passing namespace down the call stack.