### PR TITLE
remove Option for root_content_id

### DIFF
--- a/crates/indexify_internal_api/src/lib.rs
+++ b/crates/indexify_internal_api/src/lib.rs
@@ -612,7 +612,7 @@ impl Default for ContentMetadataId {
 pub struct ContentMetadata {
     pub id: ContentMetadataId,
     pub parent_id: Option<ContentMetadataId>,
-    pub root_content_id: Option<String>,
+    pub root_content_id: String,
     // Namespace name == Namespace ID
     pub namespace: String,
     pub name: String,
@@ -634,7 +634,7 @@ impl From<ContentMetadata> for indexify_coordinator::ContentMetadata {
             parent_id: value.parent_id.map(|id| id.id).unwrap_or_default(), /*  don't expose the
                               * version on the
                               * task */
-            root_content_id: value.root_content_id.unwrap_or_default(),
+            root_content_id: value.root_content_id,
             file_name: value.name,
             mime: value.content_type,
             labels: value.labels,
@@ -651,11 +651,6 @@ impl From<ContentMetadata> for indexify_coordinator::ContentMetadata {
 
 impl From<indexify_coordinator::ContentMetadata> for ContentMetadata {
     fn from(value: indexify_coordinator::ContentMetadata) -> Self {
-        let root_content_id = if value.root_content_id.is_empty() {
-            None
-        } else {
-            Some(value.root_content_id)
-        };
         let parent_id = if value.parent_id.is_empty() {
             None
         } else {
@@ -667,7 +662,7 @@ impl From<indexify_coordinator::ContentMetadata> for ContentMetadata {
                 version: 1,
             },
             parent_id,
-            root_content_id,
+            root_content_id: value.root_content_id,
             name: value.file_name,
             content_type: value.mime,
             labels: value.labels,
@@ -688,7 +683,7 @@ impl Default for ContentMetadata {
         Self {
             id: ContentMetadataId::default(),
             parent_id: None,
-            root_content_id: Some(ContentMetadataId::default().id),
+            root_content_id: ContentMetadataId::default().id,
             namespace: "test_namespace".to_string(),
             name: "test_name".to_string(),
             content_type: "test_content_type".to_string(),

--- a/src/api.rs
+++ b/src/api.rs
@@ -418,7 +418,7 @@ impl From<indexify_internal_api::ContentMetadata> for ContentMetadata {
         Self {
             id: value.id.id,
             parent_id: value.parent_id.map(|id| id.id).unwrap_or_default(),
-            root_content_id: value.root_content_id.unwrap_or_default(),
+            root_content_id: value.root_content_id,
             namespace: value.namespace,
             name: value.name,
             mime_type: value.content_type,

--- a/src/coordinator.rs
+++ b/src/coordinator.rs
@@ -270,6 +270,9 @@ impl Coordinator {
         task_id: &str,
     ) -> Result<(internal_api::Task, Option<internal_api::ContentMetadata>)> {
         let task = self.shared_state.task_with_id(task_id).await?;
+        if task.content_metadata.root_content_id == task.content_metadata.id.id {
+            return Ok((task, None));
+        }
         let root_content = self
             .shared_state
             .get_content_metadata_batch(vec![task.content_metadata.root_content_id.clone()])

--- a/src/coordinator.rs
+++ b/src/coordinator.rs
@@ -270,16 +270,12 @@ impl Coordinator {
         task_id: &str,
     ) -> Result<(internal_api::Task, Option<internal_api::ContentMetadata>)> {
         let task = self.shared_state.task_with_id(task_id).await?;
-        let mut root_content = None;
-        if let Some(root_content_id) = &task.content_metadata.root_content_id {
-            let root_cm = self
-                .shared_state
-                .get_content_metadata_batch(vec![root_content_id.clone()])
-                .await?;
-            if let Some(root_cm) = root_cm.first() {
-                root_content.replace(root_cm.clone());
-            }
-        }
+        let root_content = self
+            .shared_state
+            .get_content_metadata_batch(vec![task.content_metadata.root_content_id.clone()])
+            .await?
+            .first()
+            .cloned();
         Ok((task, root_content))
     }
 

--- a/src/data_manager.rs
+++ b/src/data_manager.rs
@@ -339,6 +339,7 @@ impl DataManager {
             file_name: file.to_string(),
             storage_url: file.to_string(),
             parent_id: "".to_string(),
+            root_content_id: id.clone(),
             created_at: current_ts_secs as i64,
             mime: mime.to_string(),
             namespace: namespace.to_string(),
@@ -346,7 +347,7 @@ impl DataManager {
             source: "ingestion".to_string(),
             size_bytes: 0,
             hash: "".to_string(),
-            ..Default::default()
+            extraction_policy_ids: HashMap::new(),
         };
         let req: indexify_coordinator::CreateContentRequest =
             indexify_coordinator::CreateContentRequest {
@@ -508,7 +509,7 @@ impl DataManager {
             file_name,
             storage_url: res.url,
             parent_id: "".to_string(),
-            root_content_id: "".to_string(),
+            root_content_id: id,
             created_at: current_ts_secs as i64,
             mime: content_type,
             namespace: namespace.to_string(),

--- a/src/ingest_extracted_content.rs
+++ b/src/ingest_extracted_content.rs
@@ -466,7 +466,7 @@ mod tests {
                 id: ContentMetadataId::new("1"),
                 name: "test".to_string(),
                 parent_id: None,
-                root_content_id: Some("1".to_string()),
+                root_content_id: "1".to_string(),
                 namespace: "test".to_string(),
                 content_type: "text/plain".to_string(),
                 storage_url: "test".to_string(),
@@ -724,7 +724,7 @@ mod tests {
             .unwrap();
         assert_eq!(
             content_metadata.first().unwrap().root_content_id,
-            Some("1".to_string())
+            "1".to_string()
         );
 
         let payload = BeginExtractedContentIngest {

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -20,7 +20,7 @@ pub mod db_utils {
     ) -> internal_api::ContentMetadata {
         internal_api::ContentMetadata {
             id: ContentMetadataId::new(id),
-            root_content_id: Some(root_content_id.to_string()),
+            root_content_id: root_content_id.to_string(),
             namespace: DEFAULT_TEST_NAMESPACE.to_string(),
             source: "test_source".to_string(),
             ..Default::default()


### PR DESCRIPTION
root_content_id does not need to be optional, it is defined in all cases. For the root of the content tree root_content_id is the same as id.