### PR TITLE
Add copy buttons and search index button

### DIFF
--- a/ui/src/components/CopyText.tsx
+++ b/ui/src/components/CopyText.tsx
@@ -1,0 +1,30 @@
+import { Box, IconButton, Tooltip } from "@mui/material";
+import ContentCopy from "@mui/icons-material/ContentCopy";
+import { useState } from "react";
+
+const CopyText = ({
+  text,
+  color,
+}: {
+  text: string;
+  color?: string;
+}) => {
+  const [showAlert, setShowAlert] = useState(false);
+  const handleCopy = () => {
+    navigator.clipboard.writeText(text);
+    setShowAlert(true);
+  };
+  return (
+    <Box>
+
+        <Tooltip title={showAlert ? "Copied!" : "Copy to clipboard"}>
+          <IconButton onClick={handleCopy}>
+            <ContentCopy sx={{ color, height:'20px' }} />
+          </IconButton>
+        </Tooltip>
+
+    </Box>
+  );
+};
+
+export default CopyText;

--- a/ui/src/components/ExtractionGraphs.tsx
+++ b/ui/src/components/ExtractionGraphs.tsx
@@ -11,6 +11,7 @@ import GavelIcon from "@mui/icons-material/Gavel";
 import InfoIcon from "@mui/icons-material/Info";
 import ExtractionPolicyItem from "./ExtractionPolicyItem";
 import { IExtractionGraphCol, IExtractionGraphColumns } from "../types";
+import CopyText from "./CopyText";
 
 const ExtractionGraphs = ({
   extractionGraphs,
@@ -27,11 +28,11 @@ const ExtractionGraphs = ({
   const cols: IExtractionGraphColumns = {
     name: { displayName: "Name", width: 350 },
     extractor: { displayName: "Extractor", width: 225 },
-    mimeTypes: { displayName: "Input MimeTypes", width: 225},
+    mimeTypes: { displayName: "Input MimeTypes", width: 225 },
     inputParams: { displayName: "Input Parameters", width: 225 },
     taskCount: { displayName: "Tasks", width: 75 },
   };
-  
+
   const renderHeader = () => {
     return (
       <Stack
@@ -110,7 +111,12 @@ const ExtractionGraphs = ({
         {extractionGraphs.map((graph) => {
           return (
             <Box key={graph.name} sx={{ p: 2 }}>
-              <Typography variant="h3">{graph.name}</Typography>
+              <Box display="flex" alignItems={"center"}>
+                <Typography variant="h3">
+                  {graph.name}
+                </Typography>
+                <CopyText text={graph.name} />
+              </Box>
               {renderGraphItems(graph.extraction_policies, "")}
             </Box>
           );

--- a/ui/src/components/tables/ContentTable.tsx
+++ b/ui/src/components/tables/ContentTable.tsx
@@ -19,6 +19,7 @@ import InfoIcon from "@mui/icons-material/Info";
 import React, { useEffect, useState } from "react";
 import moment from "moment";
 import { Link } from "react-router-dom";
+import CopyText from "../CopyText";
 
 function getChildCountMap(
   contents: IContentMetadata[]
@@ -143,7 +144,7 @@ const ContentTable = ({
           to={`/${params.row.namespace}/content/${params.row.id}`}
           target="_blank"
         >
-          <Button sx={{ p: 0.5 }} variant="outlined">
+          <Button sx={{ py: 0.5, px:2 }} variant="outlined">
             View
           </Button>
         </Link>
@@ -152,7 +153,15 @@ const ContentTable = ({
     {
       field: "id",
       headerName: "ID",
-      width: 170,
+      width: 200,
+      renderCell: (params) => {
+        return (
+          <>
+            {params.value}
+            <CopyText text={params.value} />
+          </>
+        );
+      },
     },
     {
       field: "childCount",

--- a/ui/src/components/tables/IndexTable.tsx
+++ b/ui/src/components/tables/IndexTable.tsx
@@ -1,11 +1,12 @@
 import { DataGrid, GridColDef } from "@mui/x-data-grid";
 import { IExtractionPolicy, IIndex } from "getindexify";
-import { Alert, IconButton, Typography } from "@mui/material";
+import { Alert, Button, IconButton, Typography } from "@mui/material";
 import { Box, Stack } from "@mui/system";
 import ManageSearchIcon from "@mui/icons-material/ManageSearch";
 import InfoIcon from "@mui/icons-material/Info";
 import React from "react";
 import { Link } from "react-router-dom";
+import CopyText from "../CopyText";
 
 const IndexTable = ({
   indexes,
@@ -26,14 +27,34 @@ const IndexTable = ({
 
   const columns: GridColDef[] = [
     {
+      field: "searchIndex",
+      headerName: "",
+      width: 140,
+      renderCell: (params) => {
+        return (
+          <>
+            <Link
+              to={`/${namespace}/indexes/${params.row.name}`}
+              target="_blank"
+            >
+              <Button sx={{ py: 0.5, px: 2 }} variant="outlined">
+                Search Index
+              </Button>
+            </Link>
+          </>
+        );
+      },
+    },
+    {
       field: "name",
       headerName: "Name",
       width: 500,
       renderCell: (params) => {
         return (
-          <Link to={`/${namespace}/indexes/${params.value}`}>
+          <>
             {params.value}
-          </Link>
+            <CopyText text={params.value} />
+          </>
         );
       },
     },


### PR DESCRIPTION
add copy buttons to index names, graph names and content ids
add search index button to make searching more apparent

<img width="439" alt="Screenshot 2024-05-16 at 10 40 31 AM" src="https://github.com/tensorlakeai/indexify/assets/12518571/33495804-9292-401b-bb02-ae331c69ae88">
<img width="416" alt="Screenshot 2024-05-16 at 10 40 27 AM" src="https://github.com/tensorlakeai/indexify/assets/12518571/aac9600e-5e6d-4167-bbf6-52fd3a5b3a45">
<img width="637" alt="Screenshot 2024-05-16 at 10 40 21 AM" src="https://github.com/tensorlakeai/indexify/assets/12518571/42f9ce5e-eae9-4f50-b68b-e9dff137850b">
