### PR TITLE
add content source validator

### DIFF
--- a/src/coordinator_service.rs
+++ b/src/coordinator_service.rs
@@ -156,6 +156,16 @@ impl CoordinatorServiceServer {
                     policy_request.content_source.clone(),
                 )
             };
+
+            let _source = &content_source.to_string();
+            if !_source.is_empty() && !name_to_policy_mapping.contains_key(_source) {
+                let message = format!(
+                    "content source '{_source}' is not found in the graph. \
+                    make sure the extraction policy name used as the source is defined."
+                );
+                return Err(anyhow!(message));
+            }
+
             let policy = ExtractionPolicyBuilder::default()
                 .namespace(policy_request.namespace.clone())
                 .name(policy_request.name.clone())


### PR DESCRIPTION
This PR adds a validator when creating an extraction graph to ensure that each extraction policies content source is valid.

### Example

```py
extraction_graph_spec = """
name: "gg"
extraction_policies:
  - extractor: "tensorlake/wikipedia"
    name: "wiki"
  - extractor: "tensorlake/minilm-l6"
    name: "minilm-l6"
    content_source: "mini"
"""
```

```
ExtractionGraphError | Unable to create extraction policies: content source 'mini' is not found in the graph. make sure the extraction policy name used as the source is defined.
```