### PR TITLE
return status from create_content()

### DIFF
--- a/crates/indexify_proto/src/indexify_coordinator.rs
+++ b/crates/indexify_proto/src/indexify_coordinator.rs
@@ -555,8 +555,8 @@ pub struct CreateContentRequest {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CreateContentResponse {
-    #[prost(string, tag = "1")]
-    pub id: ::prost::alloc::string::String,
+    #[prost(enumeration = "CreateContentStatus", tag = "2")]
+    pub status: i32,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -771,6 +771,32 @@ impl TaskOutcome {
             "UNKNOWN" => Some(Self::Unknown),
             "FAILED" => Some(Self::Failed),
             "SUCCESS" => Some(Self::Success),
+            _ => None,
+        }
+    }
+}
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum CreateContentStatus {
+    Created = 0,
+    Duplicate = 1,
+}
+impl CreateContentStatus {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            CreateContentStatus::Created => "CREATED",
+            CreateContentStatus::Duplicate => "DUPLICATE",
+        }
+    }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "CREATED" => Some(Self::Created),
+            "DUPLICATE" => Some(Self::Duplicate),
             _ => None,
         }
     }

--- a/protos/coordinator_service.proto
+++ b/protos/coordinator_service.proto
@@ -397,12 +397,17 @@ message ContentMetadata {
     repeated string extraction_graph_names = 14;
 }
 
+enum CreateContentStatus {
+    CREATED = 0;
+    DUPLICATE = 1;
+}
+
 message CreateContentRequest {
     ContentMetadata content = 2;
 }
 
 message CreateContentResponse {
-    string id = 1;
+    CreateContentStatus status = 2;
 }
 
 message TombstoneContentRequest {

--- a/src/coordinator.rs
+++ b/src/coordinator.rs
@@ -7,7 +7,7 @@ use std::{
 
 use anyhow::{anyhow, Ok, Result};
 use indexify_internal_api as internal_api;
-use indexify_proto::indexify_coordinator;
+use indexify_proto::indexify_coordinator::{self, CreateContentStatus};
 use internal_api::{
     ContentMetadataId,
     ExtractionGraph,
@@ -539,9 +539,8 @@ impl Coordinator {
     pub async fn create_content_metadata(
         &self,
         content_list: Vec<indexify_internal_api::ContentMetadata>,
-    ) -> Result<()> {
-        self.shared_state.create_content_batch(content_list).await?;
-        Ok(())
+    ) -> Result<Vec<CreateContentStatus>> {
+        self.shared_state.create_content_batch(content_list).await
     }
 
     pub async fn tombstone_content_metadatas(&self, content_ids: &[String]) -> Result<()> {
@@ -588,6 +587,7 @@ mod tests {
     use std::{collections::HashMap, fs, sync::Arc, time::Duration, vec};
 
     use indexify_internal_api as internal_api;
+    use indexify_proto::indexify_coordinator::CreateContentStatus;
     use internal_api::{ContentMetadataId, ContentSource, Task, TaskOutcome};
     use test_util::db_utils::Parent::{Child, Root};
 
@@ -1293,9 +1293,11 @@ mod tests {
         executor_id: &str,
     ) -> Result<(), anyhow::Error> {
         let content = create_content_for_task(coordinator, task, id).await?;
-        coordinator
+        let create_res = coordinator
             .create_content_metadata(vec![content.clone()])
             .await?;
+        assert_eq!(create_res.len(), 1);
+        assert_eq!(*create_res.first().unwrap(), CreateContentStatus::Created);
         complete_task(coordinator, task, executor_id).await
     }
 
@@ -1426,9 +1428,11 @@ mod tests {
         coordinator.run_scheduler().await?;
 
         let parent_content = test_mock_content_metadata("test_parent_id", "", &eg.name);
-        coordinator
+        let create_res = coordinator
             .create_content_metadata(vec![parent_content.clone()])
             .await?;
+        assert_eq!(create_res.len(), 1);
+        assert_eq!(*create_res.first().unwrap(), CreateContentStatus::Created);
         coordinator.run_scheduler().await?;
         let all_tasks = coordinator.shared_state.list_all_unfinished_tasks().await?;
         assert_eq!(all_tasks.len(), 1);
@@ -1444,9 +1448,11 @@ mod tests {
         // update root content
         let mut parent_content_1 = parent_content.clone();
         parent_content_1.hash = "test_parent_id_1".into();
-        coordinator
+        let create_res = coordinator
             .create_content_metadata(vec![parent_content_1.clone()])
             .await?;
+        assert_eq!(create_res.len(), 1);
+        assert_eq!(*create_res.first().unwrap(), CreateContentStatus::Created);
         coordinator.run_scheduler().await?;
         let all_tasks = coordinator.shared_state.list_all_unfinished_tasks().await?;
         assert_eq!(all_tasks.len(), 1);
@@ -1523,10 +1529,12 @@ mod tests {
         // update root content and have the first child be identical to previous version
         let mut parent_content_2 = parent_content_1.clone();
         parent_content_2.hash = "test_parent_id_2".into();
-        coordinator
+        let create_res = coordinator
             .create_content_metadata(vec![parent_content_2.clone()])
             .await?;
         coordinator.run_scheduler().await?;
+        assert_eq!(create_res.len(), 1);
+        assert_eq!(*create_res.first().unwrap(), CreateContentStatus::Created);
         let all_tasks = coordinator.shared_state.list_all_unfinished_tasks().await?;
         assert_eq!(all_tasks.len(), 1);
 
@@ -1534,9 +1542,11 @@ mod tests {
             create_content_for_task(&coordinator, &all_tasks[0], &next_child(&mut child_id))
                 .await?;
         child_content.hash = tree[1].hash.clone();
-        coordinator
+        let create_res = coordinator
             .create_content_metadata(vec![child_content])
             .await?;
+        assert_eq!(create_res.len(), 1);
+        assert_eq!(*create_res.first().unwrap(), CreateContentStatus::Duplicate);
         complete_task(&coordinator, &all_tasks[0], "test_executor_id_1").await?;
 
         coordinator.run_scheduler().await?;
@@ -1605,9 +1615,11 @@ mod tests {
         // previous version
         let mut parent_content_3 = parent_content_2.clone();
         parent_content_3.hash = "test_parent_id_3".into();
-        coordinator
+        let create_res = coordinator
             .create_content_metadata(vec![parent_content_3.clone()])
             .await?;
+        assert_eq!(create_res.len(), 1);
+        assert_eq!(*create_res.first().unwrap(), CreateContentStatus::Created);
         coordinator.run_scheduler().await?;
         let all_tasks = coordinator.shared_state.list_all_unfinished_tasks().await?;
         assert_eq!(all_tasks.len(), 1);
@@ -1643,7 +1655,9 @@ mod tests {
             .find(|c| c.source == ContentSource::ExtractionPolicyName(policy.name.clone()))
             .unwrap();
         content.hash = prev_content.hash.clone();
-        coordinator.create_content_metadata(vec![content]).await?;
+        let create_res = coordinator.create_content_metadata(vec![content]).await?;
+        assert_eq!(create_res.len(), 1);
+        assert_eq!(*create_res.first().unwrap(), CreateContentStatus::Duplicate);
         complete_task(&coordinator, &all_tasks[0], "test_executor_id_1").await?;
         coordinator.run_scheduler().await?;
         // No new task should be created

--- a/src/coordinator_service.rs
+++ b/src/coordinator_service.rs
@@ -201,14 +201,18 @@ impl CoordinatorService for CoordinatorServiceServer {
             .content
             .ok_or(tonic::Status::aborted("content is missing"))?;
         let content_meta: indexify_internal_api::ContentMetadata = content_meta.into();
-        let id = content_meta.id.clone();
         let content_list = vec![content_meta];
-        let _ = self
+        let statuses = self
             .coordinator
             .create_content_metadata(content_list)
             .await
             .map_err(|e| tonic::Status::aborted(e.to_string()))?;
-        Ok(tonic::Response::new(CreateContentResponse { id: id.id }))
+        Ok(tonic::Response::new(CreateContentResponse {
+            status: *statuses
+                .first()
+                .ok_or_else(|| tonic::Status::aborted("result invalid"))?
+                as i32,
+        }))
     }
 
     async fn tombstone_content(

--- a/src/data_manager.rs
+++ b/src/data_manager.rs
@@ -11,7 +11,7 @@ use anyhow::{anyhow, Result};
 use bytes::Bytes;
 use futures::{Stream, StreamExt};
 use indexify_internal_api as internal_api;
-use indexify_proto::indexify_coordinator::{self};
+use indexify_proto::indexify_coordinator::{self, CreateContentStatus};
 use itertools::Itertools;
 use mime::Mime;
 use nanoid::nanoid;
@@ -732,7 +732,8 @@ impl DataManager {
         let req = indexify_coordinator::CreateContentRequest {
             content: Some(content_metadata.clone()),
         };
-        self.coordinator_client
+        let res = self
+            .coordinator_client
             .get()
             .await?
             .create_content(GrpcHelper::into_req(req))
@@ -742,7 +743,18 @@ impl DataManager {
                     "unable to write content metadata to coordinator {}",
                     e.to_string()
                 )
-            })?;
+            })?
+            .into_inner();
+        if res.status() == CreateContentStatus::Duplicate {
+            if let Err(e) = self.delete_file(&content_metadata.storage_url).await {
+                tracing::warn!(
+                    "unable to delete duplicate file for {:?}: {}",
+                    content_metadata.id,
+                    e
+                );
+            }
+            return Ok(());
+        }
         let content_metadata_labels = content_metadata
             .labels
             .iter()


### PR DESCRIPTION
Return status from create_content() so the caller can determine if content was added or a duplicate was detected. Delete the uploaded content in case of duplicate and don't add new embeddings/metadata.