### PR TITLE
handle executor removal

### DIFF
--- a/src/coordinator.rs
+++ b/src/coordinator.rs
@@ -535,7 +535,9 @@ impl Coordinator {
                 indexify_internal_api::ChangeType::NewContent => {
                     self.scheduler.create_new_tasks(change).await?
                 }
-                indexify_internal_api::ChangeType::ExecutorRemoved => {}
+                indexify_internal_api::ChangeType::ExecutorRemoved => {
+                    self.scheduler.handle_executor_removed(change).await?
+                }
                 indexify_internal_api::ChangeType::NewGargabeCollectionTask => {}
             }
         }


### PR DESCRIPTION
If an executor is removed, attempt to reassign all unassigned tasks to surviving executors.