### PR TITLE
docs: fixup intermediate getting started

### DIFF
--- a/docs/docs/getting_started.md
+++ b/docs/docs/getting_started.md
@@ -29,7 +29,7 @@ Let's start by creating a new virtual environment before installing the required
 ```bash title="( Terminal 1 ) Install Dependencies"
 python3 -m venv venv
 source venv/bin/activate
-pip3 install indexify-extractor-sdk indexify wikipedia openai
+pip3 install indexify-extractor-sdk indexify wikipedia openai langchain_community
 ```
 
 ## Indexify Server


### PR DESCRIPTION
Took me a couple tries to figure out what was going on with the intermediate getting started. This gets it close to [pdfqa.ipynb](https://github.com/tensorlakeai/indexify/blob/main/docs/docs/examples/pdfqa.ipynb) but not quite there (I kept the tax example because I couldn't find the chess pdf anywhere).

I took the opportunity to update the typscript as well to something that'd run natively with node < 22.2.0. There's a deprecation issue with 22.2.0 and `Array.isArray` that I didn't end up diagnosing.