### PR TITLE
fix: load extractor docs

### DIFF
--- a/docs/docs/examples/HOA_Invoice_Data_Extraction.ipynb
+++ b/docs/docs/examples/HOA_Invoice_Data_Extraction.ipynb
@@ -85,7 +85,7 @@
     "\n",
     "from indexify_extractor_sdk import load_extractor, Content\n",
     "\n",
-    "pdfextractor, pdfconfig_cls = load_extractor(\"pdf-extractor.pdf_extractor:PDFExtractor\")\n",
+    "pdfextractor, pdfconfig_cls = load_extractor(\"indexify_extractors.pdf-extractor.pdf_extractor:PDFExtractor\")\n",
     "content = Content.from_file(\"Statement_HOA.pdf\")"
    ]
   },
@@ -149,7 +149,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "schemaextractor, schemaconfig_cls = load_extractor(\"schema.schema_extractor:SchemaExtractor\")\n",
+    "schemaextractor, schemaconfig_cls = load_extractor(\"indexify_extractors.schema.schema_extractor:SchemaExtractor\")\n",
     "\n",
     "config = schemaconfig_cls(service=\"openai\", schema=schema)\n",
     "result = schemaextractor.extract(Content.from_text(text_content), config)\n",
@@ -200,7 +200,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "llmextractor, llmconfig_cls = load_extractor(\"llm.llm_extractor:LLMExtractor\")\n",
+    "llmextractor, llmconfig_cls = load_extractor(\"indexify_extractors.llm.llm_extractor:LLMExtractor\")\n",
     "\n",
     "config = llmconfig_cls(service=\"openai\", prompt=prompt)\n",
     "result = llmextractor.extract(Content.from_text(text_content), config)\n",
@@ -291,7 +291,7 @@
    "outputs": [],
    "source": [
     "from indexify_extractor_sdk import load_extractor, Content\n",
-    "extractor, config_cls = load_extractor(\"layoutlm_document_qa.layoutlm_document_qa:LayoutLMDocumentQA\")"
+    "extractor, config_cls = load_extractor(\"indexify_extractors.layoutlm_document_qa.layoutlm_document_qa:LayoutLMDocumentQA\")"
    ]
   },
   {

--- a/docs/docs/examples/SEC_10_K_docs.ipynb
+++ b/docs/docs/examples/SEC_10_K_docs.ipynb
@@ -90,7 +90,7 @@
       "source": [
         "from indexify_extractor_sdk import load_extractor, Content\n",
         "\n",
-        "pdfextractor, pdfconfig_cls = load_extractor(\"pdf-extractor.pdf_extractor:PDFExtractor\")\n",
+        "pdfextractor, pdfconfig_cls = load_extractor(\"indexify_extractors.pdf-extractor.pdf_extractor:PDFExtractor\")\n",
         "content = Content.from_file(\"form10-k.pdf\")\n",
         "\n",
         "pdf_result = pdfextractor.extract(content)\n",

--- a/docs/docs/examples/Terms_and_Condition_Documents_of_Car_Rental.ipynb
+++ b/docs/docs/examples/Terms_and_Condition_Documents_of_Car_Rental.ipynb
@@ -76,7 +76,7 @@
       "source": [
         "from indexify_extractor_sdk import load_extractor, Content\n",
         "\n",
-        "mdextractor, mdconfig_cls = load_extractor(\"markdown.markdown_extractor:MarkdownExtractor\")\n",
+        "mdextractor, mdconfig_cls = load_extractor(\"indexify_extractors.markdown.markdown_extractor:MarkdownExtractor\")\n",
         "content = Content.from_file(\"en_agreement_200401.pdf\")\n",
         "\n",
         "md_result = mdextractor.extract(content)\n",

--- a/docs/docs/usecases/audio_extraction.md
+++ b/docs/docs/usecases/audio_extraction.md
@@ -53,7 +53,7 @@ You can test it locally and unlock the secrets hidden within your audio files:
 2. Load it in a notebook or terminal:
    ```python
    from indexify_extractor_sdk import load_extractor, Content
-   extractor, config_cls = load_extractor("whisper-asr.whisper_extractor:WhisperExtractor")
+   extractor, config_cls = load_extractor("indexify_extractors.whisper-asr.whisper_extractor:WhisperExtractor")
    content = Content.from_file("/path/to/audio.mp3")
    results = extractor.extract(content,params={})
    print(results)

--- a/docs/docs/usecases/image_retrieval.md
+++ b/docs/docs/usecases/image_retrieval.md
@@ -51,7 +51,7 @@ client.upload_file("yourextractiongraphname", path="../path/to/file")
 Load Yolo Extractor in a notebook or terminal
 ```python
 from indexify_extractor_sdk import load_extractor, Content
-extractor, config_cls = load_extractor("yolo.yolo_extractor:YoloExtractor")
+extractor, config_cls = load_extractor("indexify_extractors.yolo.yolo_extractor:YoloExtractor")
 content = Content.from_file("/path/to/file.jpg")
 results =  extractor.extract(content)
 print(results)

--- a/docs/docs/usecases/pdf_extraction.md
+++ b/docs/docs/usecases/pdf_extraction.md
@@ -90,7 +90,7 @@ You can test it locally:
    ```python
    from indexify_extractor_sdk import load_extractor, Content
 
-   extractor, config_cls = load_extractor("pdf-extractor.pdf_extractor:PDFExtractor")
+   extractor, config_cls = load_extractor("indexify_extractors.pdf-extractor.pdf_extractor:PDFExtractor")
    content = Content.from_file("/path/to/file.pdf")
 
    results =  extractor.extract(content)


### PR DESCRIPTION
Update notebook and documentation that utilizes `load_extractor` to be prefixed with `indexify_extractors` when necessary.