### PR TITLE
add support for labels update

### DIFF
--- a/crates/indexify_internal_api/src/lib.rs
+++ b/crates/indexify_internal_api/src/lib.rs
@@ -494,6 +494,12 @@ impl From<Task> for indexify_coordinator::Task {
     }
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema, PartialEq, Copy)]
+pub enum ServerTaskType {
+    Delete = 0,
+    UpdateLabels = 1,
+}
+
 pub type GarbageCollectionTaskId = String;
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema, PartialEq)]
@@ -509,6 +515,7 @@ pub struct GarbageCollectionTask {
     pub outcome: TaskOutcome,
     pub blob_store_path: String,
     pub assigned_to: Option<String>,
+    pub task_type: ServerTaskType,
 }
 
 impl GarbageCollectionTask {
@@ -516,6 +523,7 @@ impl GarbageCollectionTask {
         namespace: &str,
         content_metadata: ContentMetadata,
         output_tables: HashSet<String>,
+        task_type: ServerTaskType,
     ) -> Self {
         let mut hasher = DefaultHasher::new();
         namespace.hash(&mut hasher);
@@ -531,6 +539,7 @@ impl GarbageCollectionTask {
             outcome: TaskOutcome::Unknown,
             blob_store_path: content_metadata.storage_url,
             assigned_to: None,
+            task_type,
         }
     }
 }
@@ -543,6 +552,7 @@ impl From<GarbageCollectionTask> for indexify_coordinator::GcTask {
             content_id: value.content_id.id,
             output_tables: value.output_tables.into_iter().collect::<Vec<String>>(),
             blob_store_path: value.blob_store_path,
+            task_type: value.task_type as i32,
         }
     }
 }
@@ -1066,7 +1076,7 @@ pub enum ChangeType {
     TombstoneContentTree,
     ExecutorAdded,
     ExecutorRemoved,
-    NewGargabeCollectionTask,
+    ContentUpdated,
     TaskCompleted { root_content_id: ContentMetadataId },
 }
 
@@ -1077,7 +1087,7 @@ impl fmt::Display for ChangeType {
             ChangeType::TombstoneContentTree => write!(f, "TombstoneContentTree"),
             ChangeType::ExecutorAdded => write!(f, "ExecutorAdded"),
             ChangeType::ExecutorRemoved => write!(f, "ExecutorRemoved"),
-            ChangeType::NewGargabeCollectionTask => write!(f, "NewGarbageCollectionTask"),
+            ChangeType::ContentUpdated => write!(f, "ContentUpdated"),
             ChangeType::TaskCompleted {
                 root_content_id: content_id,
             } => {

--- a/protos/coordinator_service.proto
+++ b/protos/coordinator_service.proto
@@ -69,6 +69,8 @@ service CoordinatorService {
     rpc WaitContentExtraction(WaitContentExtractionRequest) returns (WaitContentExtractionResponse) {}
 
     rpc ListActiveContents(ListActiveContentsRequest) returns (ListActiveContentsResponse) {}
+
+    rpc UpdateLabels(UpdateLabelsRequest) returns (UpdateLabelsResponse) {}
 }
 
 message GetContentMetadataRequest {
@@ -231,12 +233,18 @@ message GCTaskAcknowledgement {
     string ingestion_server_id = 3;
 }
 
+enum GcTaskType {
+    Delete = 0;
+    UpdateLabels = 1;
+}
+
 message GCTask {
     string task_id = 1;
     string namespace = 2;
     string content_id = 3;
     repeated string output_tables = 5;
     string blob_store_path = 6;
+    GcTaskType task_type = 7;
 }
 
 message HeartbeatRequest {
@@ -520,3 +528,11 @@ message ListActiveContentsRequest {
 message ListActiveContentsResponse {
     repeated string content_ids = 1;
 }
+
+message UpdateLabelsRequest {
+    string namespace = 1;
+    string content_id = 2;
+    map<string, string> labels = 3;
+}
+
+message UpdateLabelsResponse {}

--- a/src/api.rs
+++ b/src/api.rs
@@ -395,6 +395,11 @@ pub struct ListContentResponse {
     pub content_list: Vec<ContentMetadata>,
 }
 
+#[derive(Debug, Serialize, Deserialize, Default, ToSchema, IntoParams)]
+pub struct UpdateLabelsRequest {
+    pub labels: HashMap<String, String>,
+}
+
 #[derive(Debug, Serialize, Deserialize, Default, ToSchema, Clone)]
 pub struct ContentMetadata {
     pub id: String,

--- a/src/coordinator_service.rs
+++ b/src/coordinator_service.rs
@@ -222,6 +222,20 @@ impl CoordinatorService for CoordinatorServiceServer {
         }))
     }
 
+    async fn update_labels(
+        &self,
+        request: tonic::Request<indexify_coordinator::UpdateLabelsRequest>,
+    ) -> Result<tonic::Response<indexify_coordinator::UpdateLabelsResponse>, tonic::Status> {
+        let request = request.into_inner();
+        self.coordinator
+            .update_labels(&request.namespace, &request.content_id, request.labels)
+            .await
+            .map_err(|e| tonic::Status::aborted(e.to_string()))?;
+        Ok(tonic::Response::new(
+            indexify_coordinator::UpdateLabelsResponse {},
+        ))
+    }
+
     async fn tombstone_content(
         &self,
         request: tonic::Request<TombstoneContentRequest>,
@@ -478,7 +492,7 @@ impl CoordinatorService for CoordinatorServiceServer {
                 ))
             })?;
         self.coordinator
-            .create_gc_tasks(&state_change)
+            .create_gc_tasks(state_change)
             .await
             .map_err(|e| tonic::Status::aborted(e.to_string()))?;
         Ok(tonic::Response::new(CreateGcTasksResponse {}))

--- a/src/forwardable_coordinator.rs
+++ b/src/forwardable_coordinator.rs
@@ -46,9 +46,9 @@ impl ForwardableCoordinator {
     pub async fn create_gc_tasks(
         &self,
         leader_addr: &str,
-        state_change: &indexify_internal_api::StateChange,
+        state_change: indexify_internal_api::StateChange,
     ) -> Result<(), anyhow::Error> {
-        let state_change: indexify_coordinator::StateChange = (*state_change).clone().try_into()?;
+        let state_change: indexify_coordinator::StateChange = state_change.try_into()?;
         let req = indexify_coordinator::CreateGcTasksRequest {
             state_change: Some(state_change),
         };

--- a/src/ingest_extracted_content.rs
+++ b/src/ingest_extracted_content.rs
@@ -379,8 +379,10 @@ mod tests {
 
     use std::sync::Arc;
 
+    use anyhow::Result;
     use indexify_internal_api::{
         ContentMetadata,
+        ExtractedEmbeddings,
         ExtractionGraph,
         ExtractionPolicy,
         ExtractionPolicyContentSource,
@@ -400,13 +402,18 @@ mod tests {
         data_manager::DataManager,
         metadata_storage::{self, MetadataReaderTS, MetadataStorageTS},
         metrics,
-        server::NamespaceEndpointState,
+        server::{NamespaceEndpointState, Server},
         server_config::{IndexStoreKind, ServerConfig},
         test_util::db_utils::{
             create_metadata,
             create_test_extraction_graph,
+            create_test_extraction_graph_with_children,
             mock_extractor,
+            perform_all_tasks,
             test_mock_content_metadata,
+            wait_changes_processed,
+            wait_gc_tasks_completed,
+            Parent::{Child, Root},
             DEFAULT_TEST_NAMESPACE,
         },
         vector_index::VectorIndexManager,
@@ -974,5 +981,198 @@ mod tests {
         assert_eq!(points[0].metadata, metadata1_out);
 
         coordinator.stop().await;
+    }
+
+    #[tokio::test]
+    async fn test_labels_update() -> Result<()> {
+        set_tracing();
+        let state = new_endpoint_state().await.unwrap();
+
+        let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+        let server = Server::new(Arc::new(make_test_config()))?;
+        let server_id = "1";
+
+        let test_coordinator = TestCoordinator::new().await;
+        let coordinator = &test_coordinator.coordinator;
+
+        server.start_gc_tasks_stream(
+            state.coordinator_client.clone(),
+            server_id,
+            state.data_manager.clone(),
+            shutdown_rx,
+        );
+
+        let _ = state
+            .data_manager
+            .vector_index_manager
+            .drop_index("test_table")
+            .await;
+
+        let schema = indexify_internal_api::EmbeddingSchema {
+            dim: 3,
+            distance: "cosine".to_string(),
+        };
+        state
+            .data_manager
+            .vector_index_manager
+            .create_index("test_table", schema)
+            .await?;
+
+        let _executor_id_1 = "test_executor_id_1";
+        let extractor_1 = mock_extractor();
+        coordinator
+            .register_executor(
+                "localhost:8956",
+                "test_executor_id",
+                vec![extractor_1.clone()],
+            )
+            .await?;
+
+        //  Create an extraction graph
+        let eg = create_test_extraction_graph_with_children(
+            "test_extraction_graph",
+            vec![
+                "test_extraction_policy_1",
+                "test_extraction_policy_2",
+                "test_extraction_policy_3",
+                "test_extraction_policy_4",
+                "test_extraction_policy_5",
+                "test_extraction_policy_6",
+            ],
+            &[Root, Child(0), Child(0), Child(1), Child(3), Child(3)],
+        );
+        coordinator.create_extraction_graph(eg.clone()).await?;
+        coordinator.run_scheduler().await?;
+
+        let parent_content = test_mock_content_metadata("200", "", &eg.name);
+        let create_res = coordinator
+            .create_content_metadata(vec![parent_content.clone()])
+            .await?;
+        assert_eq!(create_res.len(), 1);
+        coordinator.run_scheduler().await?;
+
+        let mut child_id = 100;
+        perform_all_tasks(&coordinator, "test_executor_id_1", &mut child_id).await?;
+
+        let tree = coordinator
+            .shared_state
+            .get_content_tree_metadata(&parent_content.id.id)?;
+        assert_eq!(tree.len(), 7);
+
+        for content in &tree {
+            if content.extraction_policy_ids.is_empty() {
+                continue;
+            }
+            let embedding = ExtractedEmbeddings {
+                content_id: content.id.id.clone(),
+                embedding: vec![1.0, 2.0, 3.0],
+                metadata: HashMap::new(),
+                content_metadata: content.clone(),
+                root_content_metadata: None,
+            };
+            state
+                .data_manager
+                .vector_index_manager
+                .add_embedding("test_table", vec![embedding])
+                .await?;
+        }
+
+        let labels: HashMap<_, _> = [("key1", "value1"), ("key2", "value2")]
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect();
+
+        state
+            .data_manager
+            .update_labels(DEFAULT_TEST_NAMESPACE, "200", labels.clone())
+            .await?;
+
+        let content = state
+            .data_manager
+            .get_content_metadata(DEFAULT_TEST_NAMESPACE, vec!["200".to_string()])
+            .await?
+            .first()
+            .cloned()
+            .unwrap();
+
+        assert_eq!(content.labels, labels);
+
+        let content = state
+            .data_manager
+            .get_content_metadata(DEFAULT_TEST_NAMESPACE, vec!["101".to_string()])
+            .await?
+            .first()
+            .cloned()
+            .unwrap();
+
+        assert_eq!(content.labels, labels);
+
+        wait_changes_processed(coordinator).await?;
+        wait_gc_tasks_completed(coordinator).await?;
+
+        let points = state
+            .data_manager
+            .vector_index_manager
+            .get_points("test_table", vec!["200".to_string(), "101".to_string()])
+            .await?;
+
+        assert_eq!(points.len(), 2);
+        assert_eq!(points[0].metadata, create_metadata(&labels));
+        assert_eq!(points[1].metadata, create_metadata(&labels));
+
+        let tree = coordinator
+            .shared_state
+            .get_content_tree_metadata(&parent_content.id.id)?;
+        assert_eq!(tree.len(), 7);
+
+        // Update labels again and check if values change.
+        let labels: HashMap<_, _> = [("key1", "value3"), ("key2", "value4")]
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect();
+
+        state
+            .data_manager
+            .update_labels(DEFAULT_TEST_NAMESPACE, "200", labels.clone())
+            .await?;
+
+        let content = state
+            .data_manager
+            .get_content_metadata(DEFAULT_TEST_NAMESPACE, vec!["200".to_string()])
+            .await?
+            .first()
+            .cloned()
+            .unwrap();
+
+        assert_eq!(content.labels, labels);
+
+        let content = state
+            .data_manager
+            .get_content_metadata(DEFAULT_TEST_NAMESPACE, vec!["101".to_string()])
+            .await?
+            .first()
+            .cloned()
+            .unwrap();
+
+        assert_eq!(content.labels, labels);
+
+        wait_changes_processed(coordinator).await?;
+        wait_gc_tasks_completed(coordinator).await?;
+
+        let points = state
+            .data_manager
+            .vector_index_manager
+            .get_points("test_table", vec!["200".to_string(), "101".to_string()])
+            .await?;
+
+        assert_eq!(points.len(), 2);
+        assert_eq!(points[0].metadata, create_metadata(&labels));
+        assert_eq!(points[1].metadata, create_metadata(&labels));
+
+        shutdown_tx.send(true)?;
+
+        test_coordinator.stop().await;
+
+        Ok(())
     }
 }

--- a/src/state/store/state_machine_objects.rs
+++ b/src/state/store/state_machine_objects.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use anyhow::{anyhow, Result};
-use indexify_internal_api as internal_api;
+use indexify_internal_api::{self as internal_api, ServerTaskType};
 use internal_api::{
     ContentMetadataId,
     ExtractionGraph,
@@ -1475,7 +1475,7 @@ impl IndexifyState {
                 gc_task,
                 mark_finished,
             } => {
-                if mark_finished {
+                if mark_finished && gc_task.task_type == ServerTaskType::Delete {
                     self.content_children_table.remove_all(&gc_task.content_id);
                 }
                 Ok(())
@@ -1548,8 +1548,6 @@ impl IndexifyState {
 
     //  START READER METHODS FOR ROCKSDB FORWARD INDEXES
 
-    /// This function is a helper method that will get the latest version of any
-    /// piece of content in the database by building a prefix foward iterator
     pub fn get_latest_version_of_content(
         &self,
         content_id: &str,


### PR DESCRIPTION
Add labels update API. Give root content, update labels for it and all child contents. Propagate label updates to indexes through gc tasks.