### PR TITLE
remove inactive executors

### DIFF
--- a/crates/indexify_proto/src/indexify_coordinator.rs
+++ b/crates/indexify_proto/src/indexify_coordinator.rs
@@ -780,11 +780,8 @@ pub struct UpdateLabelsResponse {}
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ExecutorsHeartbeatRequest {
-    #[prost(map = "string, message", tag = "1")]
-    pub executors: ::std::collections::HashMap<
-        ::prost::alloc::string::String,
-        ::prost_wkt_types::Timestamp,
-    >,
+    #[prost(string, repeated, tag = "1")]
+    pub executors: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/crates/indexify_proto/src/indexify_coordinator.rs
+++ b/crates/indexify_proto/src/indexify_coordinator.rs
@@ -777,6 +777,18 @@ pub struct UpdateLabelsRequest {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UpdateLabelsResponse {}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ExecutorsHeartbeatRequest {
+    #[prost(map = "string, message", tag = "1")]
+    pub executors: ::std::collections::HashMap<
+        ::prost::alloc::string::String,
+        ::prost_wkt_types::Timestamp,
+    >,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ExecutorsHeartbeatResponse {}
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
 pub enum TaskOutcome {
@@ -1956,6 +1968,36 @@ pub mod coordinator_service_client {
                 );
             self.inner.unary(req, path, codec).await
         }
+        pub async fn executors_heartbeat(
+            &mut self,
+            request: impl tonic::IntoRequest<super::ExecutorsHeartbeatRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::ExecutorsHeartbeatResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/indexify_coordinator.CoordinatorService/ExecutorsHeartbeat",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "indexify_coordinator.CoordinatorService",
+                        "ExecutorsHeartbeat",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
+        }
     }
 }
 /// Generated server implementations.
@@ -2204,6 +2246,13 @@ pub mod coordinator_service_server {
             request: tonic::Request<super::UpdateLabelsRequest>,
         ) -> std::result::Result<
             tonic::Response<super::UpdateLabelsResponse>,
+            tonic::Status,
+        >;
+        async fn executors_heartbeat(
+            &self,
+            request: tonic::Request<super::ExecutorsHeartbeatRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::ExecutorsHeartbeatResponse>,
             tonic::Status,
         >;
     }
@@ -3922,6 +3971,56 @@ pub mod coordinator_service_server {
                     let fut = async move {
                         let inner = inner.0;
                         let method = UpdateLabelsSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/indexify_coordinator.CoordinatorService/ExecutorsHeartbeat" => {
+                    #[allow(non_camel_case_types)]
+                    struct ExecutorsHeartbeatSvc<T: CoordinatorService>(pub Arc<T>);
+                    impl<
+                        T: CoordinatorService,
+                    > tonic::server::UnaryService<super::ExecutorsHeartbeatRequest>
+                    for ExecutorsHeartbeatSvc<T> {
+                        type Response = super::ExecutorsHeartbeatResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::ExecutorsHeartbeatRequest>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as CoordinatorService>::executors_heartbeat(
+                                        &inner,
+                                        request,
+                                    )
+                                    .await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = ExecutorsHeartbeatSvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(

--- a/protos/coordinator_service.proto
+++ b/protos/coordinator_service.proto
@@ -1,5 +1,6 @@
 syntax = "proto3";
 import "google/protobuf/struct.proto";
+import "google/protobuf/timestamp.proto";
 
 package indexify_coordinator;
 
@@ -71,6 +72,8 @@ service CoordinatorService {
     rpc ListActiveContents(ListActiveContentsRequest) returns (ListActiveContentsResponse) {}
 
     rpc UpdateLabels(UpdateLabelsRequest) returns (UpdateLabelsResponse) {}
+
+    rpc ExecutorsHeartbeat(ExecutorsHeartbeatRequest) returns (ExecutorsHeartbeatResponse) {}
 }
 
 message GetContentMetadataRequest {
@@ -536,3 +539,9 @@ message UpdateLabelsRequest {
 }
 
 message UpdateLabelsResponse {}
+
+message ExecutorsHeartbeatRequest {
+    map<string, google.protobuf.Timestamp> executors = 1;
+}
+
+message ExecutorsHeartbeatResponse {}

--- a/protos/coordinator_service.proto
+++ b/protos/coordinator_service.proto
@@ -541,7 +541,7 @@ message UpdateLabelsRequest {
 message UpdateLabelsResponse {}
 
 message ExecutorsHeartbeatRequest {
-    map<string, google.protobuf.Timestamp> executors = 1;
+    repeated string executors = 1;
 }
 
 message ExecutorsHeartbeatResponse {}

--- a/src/coordinator_service.rs
+++ b/src/coordinator_service.rs
@@ -7,7 +7,6 @@ use std::{
         Arc,
     },
     task::{Context, Poll},
-    time::Duration,
 };
 
 use anyhow::{anyhow, Result};
@@ -25,6 +24,8 @@ use indexify_proto::indexify_coordinator::{
     CreateExtractionGraphResponse,
     CreateGcTasksRequest,
     CreateGcTasksResponse,
+    ExecutorsHeartbeatRequest,
+    ExecutorsHeartbeatResponse,
     GcTask,
     GcTaskAcknowledgement,
     GetAllSchemaRequest,
@@ -99,7 +100,7 @@ use tokio::{
         watch::{self, Receiver, Sender},
     },
     task::JoinHandle,
-    time::timeout,
+    time::{timeout, Duration},
 };
 use tokio_stream::{wrappers::ReceiverStream, Stream};
 use tonic::{body::BoxBody, Request, Response, Status, Streaming};
@@ -143,7 +144,7 @@ impl<'a> Extractor for MetadataMap<'a> {
 }
 
 // How often we expect the executor to send us heartbeats.
-const EXECUTOR_HEARTBEAT_PERIOD: Duration = Duration::new(5, 0);
+pub const EXECUTOR_HEARTBEAT_PERIOD: Duration = Duration::new(5, 0);
 
 impl CoordinatorServiceServer {
     fn create_extraction_policies_for_graph(
@@ -207,6 +208,24 @@ impl CoordinatorServiceServer {
 impl CoordinatorService for CoordinatorServiceServer {
     type GCTasksStreamStream = GCTasksResponseStream;
     type HeartbeatStream = HBResponseStream;
+
+    async fn executors_heartbeat(
+        &self,
+        request: tonic::Request<ExecutorsHeartbeatRequest>,
+    ) -> Result<tonic::Response<ExecutorsHeartbeatResponse>, tonic::Status> {
+        let request = request.into_inner();
+        let mut executors = self.coordinator.all_executors();
+        for (id, time) in request.executors {
+            let duration = std::time::Duration::new(time.seconds as u64, time.nanos as u32);
+            let time = std::time::UNIX_EPOCH + duration;
+            if let Some(last_time) = executors.get_mut(&id) {
+                if *last_time < time {
+                    *last_time = time;
+                }
+            }
+        }
+        Ok(tonic::Response::new(ExecutorsHeartbeatResponse {}))
+    }
 
     async fn create_content(
         &self,
@@ -1270,14 +1289,22 @@ impl CoordinatorServer {
         if let Err(e) = start_server(self) {
             error!("unable to start metrics server: {}", e);
         }
+        let shutdown_rx_clone = shutdown_rx.clone();
         tokio::spawn(async move {
             let _ = run_scheduler(
-                shutdown_rx,
+                shutdown_rx_clone,
                 leader_change_watcher,
                 state_watcher_rx,
                 coordinator_clone,
             )
             .await;
+        });
+
+        let heartbeat_coordinator = self.coordinator.clone();
+        tokio::spawn(async move {
+            heartbeat_coordinator
+                .run_executor_heartbeat(shutdown_rx)
+                .await;
         });
 
         let layer = ServiceBuilder::new()

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -5,7 +5,7 @@ use std::{
     cell::RefCell,
     collections::{BTreeMap, HashMap, HashSet},
     path::{Path, PathBuf},
-    sync::Arc,
+    sync::{Arc, MutexGuard},
     time::SystemTime,
 };
 
@@ -727,12 +727,23 @@ impl App {
         self.state_machine.get_namespace(namespace).await
     }
 
+    pub fn my_executors(&self) -> MutexGuard<HashMap<String, SystemTime>> {
+        self.state_machine
+            .data
+            .indexify_state
+            .my_executors
+            .lock()
+            .unwrap()
+    }
+
     pub async fn register_executor(
         &self,
         addr: &str,
         executor_id: &str,
         extractors: Vec<internal_api::ExtractorDescription>,
     ) -> Result<()> {
+        self.my_executors()
+            .insert(executor_id.to_string(), SystemTime::now());
         let state_change = StateChange::new(
             executor_id.to_string(),
             internal_api::ChangeType::ExecutorAdded,

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -5,7 +5,7 @@ use std::{
     cell::RefCell,
     collections::{BTreeMap, HashMap, HashSet},
     path::{Path, PathBuf},
-    sync::{Arc, MutexGuard},
+    sync::Arc,
     time::SystemTime,
 };
 
@@ -727,23 +727,12 @@ impl App {
         self.state_machine.get_namespace(namespace).await
     }
 
-    pub fn my_executors(&self) -> MutexGuard<HashMap<String, SystemTime>> {
-        self.state_machine
-            .data
-            .indexify_state
-            .my_executors
-            .lock()
-            .unwrap()
-    }
-
     pub async fn register_executor(
         &self,
         addr: &str,
         executor_id: &str,
         extractors: Vec<internal_api::ExtractorDescription>,
     ) -> Result<()> {
-        self.my_executors()
-            .insert(executor_id.to_string(), SystemTime::now());
         let state_change = StateChange::new(
             executor_id.to_string(),
             internal_api::ChangeType::ExecutorAdded,

--- a/src/state/store/state_machine_objects.rs
+++ b/src/state/store/state_machine_objects.rs
@@ -673,12 +673,6 @@ pub struct IndexifyState {
 
     /// Next change id
     pub change_id: std::sync::Mutex<u64>,
-
-    /// Executors registered on this node.
-    pub my_executors: std::sync::Mutex<HashMap<ExecutorId, SystemTime>>,
-
-    /// All executors registered on the cluster.
-    pub all_executors: std::sync::Mutex<HashMap<ExecutorId, SystemTime>>,
 }
 
 impl fmt::Display for IndexifyState {
@@ -1370,9 +1364,6 @@ impl IndexifyState {
                 // Remove from the executor load table
                 self.executor_running_task_count.remove(executor_id);
 
-                self.my_executors.lock().unwrap().remove(executor_id);
-                self.all_executors.lock().unwrap().remove(executor_id);
-
                 return Ok(request.new_state_changes.last().map(|sc| sc.id));
             }
             RequestPayload::CreateOrUpdateContent { entries } => {
@@ -1463,11 +1454,6 @@ impl IndexifyState {
                 };
                 // initialize executor load at 0
                 self.executor_running_task_count.insert(&executor_id, 0);
-
-                self.all_executors
-                    .lock()
-                    .unwrap()
-                    .insert(executor_id.clone(), SystemTime::now());
 
                 Ok(())
             }

--- a/src/state/store/state_machine_objects.rs
+++ b/src/state/store/state_machine_objects.rs
@@ -673,6 +673,12 @@ pub struct IndexifyState {
 
     /// Next change id
     pub change_id: std::sync::Mutex<u64>,
+
+    /// Executors registered on this node.
+    pub my_executors: std::sync::Mutex<HashMap<ExecutorId, SystemTime>>,
+
+    /// All executors registered on the cluster.
+    pub all_executors: std::sync::Mutex<HashMap<ExecutorId, SystemTime>>,
 }
 
 impl fmt::Display for IndexifyState {
@@ -1364,6 +1370,9 @@ impl IndexifyState {
                 // Remove from the executor load table
                 self.executor_running_task_count.remove(executor_id);
 
+                self.my_executors.lock().unwrap().remove(executor_id);
+                self.all_executors.lock().unwrap().remove(executor_id);
+
                 return Ok(request.new_state_changes.last().map(|sc| sc.id));
             }
             RequestPayload::CreateOrUpdateContent { entries } => {
@@ -1454,6 +1463,12 @@ impl IndexifyState {
                 };
                 // initialize executor load at 0
                 self.executor_running_task_count.insert(&executor_id, 0);
+
+                self.all_executors
+                    .lock()
+                    .unwrap()
+                    .insert(executor_id.clone(), SystemTime::now());
+
                 Ok(())
             }
             RequestPayload::CreateTasks { tasks } => {


### PR DESCRIPTION
Keep track of last heartbeat time for all executors and remove the ones that failed to communicate for a period of time.

This handles the case when executor dies right after registering itself or when the server it is registered with is down.