### PR TITLE
update applied policies correctly

### DIFF
--- a/crates/indexify_proto/src/indexify_coordinator.rs
+++ b/crates/indexify_proto/src/indexify_coordinator.rs
@@ -32,6 +32,8 @@ pub struct UpdateTaskRequest {
     pub task_id: ::prost::alloc::string::String,
     #[prost(enumeration = "TaskOutcome", tag = "3")]
     pub outcome: i32,
+    #[prost(enumeration = "TaskUpdateInfo", tag = "4")]
+    pub task_update_info: i32,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -811,6 +813,32 @@ impl TaskOutcome {
             "UNKNOWN" => Some(Self::Unknown),
             "FAILED" => Some(Self::Failed),
             "SUCCESS" => Some(Self::Success),
+            _ => None,
+        }
+    }
+}
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum TaskUpdateInfo {
+    ChildCreated = 0,
+    FeaturesUpdated = 1,
+}
+impl TaskUpdateInfo {
+    /// String value of the enum field names used in the ProtoBuf definition.
+    ///
+    /// The values are not transformed in any way and thus are considered stable
+    /// (if the ProtoBuf definition does not change) and safe for programmatic use.
+    pub fn as_str_name(&self) -> &'static str {
+        match self {
+            TaskUpdateInfo::ChildCreated => "CHILD_CREATED",
+            TaskUpdateInfo::FeaturesUpdated => "FEATURES_UPDATED",
+        }
+    }
+    /// Creates an enum from field names used in the ProtoBuf definition.
+    pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+        match value {
+            "CHILD_CREATED" => Some(Self::ChildCreated),
+            "FEATURES_UPDATED" => Some(Self::FeaturesUpdated),
             _ => None,
         }
     }

--- a/protos/coordinator_service.proto
+++ b/protos/coordinator_service.proto
@@ -98,10 +98,16 @@ enum TaskOutcome {
     SUCCESS = 2;
 }
 
+enum TaskUpdateInfo {
+    CHILD_CREATED = 0;
+    FEATURES_UPDATED = 1;
+}
+
 message UpdateTaskRequest {
     string executor_id = 1;
     string task_id = 2;
     TaskOutcome outcome = 3;
+    TaskUpdateInfo task_update_info = 4;
 }
 
 message ListStateChangesRequest {

--- a/src/data_manager.rs
+++ b/src/data_manager.rs
@@ -11,7 +11,12 @@ use anyhow::{anyhow, Result};
 use bytes::Bytes;
 use futures::{Stream, StreamExt};
 use indexify_internal_api as internal_api;
-use indexify_proto::indexify_coordinator::{self, CreateContentStatus, ListActiveContentsRequest};
+use indexify_proto::indexify_coordinator::{
+    self,
+    CreateContentStatus,
+    ListActiveContentsRequest,
+    TaskUpdateInfo,
+};
 use mime::Mime;
 use nanoid::nanoid;
 use sha2::{Digest, Sha256};
@@ -634,6 +639,7 @@ impl DataManager {
     pub async fn finish_extracted_content_write(
         &self,
         begin_ingest: BeginExtractedContentIngest,
+        task_update_info: TaskUpdateInfo,
     ) -> Result<()> {
         let outcome: indexify_coordinator::TaskOutcome = begin_ingest.task_outcome.into();
 
@@ -641,6 +647,7 @@ impl DataManager {
             executor_id: begin_ingest.executor_id,
             task_id: begin_ingest.task_id,
             outcome: outcome as i32,
+            task_update_info: task_update_info as i32,
         };
         let res = self.coordinator_client.get().await?.update_task(req).await;
         if let Err(err) = res {

--- a/src/state/store/mod.rs
+++ b/src/state/store/mod.rs
@@ -45,6 +45,7 @@ use openraft::{
 use requests::{
     CreateOrUpdateContentEntry,
     StateMachineUpdateRequest,
+    TaskUpdateInfo,
     V1RequestPayload,
     V1StateMachineUpdateRequest,
 };
@@ -1516,6 +1517,7 @@ fn convert_v1_log(log: V1StateMachineUpdateRequest) -> StateMachineUpdateRequest
                 task,
                 executor_id,
                 update_time,
+                task_update_info: TaskUpdateInfo::FeaturesUpdated,
             }
         }
         V1RequestPayload::MarkStateChangesProcessed { state_changes } => {

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -15,7 +15,7 @@ pub mod db_utils {
     use serde_json::json;
     use tokio::time::{sleep, Duration};
 
-    use crate::coordinator::Coordinator;
+    use crate::{coordinator::Coordinator, state::store::requests::TaskUpdateInfo};
     pub const DEFAULT_TEST_NAMESPACE: &str = "test_namespace";
 
     pub const DEFAULT_TEST_EXTRACTOR: &str = "MockExtractor";
@@ -161,7 +161,11 @@ pub mod db_utils {
         task_clone.outcome = internal_api::TaskOutcome::Success;
         coordinator
             .shared_state
-            .update_task(task_clone, Some(executor_id.to_string()))
+            .update_task(
+                task_clone,
+                Some(executor_id.to_string()),
+                TaskUpdateInfo::FeaturesUpdated,
+            )
             .await
     }
 


### PR DESCRIPTION
If a child is created during extraction, update its applied policies list with the policy that produced the child.

Update task content applied policies list only if features were updated for this content.