### PR TITLE
sort pending tasks by creation time

### DIFF
--- a/crates/indexify_internal_api/src/v1.rs
+++ b/crates/indexify_internal_api/src/v1.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, time::SystemTime};
 
 use serde::{Deserialize, Serialize};
 
@@ -132,6 +132,7 @@ impl From<Task> for super::Task {
             input_params: task.input_params,
             outcome: task.outcome,
             index_tables: task.index_tables,
+            creation_time: SystemTime::UNIX_EPOCH,
         }
     }
 }

--- a/src/ingest_extracted_content.rs
+++ b/src/ingest_extracted_content.rs
@@ -384,7 +384,7 @@ impl IngestExtractedContentState {
 #[cfg(test)]
 mod tests {
 
-    use std::sync::Arc;
+    use std::{sync::Arc, time::SystemTime};
 
     use anyhow::Result;
     use indexify_internal_api::{
@@ -448,7 +448,19 @@ mod tests {
         content_metadata: &ContentMetadata,
         extraction_policy: ExtractionPolicy,
     ) -> Task {
-        let mut task = Task::new(task_id, content_metadata, extraction_policy);
+        let mut task = Task {
+            id: task_id.to_string(),
+            extractor: "".to_string(),
+            extraction_policy_id: extraction_policy.id.to_string(),
+            extraction_graph_name: extraction_policy.graph_name.clone(),
+            output_index_table_mapping: HashMap::new(),
+            namespace: content_metadata.namespace.clone(),
+            content_metadata: content_metadata.clone(),
+            input_params: serde_json::Value::Null,
+            outcome: TaskOutcome::Unknown,
+            index_tables: Vec::new(),
+            creation_time: SystemTime::now(),
+        };
         task.output_index_table_mapping = vec![
             ("name1".to_string(), "test_index1".to_string()),
             ("name2".to_string(), "test_index2".to_string()),

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -603,10 +603,15 @@ pub mod coordinator {
                 .with_callback({
                     let app = app.clone();
                     move |observer| {
-                        let counts = app.data.indexify_state.executor_running_task_count.inner();
-                        for (executor_id, count) in counts.iter() {
+                        let counts = app
+                            .data
+                            .indexify_state
+                            .unfinished_tasks_by_executor
+                            .read()
+                            .unwrap();
+                        for (executor_id, tasks) in counts.iter() {
                             observer.observe(
-                                *count,
+                                tasks.len() as u64,
                                 &[KeyValue::new("executor_id", executor_id.to_string())],
                             );
                         }

--- a/src/scheduler/mod.rs
+++ b/src/scheduler/mod.rs
@@ -1,6 +1,7 @@
 use std::{
     collections::{hash_map::DefaultHasher, HashMap},
     hash::{Hash, Hasher},
+    time::SystemTime,
 };
 
 use anyhow::{anyhow, Ok, Result};
@@ -223,6 +224,7 @@ impl Scheduler {
             input_params: extraction_policy.input_params.clone(),
             outcome: internal_api::TaskOutcome::Unknown,
             index_tables: index_tables.to_vec(),
+            creation_time: SystemTime::now(),
         };
         info!("created task: {:?}", task);
         Ok(task)

--- a/src/state/store/mod.rs
+++ b/src/state/store/mod.rs
@@ -9,6 +9,7 @@ use std::{
     ops::RangeBounds,
     path::{Path, PathBuf},
     sync::Arc,
+    time::SystemTime,
 };
 
 use anyhow::{anyhow, Result};
@@ -773,7 +774,7 @@ impl StateMachineStore {
     //  END FORWARD INDEX READER METHOD INTERFACES
 
     //  START REVERSE INDEX READER METHOD INTERFACES
-    pub async fn get_unassigned_tasks(&self) -> HashSet<TaskId> {
+    pub async fn get_unassigned_tasks(&self) -> HashMap<TaskId, SystemTime> {
         self.data.indexify_state.get_unassigned_tasks()
     }
 
@@ -834,15 +835,6 @@ impl StateMachineStore {
     }
 
     //  END REVERSE INDEX READER METHOD INTERFACES
-
-    //  START REVERSE INDEX WRITER METHOD INTERFACES
-    pub async fn insert_executor_running_task_count(&self, executor_id: &str, task_count: u64) {
-        self.data
-            .indexify_state
-            .insert_executor_running_task_count(executor_id, task_count);
-    }
-
-    //  END REVERSE INDEX WRITER METHOD INTERFACES
 }
 
 impl RaftSnapshotBuilder<TypeConfig> for Arc<StateMachineStore> {

--- a/src/task_allocator/planner/load_aware_distributor.rs
+++ b/src/task_allocator/planner/load_aware_distributor.rs
@@ -289,7 +289,11 @@ impl AllocationPlanner for LoadAwareDistributor {
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::HashMap, sync::Arc, time::Instant};
+    use std::{
+        collections::HashMap,
+        sync::Arc,
+        time::{Instant, SystemTime},
+    };
 
     use indexify_internal_api as internal_api;
     use internal_api::{ContentMetadata, ContentMetadataId};
@@ -320,6 +324,7 @@ mod tests {
             input_params: json!(null),
             outcome: internal_api::TaskOutcome::Unknown,
             index_tables: vec![],
+            creation_time: SystemTime::now(),
         }
     }
 


### PR DESCRIPTION
Keep the pending tasks for executor sorted by creation time, this avoids reordering of tasks because of random generation of ids and ensures that executor task list does not grow beyond specified limit.