### PR TITLE
allow to filter content by graph name and top level content

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3474,6 +3474,7 @@ dependencies = [
  "serde_with",
  "smart-default",
  "strum",
+ "tonic 0.11.0",
  "utoipa",
 ]
 

--- a/crates/indexify_internal_api/Cargo.toml
+++ b/crates/indexify_internal_api/Cargo.toml
@@ -21,3 +21,4 @@ smart-default = { workspace = true }
 strum = { workspace = true }
 utoipa = { workspace = true }
 prost-wkt-types = { workspace = true }
+tonic.workspace = true

--- a/crates/indexify_proto/src/indexify_coordinator.rs
+++ b/crates/indexify_proto/src/indexify_coordinator.rs
@@ -347,11 +347,33 @@ pub struct GetNamespaceResponse {
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Empty {}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ContentSource {
+    #[prost(oneof = "content_source::Value", tags = "1, 2, 3")]
+    pub value: ::core::option::Option<content_source::Value>,
+}
+/// Nested message and enum types in `ContentSource`.
+pub mod content_source {
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Oneof)]
+    pub enum Value {
+        #[prost(string, tag = "1")]
+        Policy(::prost::alloc::string::String),
+        #[prost(message, tag = "2")]
+        Ingestion(super::Empty),
+        #[prost(message, tag = "3")]
+        None(super::Empty),
+    }
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ListContentRequest {
     #[prost(string, tag = "1")]
     pub namespace: ::prost::alloc::string::String,
-    #[prost(string, tag = "2")]
-    pub source: ::prost::alloc::string::String,
+    #[prost(message, optional, tag = "2")]
+    pub source: ::core::option::Option<ContentSource>,
     #[prost(string, tag = "3")]
     pub parent_id: ::prost::alloc::string::String,
     #[prost(map = "string, message", tag = "4")]
@@ -365,6 +387,8 @@ pub struct ListContentRequest {
     pub start_id: ::prost::alloc::string::String,
     #[prost(bool, tag = "7")]
     pub return_total: bool,
+    #[prost(string, tag = "8")]
+    pub graph: ::prost::alloc::string::String,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/crates/indexify_proto/src/lib.rs
+++ b/crates/indexify_proto/src/lib.rs
@@ -1,4 +1,24 @@
+use indexify_coordinator::{content_source, ContentSource, Empty};
+
 #[rustfmt::skip]
 pub mod indexify_coordinator;
 #[rustfmt::skip]
 pub mod indexify_raft;
+
+impl From<String> for ContentSource {
+    fn from(s: String) -> Self {
+        if s == "ingestion" {
+            Self {
+                value: Some(content_source::Value::Ingestion(Empty {})),
+            }
+        } else if s == "" {
+            Self {
+                value: Some(content_source::Value::None(Empty {})),
+            }
+        } else {
+            Self {
+                value: Some(content_source::Value::Policy(s)),
+            }
+        }
+    }
+}

--- a/protos/coordinator_service.proto
+++ b/protos/coordinator_service.proto
@@ -1,5 +1,4 @@
 syntax = "proto3";
-
 import "google/protobuf/struct.proto";
 
 package indexify_coordinator;
@@ -313,14 +312,26 @@ message GetNamespaceResponse {
     Namespace namespace = 1;
 }
 
+message Empty {
+}
+
+message ContentSource {
+    oneof value {
+        string policy = 1;
+        Empty ingestion = 2;
+        Empty none = 3;
+    }
+}
+
 message ListContentRequest {
     string namespace = 1;
-    string source = 2;
+    ContentSource source = 2;
     string parent_id = 3;
     map<string, google.protobuf.Value> labels_eq = 4;
     uint64 limit = 5;
     string start_id = 6;
     bool return_total = 7;
+    string graph = 8;
 }
 
 message ListContentResponse {

--- a/src/api.rs
+++ b/src/api.rs
@@ -5,7 +5,7 @@ use axum::{
     http::StatusCode,
     response::{IntoResponse, Response},
 };
-use indexify_internal_api as internal_api;
+use indexify_internal_api::{self as internal_api};
 use indexify_proto::indexify_coordinator::{self};
 use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, BytesOrString};
@@ -341,6 +341,11 @@ impl From<metadata_storage::ExtractedMetadata> for ExtractedMetadata {
 
 #[derive(Debug, Serialize, Deserialize, ToSchema, PartialEq, Clone)]
 pub struct ListContent {
+    #[serde(
+        deserialize_with = "api_utils::deserialize_none_to_empty_string",
+        default
+    )]
+    pub graph: String,
     #[serde(
         deserialize_with = "api_utils::deserialize_none_to_empty_string",
         default

--- a/src/api_utils.rs
+++ b/src/api_utils.rs
@@ -302,6 +302,7 @@ mod test_deserialize_labels_eq_filter {
     #[test]
     fn test_key_value() {
         let expected_query: Query<ListContent> = Query(ListContent {
+            graph: "".to_string(),
             source: "foo".to_string(),
             parent_id: "".to_string(),
             labels_eq: Some({
@@ -325,6 +326,7 @@ mod test_deserialize_labels_eq_filter {
     #[test]
     fn test_key_empty_value() {
         let expected_query: Query<ListContent> = Query(ListContent {
+            graph: "".to_string(),
             source: "foo".to_string(),
             parent_id: "".to_string(),
             labels_eq: Some({
@@ -359,6 +361,7 @@ mod test_deserialize_labels_eq_filter {
     #[test]
     fn test_multiple_key_value() {
         let expected_query: Query<ListContent> = Query(ListContent {
+            graph: "".to_string(),
             source: "foo".to_string(),
             parent_id: "".to_string(),
             labels_eq: Some({
@@ -384,6 +387,7 @@ mod test_deserialize_labels_eq_filter {
     #[test]
     fn test_multiple_key_value_key_empty_value() {
         let expected_query: Query<ListContent> = Query(ListContent {
+            graph: "".to_string(),
             source: "foo".to_string(),
             parent_id: "".to_string(),
             labels_eq: Some({

--- a/src/coordinator_filters.rs
+++ b/src/coordinator_filters.rs
@@ -1,13 +1,14 @@
 use std::collections::HashMap;
 
+use indexify_internal_api::ContentSourceFilter;
 use itertools::Itertools;
 
 pub fn content_filter(
     content: &indexify_internal_api::ContentMetadata,
-    source: &str,
+    source: &ContentSourceFilter,
     labels_eq: &HashMap<String, serde_json::Value>,
 ) -> bool {
-    if !source.is_empty() && source != content.source.to_string() {
+    if !source.matches(&content.source) {
         return false;
     }
     if !labels_eq.is_empty() && *labels_eq != content.labels {

--- a/src/coordinator_service.rs
+++ b/src/coordinator_service.rs
@@ -14,7 +14,7 @@ use anyhow::{anyhow, Result};
 use axum::{extract::State, routing::get};
 use futures::StreamExt;
 use hyper::StatusCode;
-use indexify_internal_api::{self as internal_api};
+use indexify_internal_api::{self as internal_api, ContentSourceFilter};
 use indexify_proto::indexify_coordinator::{
     self,
     coordinator_service_server::CoordinatorService,
@@ -302,12 +302,14 @@ impl CoordinatorService for CoordinatorServiceServer {
         } else {
             Some(req.limit)
         };
+        let source_filter: ContentSourceFilter = req.source.try_into()?;
 
         let filter = |c: &internal_api::ContentMetadata| {
             c.namespace == req.namespace &&
+                (req.graph.is_empty() || c.extraction_graph_names.contains(&req.graph)) &&
                 (req.parent_id.is_empty() ||
                     Some(&req.parent_id) == c.parent_id.as_ref().map(|id| &id.id)) &&
-                content_filter(c, &req.source, &labels_eq)
+                content_filter(c, &source_filter, &labels_eq)
         };
         let response = self
             .coordinator

--- a/src/data_manager.rs
+++ b/src/data_manager.rs
@@ -10,7 +10,7 @@ use std::{
 use anyhow::{anyhow, Result};
 use bytes::Bytes;
 use futures::{Stream, StreamExt};
-use indexify_internal_api as internal_api;
+use indexify_internal_api::{self as internal_api};
 use indexify_proto::indexify_coordinator::{self, CreateContentStatus, ListActiveContentsRequest};
 use mime::Mime;
 use nanoid::nanoid;
@@ -242,6 +242,7 @@ impl DataManager {
     pub async fn list_content(
         &self,
         namespace: &str,
+        graph: &str,
         source_filter: &str,
         parent_id_filter: &str,
         labels_eq_filter: Option<&HashMap<String, serde_json::Value>>,
@@ -253,10 +254,10 @@ impl DataManager {
         let labels_eq = internal_api::utils::convert_map_serde_to_prost_json(
             labels_eq_filter.unwrap_or(&default_labels_eq).clone(),
         )?;
-
         let req = indexify_coordinator::ListContentRequest {
+            graph: graph.to_string(),
             namespace: namespace.to_string(),
-            source: source_filter.to_string(),
+            source: Some(source_filter.to_string().into()),
             parent_id: parent_id_filter.to_string(),
             labels_eq,
             start_id,

--- a/src/server.rs
+++ b/src/server.rs
@@ -726,6 +726,7 @@ async fn list_content(
         .data_manager
         .list_content(
             &namespace,
+            &filter.graph,
             &filter.source,
             &filter.parent_id,
             filter.labels_eq.as_ref(),


### PR DESCRIPTION
Allow filtering content by graph name.

Specifying 'ingestion' for source filter will select top level content.