### PR TITLE
UI - Show task count on extraction policy page / Make colors and naming conventions consistent

### DIFF
--- a/ui/src/components/ExtractionPolicyItem.tsx
+++ b/ui/src/components/ExtractionPolicyItem.tsx
@@ -127,8 +127,11 @@ const ExtractionPolicyItem = ({
         </Box>
         <Box sx={{ minWidth: cols.taskCount?.width }}>
           <Stack direction="row" spacing={1}>
-            <Tooltip title="Uknown">
-              <Chip label={taskCounts.totalUnknown} />
+            <Tooltip title="In Progress">
+              <Chip
+                sx={{ backgroundColor: '#E5EFFB' }}
+                label={taskCounts.totalUnknown}
+              />
             </Tooltip>
             <Tooltip title="Failed">
               <Chip

--- a/ui/src/components/TasksTable.tsx
+++ b/ui/src/components/TasksTable.tsx
@@ -101,18 +101,21 @@ const TasksTable = ({
       headerName: 'Status',
       renderCell: (params) => {
         if (params.value === TaskStatus.Failure) {
-          return <Chip label="Failure" sx={{ backgroundColor: "#FBE5E5"}} />
+          return <Chip label="Failure" sx={{ backgroundColor: '#FBE5E5' }} />
         } else if (params.value === TaskStatus.Success) {
-          return <Chip label="Success" sx={{ backgroundColor: "#E5FBE6"}} />
+          return <Chip label="Success" sx={{ backgroundColor: '#E5FBE6' }} />
         } else {
-          return <Chip label="In Progress" sx={{ backgroundColor: "#E5EFFB"}} />
+          return (
+            <Chip label="In Progress" sx={{ backgroundColor: '#E5EFFB' }} />
+          )
         }
-      }
+      },
     },
     {
       field: 'content_metadata.source',
       headerName: 'Source',
-      valueGetter: (params) => params.row.content_metadata.source,
+      valueGetter: (params) =>
+        params.row.content_metadata.source || 'Ingestion',
       flex: 1,
     },
     {
@@ -154,7 +157,7 @@ const TasksTable = ({
         }}
       >
         <DataGrid
-          sx={{ backgroundColor: 'white', borderRadius: "12px" }}
+          sx={{ backgroundColor: 'white', borderRadius: '12px' }}
           autoHeight
           rows={tasks.slice(0, paginationModel.pageSize)}
           rowCount={rowCountState}
@@ -169,11 +172,7 @@ const TasksTable = ({
     )
   }
 
-  return (
-    <>
-      {renderContent()}
-    </>
-  )
+  return <>{renderContent()}</>
 }
 
 export default TasksTable

--- a/ui/src/routes/Namespace/ExtractionPolicyPage.tsx
+++ b/ui/src/routes/Namespace/ExtractionPolicyPage.tsx
@@ -1,5 +1,12 @@
 import { useLoaderData } from 'react-router-dom'
-import { Box, Typography, Stack, Breadcrumbs } from '@mui/material'
+import {
+  Box,
+  Typography,
+  Stack,
+  Breadcrumbs,
+  Tooltip,
+  Chip,
+} from '@mui/material'
 import {
   ExtractionGraph,
   IExtractionPolicy,
@@ -9,14 +16,17 @@ import {
 import TasksTable from '../../components/TasksTable'
 import { Link } from 'react-router-dom'
 import NavigateNextIcon from '@mui/icons-material/NavigateNext'
+import { TaskCounts } from '../../types'
 
 const ExtractionPolicyPage = () => {
-  const { policy, namespace, extractionGraph, client } = useLoaderData() as {
-    policy: IExtractionPolicy
-    namespace: string
-    client: IndexifyClient
-    extractionGraph: ExtractionGraph
-  }
+  const { policy, namespace, extractionGraph, taskCounts, client } =
+    useLoaderData() as {
+      policy: IExtractionPolicy
+      namespace: string
+      client: IndexifyClient
+      extractionGraph: ExtractionGraph
+      taskCounts?: TaskCounts
+    }
 
   const taskLoader = async (
     pageSize: number,
@@ -48,6 +58,36 @@ const ExtractionPolicyPage = () => {
         <Typography variant="h2" component="h1">
           Extraction Policy - {policy.name}
         </Typography>
+      </Box>
+      <Box>
+        {taskCounts && (
+          <Stack
+            direction="row"
+            spacing={1}
+            display={'flex'}
+            alignItems={'center'}
+          >
+            <Typography variant="body1">Tasks</Typography>
+            <Tooltip title="In Progress">
+              <Chip
+                sx={{ backgroundColor: '#E5EFFB' }}
+                label={taskCounts.totalUnknown}
+              />
+            </Tooltip>
+            <Tooltip title="Failed">
+              <Chip
+                sx={{ backgroundColor: '#FBE5E5' }}
+                label={taskCounts.totalFailed}
+              />
+            </Tooltip>
+            <Tooltip title="Success">
+              <Chip
+                sx={{ backgroundColor: '#E5FBE6' }}
+                label={taskCounts.totalSuccess}
+              />
+            </Tooltip>
+          </Stack>
+        )}
       </Box>
       <TasksTable
         namespace={namespace}

--- a/ui/src/utils/loaders.ts
+++ b/ui/src/utils/loaders.ts
@@ -6,7 +6,7 @@ import {
   getIndexifyServiceURL,
   groupMetadataByExtractor,
 } from './helpers'
-import { TaskCountsMap } from '../types'
+import { TaskCounts, TaskCountsMap } from '../types'
 
 async function createClient(namespace: string | undefined) {
   if (!namespace) throw new Error('Namespace is required')
@@ -79,7 +79,13 @@ export async function ExtractionPolicyPageLoader({
     .find(
       (policy) => policy.name === policyname && policy.graph_name === graphname
     )
-  return { policy, namespace, extractionGraph, client }
+  
+  let taskCounts:TaskCounts | undefined = undefined
+  if (policy?.id) {
+    taskCounts = await getExtractionPolicyTaskCounts(policy.id, client)
+  }
+    
+  return { policy, namespace, extractionGraph, client, taskCounts }
 }
 
 export async function ExtractorsPageLoader({ params }: LoaderFunctionArgs) {


### PR DESCRIPTION
Add task count on extraction policy page
Make unknown status display as "In Progress"
Make in progress colors consistent
When task has no source display as "Ingested"