### PR TITLE
remove unnecessary Option<>

### DIFF
--- a/src/coordinator.rs
+++ b/src/coordinator.rs
@@ -543,7 +543,7 @@ impl Coordinator {
                 .shared_state
                 .get_extraction_policies_from_ids(applied_extraction_policy_ids)
                 .await?;
-            for applied_extraction_policy in applied_extraction_policies.clone().unwrap() {
+            for applied_extraction_policy in applied_extraction_policies {
                 output_tables.insert(
                     content_metadata.id.clone(),
                     applied_extraction_policy

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -469,7 +469,7 @@ impl App {
     pub async fn get_extraction_policies_from_ids(
         &self,
         extraction_policy_ids: HashSet<String>,
-    ) -> Result<Option<Vec<ExtractionPolicy>>> {
+    ) -> Result<Vec<ExtractionPolicy>> {
         self.state_machine
             .get_extraction_policies_from_ids(extraction_policy_ids)
     }
@@ -689,8 +689,7 @@ impl App {
         };
         let extraction_policies = self
             .state_machine
-            .get_extraction_policies_from_ids(extraction_policy_ids.into_iter().collect())?
-            .unwrap_or_else(Vec::new);
+            .get_extraction_policies_from_ids(extraction_policy_ids.into_iter().collect())?;
         Ok(extraction_policies)
     }
 

--- a/src/state/store/mod.rs
+++ b/src/state/store/mod.rs
@@ -626,7 +626,7 @@ impl StateMachineStore {
     pub fn get_extraction_policies_from_ids(
         &self,
         extraction_policy_ids: HashSet<String>,
-    ) -> Result<Option<Vec<ExtractionPolicy>>> {
+    ) -> Result<Vec<ExtractionPolicy>> {
         self.data
             .indexify_state
             .get_extraction_policies_from_ids(extraction_policy_ids, &self.db.read().unwrap())

--- a/src/state/store/state_machine_objects.rs
+++ b/src/state/store/state_machine_objects.rs
@@ -1835,7 +1835,7 @@ impl IndexifyState {
         &self,
         extraction_policy_ids: HashSet<String>,
         db: &OptimisticTransactionDB,
-    ) -> Result<Option<Vec<ExtractionPolicy>>, StateMachineError> {
+    ) -> Result<Vec<ExtractionPolicy>, StateMachineError> {
         let txn = db.transaction();
 
         let mut policies = Vec::new();
@@ -1858,12 +1858,7 @@ impl IndexifyState {
             }
             // If None, the policy is not found; we simply skip it.
         }
-
-        if policies.is_empty() {
-            Ok(None)
-        } else {
-            Ok(Some(policies))
-        }
+        Ok(policies)
     }
 
     pub fn get_extraction_policy_by_names(


### PR DESCRIPTION
Remove unnecessary Option<> wrapper, already returning a Vec which can be empty.