### PR TITLE
ui: move UI to its own crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3386,6 +3386,7 @@ dependencies = [
  "hyper-util",
  "indexify_internal_api",
  "indexify_proto",
+ "indexify_ui",
  "itertools 0.12.1",
  "jsonschema",
  "lance",
@@ -3487,6 +3488,14 @@ dependencies = [
  "prost-wkt-types",
  "serde",
  "tonic 0.11.0",
+]
+
+[[package]]
+name = "indexify_ui"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "rust-embed",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,27 +11,32 @@ resolver = "2"
 axum-server = { git = "https://github.com/grafbase/axum-server", branch = "rustls-0.23-tokio-rustls-0.26" }
 
 [workspace]
-members = [".", "crates/indexify_internal_api", "crates/indexify_proto"]
+members = [
+    ".",
+    "crates/indexify_internal_api",
+    "crates/indexify_proto",
+    "crates/indexify_ui",
+]
 
 [workspace.dependencies]
-anyerror = { version = "*", features=["anyhow"]}
+anyerror = { version = "*", features = ["anyhow"] }
 anyhow = { version = "1" }
 async-trait = "0.1"
 askama = { version = "0.12" }
-arrow-schema = {version = "51.0.0"}
-arrow-array = {version = "51.0.0" }
+arrow-schema = { version = "51.0.0" }
+arrow-array = { version = "51.0.0" }
 axum = { version = "0.7", features = ["multipart", "macros", "ws"] }
 axum-otel-metrics = "0.8"
 axum-tracing-opentelemetry = "0.16"
-axum-server = {version = "0.6.0", features = ["tls-rustls"]}
+axum-server = { version = "0.6.0", features = ["tls-rustls"] }
 axum-typed-websockets = "0.6.0"
-axum-streams = {version = "0.12.0"}
+axum-streams = { version = "0.12.0" }
 backtrace = "0.3"
 base64 = "0.21.0"
 bytes = "1"
 byteorder = "1"
 clap = { version = "4", features = ["derive"] }
-derive_builder = {version = "0.20.0"}
+derive_builder = { version = "0.20.0" }
 figment = { version = "0.10", features = ["yaml", "env"] }
 flexbuffers = { version = "2.0" }
 futures = { version = "0.3" }
@@ -48,7 +53,12 @@ mime = { version = "0.3" }
 mime_guess = { version = "2" }
 moka = { version = "0.12", features = ["default", "future"] }
 nanoid = { version = "0.4" }
-openraft = {version = "0.9.11", features =["serde_json", "serde", "storage-v2", "generic-snapshot-data"]}
+openraft = { version = "0.9.11", features = [
+    "serde_json",
+    "serde",
+    "storage-v2",
+    "generic-snapshot-data",
+] }
 opensearch = { version = "2", default_features = false, features = [
     "rustls-tls",
 ] }
@@ -57,7 +67,7 @@ pgvector = { version = "0.3", features = ["sqlx"] }
 prost = { version = "0.12.6" }
 prost-types = { version = "0.12" }
 prost-wkt = "0.5.1"
-prost-wkt-types = {version = "0.5.1" }
+prost-wkt-types = { version = "0.5.1" }
 qdrant-client = { version = "1.9.0" }
 rand = { version = "0.8" }
 redis = { version = "0.24", features = [
@@ -83,7 +93,7 @@ rusqlite = { version = "0.30.0", features = ["bundled", "serde_json"] }
 serde = { version = "1", features = ["derive"] }
 serde_with = { version = "3.4.0" }
 serde_yaml = { version = "0.9" }
-serde_json = {version = "1.0.116"}
+serde_json = { version = "1.0.116" }
 smart-default = { version = "0.7" }
 sqlx = { version = "0.7.3", features = [
     "runtime-tokio",
@@ -100,10 +110,11 @@ tonic = { version = "0.11.0", features = ["prost", "transport", "tls"] }
 tokio = { version = "1", features = ["full"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
 tokio-rustls = { version = "0.26" }
-tokio-util = {version ="0.7.10"}
+tokio-util = { version = "0.7.10" }
 tower = { version = "0.4" }
 tower-http = { version = "0.5.1", default-features = false, features = [
-    "cors", "trace"
+    "cors",
+    "trace",
 ] }
 tracing = { version = "0.1", features = ["log"] }
 tracing-core = "0.1"
@@ -111,7 +122,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tracing-unwrap = { version = "0.10" }
 url = "2"
 utoipa = { version = "4.2.3", features = ["axum_extras"] }
-utoipa-swagger-ui = {version = "7.1.0", features = ["axum"] }
+utoipa-swagger-ui = { version = "7.1.0", features = ["axum"] }
 utoipa-rapidoc = { version = "4.0.0", features = ["axum"] }
 utoipa-redoc = { version = "4.0.0", features = ["axum"] }
 object_store = { version = "0.9", features = ["aws"] }
@@ -119,11 +130,17 @@ local-ip-address = { version = "0.6" }
 flate2 = "1"
 tar = "0.4"
 walkdir = { version = "2" }
-lance = {version = "0.12.1", default_features=false}
-lancedb = {version = "0.5.2", default_features = false}
+lance = { version = "0.12.1", default_features = false }
+lancedb = { version = "0.5.2", default_features = false }
 gluesql = { git = "https://github.com/gluesql/gluesql.git", rev = "07dd839", default_features = false }
-tracing-opentelemetry = { version = "0.23.0", features = ["async-trait", "futures-util"] }
-opentelemetry-otlp = { version = "0.15.0", features = ["http-proto", "grpc-tonic"] }
+tracing-opentelemetry = { version = "0.23.0", features = [
+    "async-trait",
+    "futures-util",
+] }
+opentelemetry-otlp = { version = "0.15.0", features = [
+    "http-proto",
+    "grpc-tonic",
+] }
 opentelemetry-tonic = "0.1.0"
 http = "1.1.0"
 opentelemetry-stdout = { version = "0.3.0", features = ["logs", "trace"] }
@@ -134,14 +151,14 @@ anyerror = { workspace = true }
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 askama = { workspace = true }
-arrow-schema = {workspace = true}
-arrow-array = {workspace=true}
+arrow-schema = { workspace = true }
+arrow-array = { workspace = true }
 axum = { workspace = true }
 axum-otel-metrics = { workspace = true }
 axum-tracing-opentelemetry = { workspace = true }
-axum-server = {workspace = true }
+axum-server = { workspace = true }
 axum-typed-websockets = { workspace = true }
-axum-streams = {workspace = true}
+axum-streams = { workspace = true }
 base64 = { workspace = true }
 byteorder = { workspace = true }
 bytes = { workspace = true }
@@ -190,7 +207,7 @@ tonic = { workspace = true }
 tokio = { workspace = true }
 tokio-rustls = { workspace = true }
 tokio-stream = { workspace = true }
-tokio-util = {workspace = true}
+tokio-util = { workspace = true }
 tower = { workspace = true }
 tower-http = { workspace = true }
 tracing = { workspace = true }
@@ -212,7 +229,7 @@ lancedb = { workspace = true }
 async-stream = "0.3.5"
 once_cell = "1.19.0"
 pin-project-lite = "0.2.13"
-gluesql = {workspace=true, default-features=false}
+gluesql = { workspace = true, default-features = false }
 uuid = "1.8.0"
 sha2 = "0.10.8"
 opentelemetry-prometheus = "0.15"
@@ -224,6 +241,7 @@ opentelemetry-tonic = { workspace = true }
 http = { workspace = true }
 opentelemetry-stdout = { workspace = true }
 opentelemetry-datadog = { workspace = true }
+indexify_ui = { path = "crates/indexify_ui" }
 
 [dev-dependencies]
 tracing-test = { version = "0.2", features = ["no-env-filter"] }

--- a/crates/indexify_ui/Cargo.toml
+++ b/crates/indexify_ui/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "indexify_ui"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+rust-embed.workspace = true
+
+[build-dependencies]
+anyhow.workspace = true

--- a/crates/indexify_ui/build.rs
+++ b/crates/indexify_ui/build.rs
@@ -1,0 +1,24 @@
+use std::process::Command;
+
+use anyhow::{anyhow, Result};
+
+fn main() -> Result<()> {
+    println!("cargo:rerun-if-changed=../../ui/src");
+    println!("cargo:rerun-if-changed=../../ui/tsconfig.json");
+    println!("cargo:rerun-if-changed=../../ui/package.json");
+    println!("cargo:rerun-if-changed=../../ui/package-lock.json");
+    println!("cargo:rerun-if-changed=../../ui/public");
+
+    if !Command::new("sh")
+        .arg("-c")
+        .arg("cd ../../ui && npm run build")
+        .status()?
+        .success()
+    {
+        return Err(anyhow!(
+            "Failed to execute npm commands in the 'ui' directory"
+        ));
+    }
+
+    Ok(())
+}

--- a/crates/indexify_ui/src/lib.rs
+++ b/crates/indexify_ui/src/lib.rs
@@ -1,0 +1,5 @@
+use rust_embed::RustEmbed;
+
+#[derive(RustEmbed)]
+#[folder = "../../ui/build"]
+pub struct Assets;

--- a/src/server.rs
+++ b/src/server.rs
@@ -23,6 +23,7 @@ use indexify_proto::indexify_coordinator::{
     ListStateChangesRequest,
     ListTasksRequest,
 };
+use indexify_ui::Assets as UiAssets;
 use prometheus::Encoder;
 use rust_embed::RustEmbed;
 use tokio::{
@@ -54,10 +55,6 @@ use crate::{
 };
 
 const DEFAULT_SEARCH_LIMIT: u64 = 5;
-
-#[derive(RustEmbed)]
-#[folder = "ui/build"]
-pub struct UiAssets;
 
 #[derive(Clone, Debug)]
 pub struct NamespaceEndpointState {


### PR DESCRIPTION
While `build.rs` allows conditional compilation,
it requires that it is crate-wide. By moving the
UI's embed into its own crate, `npm run build`
will only be called when files change in the `ui`
directory.

Note: also removed `npm ci` from the crate build
itself. That's useful but because you get zero
feedback it is ~impossible to diagnose from cargo
itself. Leaving `npm ci` as something that is run
during the UI development process separately.

Fixes #691