### PR TITLE
api: adding serialization for filters

### DIFF
--- a/src/api/utils.rs
+++ b/src/api/utils.rs
@@ -1,0 +1,9 @@
+use anyhow::Result;
+
+pub fn deserialize_none_to_empty_string<'de, D>(deserializer: D) -> Result<String, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let s: Option<String> = serde::Deserialize::deserialize(deserializer)?;
+    Ok(s.unwrap_or("".to_string()))
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,6 @@ pub mod state;
 pub mod task_allocator;
 
 mod api;
-mod api_utils;
 mod blob_storage;
 mod caching;
 mod cmd;


### PR DESCRIPTION
The HashMap<> for filters was getting serialized as a JSON object which couldn't be deserialized by the clients. Move to using `with` for symmetric handling for filters and handle Option<> gracefully.