### PR TITLE
feature to allow to link two extraction graphs

### DIFF
--- a/crates/indexify_internal_api/src/lib.rs
+++ b/crates/indexify_internal_api/src/lib.rs
@@ -85,6 +85,35 @@ impl ExtractionGraphBuilder {
     }
 }
 
+#[derive(Debug, Clone, Serialize, PartialEq, Eq, Deserialize, Hash)]
+pub struct ExtractionGraphNode {
+    pub namespace: String,
+    pub graph_name: String,
+    pub source: ContentSource,
+}
+
+/// Links a node in extraction graph to another graph.
+/// All top level policies in the linked graph will be applied to the
+/// specified node.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq, Deserialize)]
+pub struct ExtractionGraphLink {
+    pub node: ExtractionGraphNode,
+    pub graph_name: String,
+}
+
+impl From<indexify_coordinator::LinkExtractionGraphsRequest> for ExtractionGraphLink {
+    fn from(value: indexify_coordinator::LinkExtractionGraphsRequest) -> Self {
+        Self {
+            node: ExtractionGraphNode {
+                namespace: value.namespace,
+                graph_name: value.source_graph_name,
+                source: value.content_source.into(),
+            },
+            graph_name: value.linked_graph_name,
+        }
+    }
+}
+
 pub type IndexName = String;
 pub type IndexId = String;
 
@@ -794,7 +823,7 @@ impl Default for ContentMetadataId {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 pub enum ContentSource {
     Ingestion,
     ExtractionPolicyName(ExtractionPolicyName),

--- a/crates/indexify_proto/src/indexify_coordinator.rs
+++ b/crates/indexify_proto/src/indexify_coordinator.rs
@@ -834,6 +834,21 @@ pub struct ExecutorsHeartbeatRequest {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ExecutorsHeartbeatResponse {}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct LinkExtractionGraphsRequest {
+    #[prost(string, tag = "1")]
+    pub namespace: ::prost::alloc::string::String,
+    #[prost(string, tag = "2")]
+    pub source_graph_name: ::prost::alloc::string::String,
+    #[prost(string, tag = "3")]
+    pub content_source: ::prost::alloc::string::String,
+    #[prost(string, tag = "4")]
+    pub linked_graph_name: ::prost::alloc::string::String,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct LinkExtractionGraphsResponse {}
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
 pub enum TaskOutcome {
@@ -2075,6 +2090,36 @@ pub mod coordinator_service_client {
                 );
             self.inner.unary(req, path, codec).await
         }
+        pub async fn link_extraction_graphs(
+            &mut self,
+            request: impl tonic::IntoRequest<super::LinkExtractionGraphsRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::LinkExtractionGraphsResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/indexify_coordinator.CoordinatorService/LinkExtractionGraphs",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "indexify_coordinator.CoordinatorService",
+                        "LinkExtractionGraphs",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
+        }
     }
 }
 /// Generated server implementations.
@@ -2330,6 +2375,13 @@ pub mod coordinator_service_server {
             request: tonic::Request<super::ExecutorsHeartbeatRequest>,
         ) -> std::result::Result<
             tonic::Response<super::ExecutorsHeartbeatResponse>,
+            tonic::Status,
+        >;
+        async fn link_extraction_graphs(
+            &self,
+            request: tonic::Request<super::LinkExtractionGraphsRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::LinkExtractionGraphsResponse>,
             tonic::Status,
         >;
     }
@@ -4098,6 +4150,56 @@ pub mod coordinator_service_server {
                     let fut = async move {
                         let inner = inner.0;
                         let method = ExecutorsHeartbeatSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/indexify_coordinator.CoordinatorService/LinkExtractionGraphs" => {
+                    #[allow(non_camel_case_types)]
+                    struct LinkExtractionGraphsSvc<T: CoordinatorService>(pub Arc<T>);
+                    impl<
+                        T: CoordinatorService,
+                    > tonic::server::UnaryService<super::LinkExtractionGraphsRequest>
+                    for LinkExtractionGraphsSvc<T> {
+                        type Response = super::LinkExtractionGraphsResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<super::LinkExtractionGraphsRequest>,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as CoordinatorService>::link_extraction_graphs(
+                                        &inner,
+                                        request,
+                                    )
+                                    .await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = LinkExtractionGraphsSvc(inner);
                         let codec = tonic::codec::ProstCodec::default();
                         let mut grpc = tonic::server::Grpc::new(codec)
                             .apply_compression_config(

--- a/protos/coordinator_service.proto
+++ b/protos/coordinator_service.proto
@@ -73,6 +73,8 @@ service CoordinatorService {
     rpc UpdateLabels(UpdateLabelsRequest) returns (UpdateLabelsResponse) {}
 
     rpc ExecutorsHeartbeat(ExecutorsHeartbeatRequest) returns (ExecutorsHeartbeatResponse) {}
+
+    rpc LinkExtractionGraphs(LinkExtractionGraphsRequest) returns (LinkExtractionGraphsResponse) {}
 }
 
 message GetContentMetadataRequest {
@@ -575,3 +577,12 @@ message ExecutorsHeartbeatRequest {
 }
 
 message ExecutorsHeartbeatResponse {}
+
+message LinkExtractionGraphsRequest {
+    string namespace = 1;
+    string source_graph_name = 2;
+    string content_source = 3;
+    string linked_graph_name = 4;
+}
+
+message LinkExtractionGraphsResponse {}

--- a/src/api.rs
+++ b/src/api.rs
@@ -16,6 +16,13 @@ use utoipa::{IntoParams, ToSchema};
 use crate::{api_utils, metadata_storage, vectordbs};
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct ExtractionGraphLink {
+    pub source_graph_name: String,
+    pub content_source: String,
+    pub linked_graph_name: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct ExtractionGraph {
     pub id: String,
     pub name: String,

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -593,6 +593,9 @@ impl App {
                 }
             }
         }
+        if self.state_machine.creates_cycle(&link)? {
+            return Err(anyhow!("unable to link extraction graphs: cycle detected"));
+        }
         let req = StateMachineUpdateRequest {
             payload: RequestPayload::CreateExtractionGraphLink {
                 extraction_graph_link: link,

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -11,14 +11,16 @@ use std::{
 
 use anyhow::{anyhow, Result};
 use grpc_server::RaftGrpcServer;
-use indexify_internal_api::{self as internal_api};
+use indexify_internal_api::{self as internal_api, ExtractionGraphNode};
 use indexify_proto::{
     indexify_coordinator::CreateContentStatus,
     indexify_raft::raft_api_server::RaftApiServer,
 };
 use internal_api::{
     ContentMetadataId,
+    ContentSource,
     ExtractionGraph,
+    ExtractionGraphLink,
     ExtractionPolicy,
     StateChange,
     StateChangeId,
@@ -415,27 +417,34 @@ impl App {
         content_metadata: &internal_api::ContentMetadata,
     ) -> Result<Vec<ExtractionPolicy>> {
         if content_metadata.tombstoned {
-            return Ok(vec![]);
-        }
-
-        if content_metadata.extraction_graph_names.is_empty() {
             return Ok(Vec::new());
         }
-        let extraction_graphs = self.get_extraction_graphs_by_name(
-            &content_metadata.namespace,
-            &content_metadata.extraction_graph_names,
-        )?;
-        let mut all_extraction_policies: Vec<ExtractionPolicy> = Vec::new();
-        for extraction_graph in extraction_graphs {
-            if let Some(eg) = extraction_graph {
-                all_extraction_policies.extend(eg.extraction_policies);
+        let mut policy_ids = Vec::new();
+        for graph_name in &content_metadata.extraction_graph_names {
+            let graph_links = self
+                .state_machine
+                .data
+                .indexify_state
+                .graph_links
+                .read()
+                .unwrap();
+            let key = ExtractionGraphNode {
+                namespace: content_metadata.namespace.clone(),
+                graph_name: graph_name.clone(),
+                source: content_metadata.source.clone(),
+            };
+            if let Some(graph_links) = graph_links.get(&key) {
+                policy_ids.extend(graph_links.iter().cloned());
             }
         }
+        if policy_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+        let all_extraction_policies = self
+            .get_extraction_policies_from_ids(policy_ids.into_iter().collect())
+            .await?;
         let mut matched_policies = Vec::new();
         for extraction_policy in all_extraction_policies {
-            if content_metadata.source != extraction_policy.content_source {
-                continue;
-            }
             if !extraction_policy.filters.iter().all(|(name, value)| {
                 content_metadata
                     .labels
@@ -557,6 +566,44 @@ impl App {
             .client_write(req)
             .await
             .map_err(|e| anyhow!("unable to remove executor {}", e))?;
+        Ok(())
+    }
+
+    pub async fn link_graphs(&self, link: ExtractionGraphLink) -> Result<()> {
+        let graphs = vec![link.node.graph_name.clone(), link.graph_name.clone()];
+        let graphs = self.get_extraction_graphs_by_name(&link.node.namespace, &graphs)?;
+        if graphs.len() != 2 || graphs[0].is_none() || graphs[1].is_none() {
+            return Err(anyhow!(
+                "unable to link extraction graphs: one or more graphs not found"
+            ));
+        }
+        match link.node.source {
+            ContentSource::Ingestion => (),
+            ContentSource::ExtractionPolicyName(ref policy_name) => {
+                if !graphs[0]
+                    .as_ref()
+                    .unwrap()
+                    .extraction_policies
+                    .iter()
+                    .any(|policy| policy.name == *policy_name)
+                {
+                    return Err(anyhow!(
+                        "unable to link extraction graphs: source extraction policy not found"
+                    ));
+                }
+            }
+        }
+        let req = StateMachineUpdateRequest {
+            payload: RequestPayload::CreateExtractionGraphLink {
+                extraction_graph_link: link,
+            },
+            new_state_changes: vec![],
+            state_changes_processed: vec![],
+        };
+        self.forwardable_raft
+            .client_write(req)
+            .await
+            .map_err(|e| anyhow!("unable to link extraction graphs: {}", e.to_string()))?;
         Ok(())
     }
 

--- a/src/state/store/mod.rs
+++ b/src/state/store/mod.rs
@@ -129,6 +129,7 @@ pub enum StateMachineColumns {
     CoordinatorAddress,                 //  NodeId -> Coordinator address
     ExtractionGraphs,                   //  ExtractionGraphId -> ExtractionGraph
     RaftState,                          //  Raft state
+    ExtractionGraphLinks,               //  Namespace/Graph/Source -> Linked graph name
 }
 
 const LAST_MEMBERSHIP_KEY: &[u8] = b"last_membership";

--- a/src/state/store/requests.rs
+++ b/src/state/store/requests.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, time::SystemTime};
 
 use indexify_internal_api as internal_api;
-use internal_api::{StateChange, StateChangeId};
+use internal_api::{ExtractionGraphLink, StateChange, StateChangeId};
 use serde::{Deserialize, Serialize};
 
 use super::{ExecutorId, TaskId};
@@ -63,6 +63,9 @@ pub enum RequestPayload {
         extraction_graph: internal_api::ExtractionGraph,
         structured_data_schema: internal_api::StructuredDataSchema,
         indexes: Vec<internal_api::Index>,
+    },
+    CreateExtractionGraphLink {
+        extraction_graph_link: ExtractionGraphLink,
     },
     CreateOrUpdateContent {
         entries: Vec<CreateOrUpdateContentEntry>,

--- a/src/state/store/state_machine_objects.rs
+++ b/src/state/store/state_machine_objects.rs
@@ -702,7 +702,7 @@ pub struct IndexifyState {
     pub change_id: std::sync::Mutex<u64>,
 
     /// Graph+ContentSource->Policy Id
-    pub graph_links: Arc<RwLock<HashMap<ExtractionGraphNode, HashSet<String>>>>,
+    pub graph_links: Arc<RwLock<HashMap<ExtractionGraphNode, HashSet<ExtractionPolicyId>>>>,
 }
 
 impl fmt::Display for IndexifyState {

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -178,13 +178,10 @@ pub mod db_utils {
         task: &Task,
         id: &str,
     ) -> Result<internal_api::ContentMetadata, anyhow::Error> {
-        let mut content = test_mock_content_metadata(
-            id,
-            task.content_metadata.get_root_id(),
-            &task.content_metadata.extraction_graph_names[0],
-        );
-        content.parent_id = Some(task.content_metadata.id.clone());
         let policy = coordinator.get_extraction_policy(task.extraction_policy_id.clone())?;
+        let mut content =
+            test_mock_content_metadata(id, task.content_metadata.get_root_id(), &policy.graph_name);
+        content.parent_id = Some(task.content_metadata.id.clone());
         content.source = ContentSource::ExtractionPolicyName(policy.name);
         Ok(content)
     }


### PR DESCRIPTION
Feature to support making an output of an extraction graph an input to another extraction graph. All top level policies (with content source ingestion) of the linked graph are applied to the specified graph/content_source combination.