### PR TITLE
remove content_namespace_table

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3355,7 +3355,7 @@ dependencies = [
 
 [[package]]
 name = "indexify"
-version = "0.1.16"
+version = "0.1.17"
 dependencies = [
  "anyerror",
  "anyhow",


### PR DESCRIPTION
Don't need to keep content_namespace_table, used for tests only. Read from database directly.