### PR TITLE
generate openapi descriptions for extraction graphs

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -826,7 +826,7 @@ pub struct TaskAssignments {
     pub assignments: HashMap<String, String>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
 pub struct UploadFileResponse {
     pub content_id: String,
 }

--- a/src/api_utils.rs
+++ b/src/api_utils.rs
@@ -302,7 +302,6 @@ mod test_deserialize_labels_eq_filter {
     #[test]
     fn test_key_value() {
         let expected_query: Query<ListContent> = Query(ListContent {
-            graph: "".to_string(),
             source: "foo".to_string(),
             parent_id: "".to_string(),
             labels_eq: Some({
@@ -326,7 +325,6 @@ mod test_deserialize_labels_eq_filter {
     #[test]
     fn test_key_empty_value() {
         let expected_query: Query<ListContent> = Query(ListContent {
-            graph: "".to_string(),
             source: "foo".to_string(),
             parent_id: "".to_string(),
             labels_eq: Some({
@@ -361,7 +359,6 @@ mod test_deserialize_labels_eq_filter {
     #[test]
     fn test_multiple_key_value() {
         let expected_query: Query<ListContent> = Query(ListContent {
-            graph: "".to_string(),
             source: "foo".to_string(),
             parent_id: "".to_string(),
             labels_eq: Some({
@@ -387,7 +384,6 @@ mod test_deserialize_labels_eq_filter {
     #[test]
     fn test_multiple_key_value_key_empty_value() {
         let expected_query: Query<ListContent> = Query(ListContent {
-            graph: "".to_string(),
             source: "foo".to_string(),
             parent_id: "".to_string(),
             labels_eq: Some({

--- a/src/server.rs
+++ b/src/server.rs
@@ -33,7 +33,11 @@ use tokio::{
 use tokio_stream::StreamExt;
 use tower_http::cors::{Any, CorsLayer};
 use tracing::info;
-use utoipa::OpenApi;
+use utoipa::{
+    openapi::{self, InfoBuilder, OpenApiBuilder},
+    OpenApi,
+    ToSchema,
+};
 use utoipa_rapidoc::RapiDoc;
 use utoipa_redoc::{Redoc, Servable};
 use utoipa_swagger_ui::SwaggerUi;
@@ -171,6 +175,10 @@ impl Server {
             .merge(Redoc::with_url("/redoc", ApiDoc::openapi()))
             .merge(RapiDoc::new("/api-docs/openapi.json").path("/rapidoc"))
             .route("/", get(root))
+            .route(
+                "/namespaces/:namespace/openapi.json",
+                get(namespace_open_api).with_state(namespace_endpoint_state.clone()),
+            )
             .route(
                 "/namespaces/:namespace/extraction_graphs",
                 post(create_extraction_graph).with_state(namespace_endpoint_state.clone()),
@@ -517,6 +525,84 @@ async fn list_namespaces(
     Ok(Json(ListNamespacesResponse {
         namespaces: data_namespaces,
     }))
+}
+
+async fn namespace_open_api(
+    Path(namespace): Path<String>,
+    State(state): State<NamespaceEndpointState>,
+) -> Result<Json<openapi::OpenApi>, IndexifyAPIError> {
+    let extraction_graphs = state
+        .data_manager
+        .list_extraction_graphs(&namespace)
+        .await
+        .map_err(|e| {
+            IndexifyAPIError::new(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                &format!("failed to get namespace: {}", e),
+            )
+        })?;
+    let mut builder = OpenApiBuilder::default();
+    let info = InfoBuilder::default()
+        .title("Indexify API")
+        .version(env!("CARGO_PKG_VERSION"))
+        .build();
+    builder = builder.info(info);
+    let mut paths = utoipa::openapi::PathsBuilder::default();
+    for eg in extraction_graphs {
+        let response = utoipa::openapi::response::ResponseBuilder::default()
+            .description("content uploaded successfully")
+            .content(
+                "application/json",
+                utoipa::openapi::content::ContentBuilder::default()
+                    .schema(utoipa::openapi::Ref::from_schema_name("UploadFileResponse"))
+                    .build(),
+            )
+            .build();
+        let operation = utoipa::openapi::path::OperationBuilder::default()
+            .summary(Some(format!(
+                "upload and extract content using graph '{}'",
+                eg.name
+            )))
+            .request_body(Some(
+                utoipa::openapi::request_body::RequestBodyBuilder::default()
+                    .description(Some("content to be uploaded and extracted"))
+                    .required(Some(openapi::Required::True))
+                    .build(),
+            ))
+            .response("200", response)
+            .response(
+                "500",
+                utoipa::openapi::response::ResponseBuilder::new()
+                    .description("Internal Server Error")
+                    .build(),
+            )
+            .parameter(
+                openapi::path::ParameterBuilder::default()
+                    .name("id")
+                    .parameter_in(openapi::path::ParameterIn::Query)
+                    .description(Some("id of the content"))
+                    .required(openapi::Required::False)
+                    .build(),
+            )
+            .description(eg.description);
+        let item = utoipa::openapi::path::PathItemBuilder::default()
+            .operation(utoipa::openapi::path::PathItemType::Post, operation.build())
+            .build();
+        paths = paths.path(
+            format!(
+                "/namespaces/{}/extraction_graphs/{}/extract",
+                namespace, eg.name
+            ),
+            item,
+        );
+    }
+    let components = utoipa::openapi::ComponentsBuilder::default()
+        .schema_from::<UploadFileResponse>()
+        .schema_from::<UploadFileQueryParams>()
+        .build();
+    builder = builder.paths(paths.build()).components(Some(components));
+    let openapi = builder.build();
+    Ok(Json(openapi))
 }
 
 /// Get metadata for a specific namespace
@@ -888,7 +974,7 @@ async fn download_content(
         .map_err(|e| IndexifyAPIError::new(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string()))
 }
 
-#[derive(Debug, serde::Deserialize)]
+#[derive(Debug, serde::Deserialize, ToSchema)]
 struct UploadFileQueryParams {
     id: Option<String>,
 }
@@ -1246,7 +1332,7 @@ async fn list_tasks(
         .map_err(IndexifyAPIError::internal_error)?
         .list_tasks(ListTasksRequest {
             namespace: namespace.clone(),
-            extraction_policy: extraction_policy,
+            extraction_policy,
             start_id: query.start_id.clone().unwrap_or_default(),
             limit: query.limit.unwrap_or(10),
             content_id: query.content_id.unwrap_or_default(),


### PR DESCRIPTION
Add api to upload file through path containing extraction graph name. Generate per namespace openapi json description for each extraction graph path.