### PR TITLE
update streaming api for content updates

### DIFF
--- a/crates/indexify_proto/src/indexify_coordinator.rs
+++ b/crates/indexify_proto/src/indexify_coordinator.rs
@@ -798,6 +798,22 @@ pub struct GetIngestionInfoRequest {
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
+pub struct RequestContentExtractionEventStream {
+    #[prost(string, tag = "1")]
+    pub namespace: ::prost::alloc::string::String,
+    #[prost(string, tag = "2")]
+    pub extraction_graph_name: ::prost::alloc::string::String,
+    #[prost(string, tag = "3")]
+    pub extraction_policy: ::prost::alloc::string::String,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ContentExtractionEvent {
+    #[prost(string, tag = "1")]
+    pub content_id: ::prost::alloc::string::String,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetIngestionInfoResponse {
     #[prost(message, optional, tag = "1")]
     pub task: ::core::option::Option<Task>,
@@ -2040,6 +2056,36 @@ pub mod coordinator_service_client {
                 );
             self.inner.unary(req, path, codec).await
         }
+        pub async fn stream_content_extraction_status(
+            &mut self,
+            request: impl tonic::IntoRequest<super::RequestContentExtractionEventStream>,
+        ) -> std::result::Result<
+            tonic::Response<tonic::codec::Streaming<super::ContentExtractionEvent>>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/indexify_coordinator.CoordinatorService/StreamContentExtractionStatus",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "indexify_coordinator.CoordinatorService",
+                        "StreamContentExtractionStatus",
+                    ),
+                );
+            self.inner.server_streaming(req, path, codec).await
+        }
         pub async fn wait_content_extraction(
             &mut self,
             request: impl tonic::IntoRequest<super::WaitContentExtractionRequest>,
@@ -2454,6 +2500,19 @@ pub mod coordinator_service_server {
             request: tonic::Request<super::GetIngestionInfoRequest>,
         ) -> std::result::Result<
             tonic::Response<super::GetIngestionInfoResponse>,
+            tonic::Status,
+        >;
+        /// Server streaming response type for the StreamContentExtractionStatus method.
+        type StreamContentExtractionStatusStream: tonic::codegen::tokio_stream::Stream<
+                Item = std::result::Result<super::ContentExtractionEvent, tonic::Status>,
+            >
+            + Send
+            + 'static;
+        async fn stream_content_extraction_status(
+            &self,
+            request: tonic::Request<super::RequestContentExtractionEventStream>,
+        ) -> std::result::Result<
+            tonic::Response<Self::StreamContentExtractionStatusStream>,
             tonic::Status,
         >;
         async fn wait_content_extraction(
@@ -4128,6 +4187,62 @@ pub mod coordinator_service_server {
                                 max_encoding_message_size,
                             );
                         let res = grpc.unary(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/indexify_coordinator.CoordinatorService/StreamContentExtractionStatus" => {
+                    #[allow(non_camel_case_types)]
+                    struct StreamContentExtractionStatusSvc<T: CoordinatorService>(
+                        pub Arc<T>,
+                    );
+                    impl<
+                        T: CoordinatorService,
+                    > tonic::server::ServerStreamingService<
+                        super::RequestContentExtractionEventStream,
+                    > for StreamContentExtractionStatusSvc<T> {
+                        type Response = super::ContentExtractionEvent;
+                        type ResponseStream = T::StreamContentExtractionStatusStream;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::ResponseStream>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<
+                                super::RequestContentExtractionEventStream,
+                            >,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as CoordinatorService>::stream_content_extraction_status(
+                                        &inner,
+                                        request,
+                                    )
+                                    .await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = StreamContentExtractionStatusSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.server_streaming(method, req).await;
                         Ok(res)
                     };
                     Box::pin(fut)

--- a/protos/coordinator_service.proto
+++ b/protos/coordinator_service.proto
@@ -68,6 +68,8 @@ service CoordinatorService {
 
     rpc GetIngestionInfo(GetIngestionInfoRequest) returns (GetIngestionInfoResponse) {}
 
+    rpc StreamContentExtractionStatus(RequestContentExtractionEventStream) returns (stream ContentExtractionEvent) {}
+
     rpc WaitContentExtraction(WaitContentExtractionRequest) returns (WaitContentExtractionResponse) {}
 
     rpc ListActiveContents(ListActiveContentsRequest) returns (ListActiveContentsResponse) {}
@@ -556,6 +558,16 @@ message GetTaskResponse {
 
 message GetIngestionInfoRequest {
     string task_id = 1;
+}
+
+message RequestContentExtractionEventStream {
+    string namespace = 1;
+    string extraction_graph_name = 2;
+    string extraction_policy = 3;
+}
+
+message ContentExtractionEvent {
+    string content_id = 1;
 }
 
 message GetIngestionInfoResponse {

--- a/src/coordinator.rs
+++ b/src/coordinator.rs
@@ -715,6 +715,10 @@ impl Coordinator {
         self.shared_state.subscribe_to_gc_task_events().await
     }
 
+    pub fn subscribe_to_content_stream(&self) -> broadcast::Receiver<String> {
+        self.shared_state.subscribe_to_content_stream()
+    }
+
     pub fn get_state_watcher(&self) -> Receiver<StateChangeId> {
         self.shared_state.get_state_change_watcher()
     }

--- a/src/server.rs
+++ b/src/server.rs
@@ -185,6 +185,10 @@ impl Server {
                 post(upload_file).with_state(namespace_endpoint_state.clone()),
             )
             .route(
+                "/namespaces/:namespace/extraction_graphs/:extraction_graph/extract",
+                put(upload_file).with_state(namespace_endpoint_state.clone()),
+            )
+            .route(
                 "/namespaces/:namespace/extraction_graphs/:extraction_graph/extract_remote",
                 post(ingest_remote_file).with_state(namespace_endpoint_state.clone()),
             )
@@ -196,9 +200,7 @@ impl Server {
                 "/namespaces/:namespace/extraction_graphs/:extraction_graph/extraction_policies/:extraction_policy/tasks",
                 get(list_tasks).with_state(namespace_endpoint_state.clone()),
             )
-            .route("/namespaces/:namespace/content/:content_id/download",
-                get(download_content).with_state(namespace_endpoint_state.clone()))
-            .route("/namespaces/:namespace/extraction_graphs/:extraction_graph/extraction_policies/:extraction_policy/content/:content_id",
+           .route("/namespaces/:namespace/extraction_graphs/:extraction_graph/extraction_policies/:extraction_policy/content/:content_id",
                 get(get_content_tree_metadata).with_state(namespace_endpoint_state.clone()))
             .route(
                 "/namespaces/:namespace/extraction_graphs/:graph/links",
@@ -222,6 +224,9 @@ impl Server {
             .route(
                 "/namespaces/:namespace/active_content",
                 get(active_content).with_state(namespace_endpoint_state.clone()),
+            )
+            .route("/namespaces/:namespace/content/:content_id/download",
+                get(download_content).with_state(namespace_endpoint_state.clone()),
             )
             .route(
                 "/namespaces/:namespace/content/:content_id/metadata",

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -1418,6 +1418,12 @@ impl App {
         self.state_machine.subscribe_to_gc_task_events().await
     }
 
+    pub fn subscribe_to_content_stream(
+        &self,
+    ) -> broadcast::Receiver<String> {
+        self.state_machine.subscribe_to_content_stream()
+    }
+
     pub async fn ensure_leader(&self) -> Result<Option<typ::ForwardToLeader>> {
         self.forwardable_raft.ensure_leader().await
     }


### PR DESCRIPTION
Unfinished work to get extraction update stream from a graph. The UX would be similar to listening to a Kafka/message queue topic. 

Use cases - waking up Agents when there is new structured data from ingestion pipelines. 