### PR TITLE
chore: conditional run for tests and lint workflows

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,6 +13,7 @@ env:
 
 jobs:
   changes:
+    name: Get Changes
     runs-on: ubuntu-latest
     outputs:
       ui: ${{ steps.filter.outputs.ui }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -42,16 +42,20 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: '20'
+
       - name: Npm Install
         run: cd ui && npm ci
+
       - name: UI Lint Check
         run: cd ui && npm run lint
+
       - name: Setup Rust
         uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly
           components: rustfmt
           override: true
+
       - name: Rust Format Check
         run: |
           cargo +nightly fmt -- --check

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,4 +1,5 @@
 name: Tests
+
 on:
   push:
     branches:
@@ -11,8 +12,28 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      ui: ${{ steps.filter.outputs.ui }}
+      other: ${{ steps.filter.outputs.other }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          filters: |
+            ui:
+              - 'ui/**'
+            other:
+              - '**'
+              - '!ui/**'
+              - '!docs/**'
+
   lint:
     name: Lint Checks
+    needs: changes
+    if: ${{ needs.changes.outputs.ui == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -21,25 +42,24 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: '20'
-
       - name: Npm Install
         run: cd ui && npm ci
-
       - name: UI Lint Check
         run: cd ui && npm run lint
-
       - name: Setup Rust
         uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly
           components: rustfmt
           override: true
-
       - name: Rust Format Check
         run: |
           cargo +nightly fmt -- --check
+
   test:
     name: Run Tests
+    needs: changes
+    if: ${{ needs.changes.outputs.other == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
**Before:**

We used to run the `Lint Check` and `Run Tests` workflow for every PR. Which IMO is not needed and just consumes a lot of GH Action TIme

**Now:**

- The `Lint Check` job runs only if there are any changes to the code inside `/ui`
- The `Run Tests` job will run for all the other file changes inside the repo, but not for the ones inside `/ui` and `/docs`