### PR TITLE
use prefix for iteration

### DIFF
--- a/crates/indexify_internal_api/src/lib.rs
+++ b/crates/indexify_internal_api/src/lib.rs
@@ -503,7 +503,7 @@ fn default_creation_time() -> SystemTime {
 pub struct Task {
     pub id: String,
     pub extractor: String,
-    pub extraction_policy_id: String,
+    pub extraction_policy_name: String,
     pub extraction_graph_name: String,
     pub output_index_table_mapping: HashMap<String, String>,
     pub namespace: String,
@@ -527,7 +527,7 @@ impl Display for Task {
         write!(
             f,
             "Task(id: {}, extractor: {}, extraction_policy_id: {}, extraction_graph_name: {}, namespace: {}, content_id: {}, outcome: {:?})",
-            self.id, self.extractor, self.extraction_policy_id, self.extraction_graph_name, self.namespace, self.content_metadata.id.id, self.outcome
+            self.id, self.extractor, self.extraction_policy_name, self.extraction_graph_name, self.namespace, self.content_metadata.id.id, self.outcome
         )
     }
 }
@@ -543,7 +543,7 @@ impl TryFrom<Task> for indexify_coordinator::Task {
             namespace: value.namespace,
             content_metadata: Some(value.content_metadata.try_into()?),
             input_params: value.input_params.to_string(),
-            extraction_policy_id: value.extraction_policy_id,
+            extraction_policy_id: value.extraction_policy_name,
             extraction_graph_name: value.extraction_graph_name,
             output_index_mapping: value.output_index_table_mapping,
             outcome: outcome as i32,

--- a/crates/indexify_internal_api/src/lib.rs
+++ b/crates/indexify_internal_api/src/lib.rs
@@ -87,6 +87,34 @@ impl ExtractionGraphBuilder {
     }
 }
 
+#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ExtractionGraphAnalytics {
+    pub task_analytics: HashMap<String, TaskAnalytics>,
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub struct TaskAnalytics {
+    pub pending_tasks: u64,
+    pub successful_tasks: u64,
+    pub failed_tasks: u64,
+}
+
+impl TaskAnalytics {
+    pub fn pending(&mut self) {
+        self.pending_tasks += 1;
+    }
+
+    pub fn success(&mut self) {
+        self.successful_tasks += 1;
+        self.pending_tasks -= 1;
+    }
+
+    pub fn fail(&mut self) {
+        self.failed_tasks += 1;
+        self.pending_tasks -= 1;
+    }
+}
+
 #[derive(Debug, Clone, Serialize, PartialEq, Eq, Deserialize, Hash)]
 pub struct ExtractionGraphNode {
     pub namespace: String,

--- a/crates/indexify_internal_api/src/v1.rs
+++ b/crates/indexify_internal_api/src/v1.rs
@@ -133,7 +133,7 @@ impl From<Task> for super::Task {
             content_metadata: task.content_metadata.clone().into(),
             id: task.id,
             extractor: task.extractor,
-            extraction_policy_id: task.extraction_policy_id,
+            extraction_policy_name: task.extraction_policy_id,
             extraction_graph_name: task.extraction_graph_name,
             output_index_table_mapping: task.output_index_table_mapping,
             namespace: task.namespace,

--- a/crates/indexify_proto/src/indexify_coordinator.rs
+++ b/crates/indexify_proto/src/indexify_coordinator.rs
@@ -287,6 +287,33 @@ pub struct HeartbeatRequest {
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GetExtractionGraphAnalyticsRequest {
+    #[prost(string, tag = "1")]
+    pub namespace: ::prost::alloc::string::String,
+    #[prost(string, tag = "2")]
+    pub extraction_graph: ::prost::alloc::string::String,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct TaskAnalytics {
+    #[prost(uint64, tag = "1")]
+    pub pending: u64,
+    #[prost(uint64, tag = "2")]
+    pub success: u64,
+    #[prost(uint64, tag = "3")]
+    pub failure: u64,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct GetExtractionGraphAnalyticsResponse {
+    #[prost(map = "string, message", tag = "1")]
+    pub task_analytics: ::std::collections::HashMap<
+        ::prost::alloc::string::String,
+        TaskAnalytics,
+    >,
+}
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct HeartbeatResponse {
     #[prost(string, tag = "1")]
     pub executor_id: ::prost::alloc::string::String,
@@ -1681,6 +1708,36 @@ pub mod coordinator_service_client {
                 );
             self.inner.streaming(req, path, codec).await
         }
+        pub async fn get_extraction_graph_analytics(
+            &mut self,
+            request: impl tonic::IntoRequest<super::GetExtractionGraphAnalyticsRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::GetExtractionGraphAnalyticsResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::new(
+                        tonic::Code::Unknown,
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
+            let codec = tonic::codec::ProstCodec::default();
+            let path = http::uri::PathAndQuery::from_static(
+                "/indexify_coordinator.CoordinatorService/GetExtractionGraphAnalytics",
+            );
+            let mut req = request.into_request();
+            req.extensions_mut()
+                .insert(
+                    GrpcMethod::new(
+                        "indexify_coordinator.CoordinatorService",
+                        "GetExtractionGraphAnalytics",
+                    ),
+                );
+            self.inner.unary(req, path, codec).await
+        }
         pub async fn list_indexes(
             &mut self,
             request: impl tonic::IntoRequest<super::ListIndexesRequest>,
@@ -2459,6 +2516,13 @@ pub mod coordinator_service_server {
             &self,
             request: tonic::Request<tonic::Streaming<super::HeartbeatRequest>>,
         ) -> std::result::Result<tonic::Response<Self::HeartbeatStream>, tonic::Status>;
+        async fn get_extraction_graph_analytics(
+            &self,
+            request: tonic::Request<super::GetExtractionGraphAnalyticsRequest>,
+        ) -> std::result::Result<
+            tonic::Response<super::GetExtractionGraphAnalyticsResponse>,
+            tonic::Status,
+        >;
         async fn list_indexes(
             &self,
             request: tonic::Request<super::ListIndexesRequest>,
@@ -3609,6 +3673,61 @@ pub mod coordinator_service_server {
                                 max_encoding_message_size,
                             );
                         let res = grpc.streaming(method, req).await;
+                        Ok(res)
+                    };
+                    Box::pin(fut)
+                }
+                "/indexify_coordinator.CoordinatorService/GetExtractionGraphAnalytics" => {
+                    #[allow(non_camel_case_types)]
+                    struct GetExtractionGraphAnalyticsSvc<T: CoordinatorService>(
+                        pub Arc<T>,
+                    );
+                    impl<
+                        T: CoordinatorService,
+                    > tonic::server::UnaryService<
+                        super::GetExtractionGraphAnalyticsRequest,
+                    > for GetExtractionGraphAnalyticsSvc<T> {
+                        type Response = super::GetExtractionGraphAnalyticsResponse;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
+                        fn call(
+                            &mut self,
+                            request: tonic::Request<
+                                super::GetExtractionGraphAnalyticsRequest,
+                            >,
+                        ) -> Self::Future {
+                            let inner = Arc::clone(&self.0);
+                            let fut = async move {
+                                <T as CoordinatorService>::get_extraction_graph_analytics(
+                                        &inner,
+                                        request,
+                                    )
+                                    .await
+                            };
+                            Box::pin(fut)
+                        }
+                    }
+                    let accept_compression_encodings = self.accept_compression_encodings;
+                    let send_compression_encodings = self.send_compression_encodings;
+                    let max_decoding_message_size = self.max_decoding_message_size;
+                    let max_encoding_message_size = self.max_encoding_message_size;
+                    let inner = self.inner.clone();
+                    let fut = async move {
+                        let inner = inner.0;
+                        let method = GetExtractionGraphAnalyticsSvc(inner);
+                        let codec = tonic::codec::ProstCodec::default();
+                        let mut grpc = tonic::server::Grpc::new(codec)
+                            .apply_compression_config(
+                                accept_compression_encodings,
+                                send_compression_encodings,
+                            )
+                            .apply_max_message_size_config(
+                                max_decoding_message_size,
+                                max_encoding_message_size,
+                            );
+                        let res = grpc.unary(method, req).await;
                         Ok(res)
                     };
                     Box::pin(fut)

--- a/protos/coordinator_service.proto
+++ b/protos/coordinator_service.proto
@@ -42,6 +42,8 @@ service CoordinatorService {
 
     rpc Heartbeat(stream HeartbeatRequest) returns (stream HeartbeatResponse) {}
 
+    rpc GetExtractionGraphAnalytics(GetExtractionGraphAnalyticsRequest) returns (GetExtractionGraphAnalyticsResponse) {}
+
     rpc ListIndexes(ListIndexesRequest) returns (ListIndexesResponse) {}
 
     rpc GetIndex(GetIndexRequest) returns (GetIndexResponse) {}
@@ -287,6 +289,21 @@ message GCTask {
 message HeartbeatRequest {
     string executor_id = 1;
     int64 pending_tasks = 2;
+}
+
+message GetExtractionGraphAnalyticsRequest {
+    string namespace = 1;
+    string extraction_graph = 2;
+}
+
+message TaskAnalytics {
+    uint64 pending = 1;
+    uint64 success = 2;
+    uint64 failure = 3;
+}
+
+message GetExtractionGraphAnalyticsResponse {
+    map<string, TaskAnalytics> task_analytics = 1;
 }
 
 message HeartbeatResponse {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "1.79"

--- a/src/api.rs
+++ b/src/api.rs
@@ -770,6 +770,35 @@ pub struct ListTasks {
 }
 
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct TaskAnalytics {
+    pub pending: u64,
+    pub success: u64,
+    pub failure: u64,
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct ExtractionGraphAnalytics {
+    pub task_analytics: HashMap<String, TaskAnalytics>,
+}
+
+impl From<indexify_coordinator::GetExtractionGraphAnalyticsResponse> for ExtractionGraphAnalytics {
+    fn from(value: indexify_coordinator::GetExtractionGraphAnalyticsResponse) -> Self {
+        let mut task_analytics = HashMap::new();
+        for (k, v) in value.task_analytics.iter() {
+            task_analytics.insert(
+                k.clone(),
+                TaskAnalytics {
+                    pending: v.pending,
+                    success: v.success,
+                    failure: v.failure,
+                },
+            );
+        }
+        Self { task_analytics }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
 pub struct ListTasksResponse {
     pub tasks: Vec<Task>,
     pub total: u64,

--- a/src/coordinator.rs
+++ b/src/coordinator.rs
@@ -555,6 +555,16 @@ impl Coordinator {
         Ok(indexes_to_create)
     }
 
+    pub async fn get_graph_analytics(
+        &self,
+        namespace: &str,
+        graph_name: &str,
+    ) -> Result<Option<indexify_internal_api::ExtractionGraphAnalytics>> {
+        self.shared_state
+            .get_graph_analytics(namespace, graph_name)
+            .await
+    }
+
     pub async fn create_content_tree_tasks(
         &self,
         content_tree: Vec<internal_api::ContentMetadata>,

--- a/src/coordinator.rs
+++ b/src/coordinator.rs
@@ -1845,7 +1845,7 @@ mod tests {
             create_content_for_task(&coordinator, &all_tasks[0], &next_child(&mut child_id))
                 .await?;
         let policy =
-            coordinator.get_extraction_policy(all_tasks[0].extraction_policy_id.clone())?;
+            coordinator.get_extraction_policy(all_tasks[0].extraction_policy_name.clone())?;
         let prev_content = tree
             .iter()
             .find(|c| c.source == ContentSource::ExtractionPolicyName(policy.name.clone()))

--- a/src/coordinator_client.rs
+++ b/src/coordinator_client.rs
@@ -156,6 +156,25 @@ impl CoordinatorClient {
         Ok(response.into_inner().graphs)
     }
 
+    pub async fn get_extraction_graph_analytics(
+        &self,
+        namespace: &str,
+        extraction_graph_name: &str,
+    ) -> Result<indexify_coordinator::GetExtractionGraphAnalyticsResponse> {
+        let request = tonic::Request::new(
+            indexify_proto::indexify_coordinator::GetExtractionGraphAnalyticsRequest {
+                namespace: namespace.to_string(),
+                extraction_graph: extraction_graph_name.to_string(),
+            },
+        );
+        let response = self
+            .get()
+            .await?
+            .get_extraction_graph_analytics(request)
+            .await?;
+        Ok(response.into_inner())
+    }
+
     pub async fn get_raft_metrics_snapshot(
         &self,
     ) -> Result<Json<RaftMetricsSnapshotResponse>, IndexifyAPIError> {

--- a/src/coordinator_service.rs
+++ b/src/coordinator_service.rs
@@ -1121,7 +1121,7 @@ impl CoordinatorService for CoordinatorServiceServer {
         };
         let filter = |task: &Task| {
             task.namespace == req.namespace &&
-                (policy_id.is_empty() || task.extraction_policy_id == policy_id) &&
+                (policy_id.is_empty() || task.extraction_policy_name == policy_id) &&
                 (req.content_id.is_empty() || task.content_metadata.id.id == req.content_id) &&
                 outcome.matches(task.outcome)
         };

--- a/src/ingest_extracted_content.rs
+++ b/src/ingest_extracted_content.rs
@@ -451,7 +451,7 @@ mod tests {
         let mut task = Task {
             id: task_id.to_string(),
             extractor: "".to_string(),
-            extraction_policy_id: extraction_policy.id.to_string(),
+            extraction_policy_name: extraction_policy.id.to_string(),
             extraction_graph_name: extraction_policy.graph_name.clone(),
             output_index_table_mapping: HashMap::new(),
             namespace: content_metadata.namespace.clone(),

--- a/src/scheduler/mod.rs
+++ b/src/scheduler/mod.rs
@@ -222,7 +222,7 @@ impl Scheduler {
             id,
             extractor: extraction_policy.extractor.clone(),
             extraction_graph_name: extraction_policy.graph_name.clone(),
-            extraction_policy_id: extraction_policy.id.clone(),
+            extraction_policy_name: extraction_policy.id.clone(),
             output_index_table_mapping: output_mapping.clone(),
             namespace: extraction_policy.namespace.clone(),
             content_metadata: content.clone(),

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -1543,7 +1543,7 @@ mod tests {
             id: task_id.into(),
             namespace: content_metadata.namespace.clone(),
             extractor: "".to_string(),
-            extraction_policy_id: "".to_string(),
+            extraction_policy_name: "".to_string(),
             extraction_graph_name: "".to_string(),
             content_metadata: content_metadata.clone(),
             output_index_table_mapping: Default::default(),

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -759,6 +759,16 @@ impl App {
         Ok(())
     }
 
+    pub async fn get_graph_analytics(
+        &self,
+        namespace: &str,
+        graph_name: &str,
+    ) -> Result<Option<indexify_internal_api::ExtractionGraphAnalytics>> {
+        self.state_machine
+            .get_graph_analytics(namespace, graph_name)
+            .await
+    }
+
     pub fn extractor_with_name(
         &self,
         extractor: &str,

--- a/src/state/store/state_machine_objects.rs
+++ b/src/state/store/state_machine_objects.rs
@@ -842,7 +842,7 @@ impl IndexifyState {
                     db,
                     txn,
                     &task.content_metadata.id,
-                    &task.extraction_policy_id,
+                    &task.extraction_policy_name,
                     update_time,
                 )?;
             }
@@ -867,7 +867,7 @@ impl IndexifyState {
     ) -> Result<(), StateMachineError> {
         let key = format!(
             "{}_{}_{}",
-            new_task.namespace, new_task.extraction_graph_name, new_task.extraction_policy_id
+            new_task.namespace, new_task.extraction_graph_name, new_task.extraction_policy_name
         );
         let task_analytics = db
             .get_cf(StateMachineColumns::TaskAnalytics.cf(db), key.clone())

--- a/src/state/store/state_machine_objects.rs
+++ b/src/state/store/state_machine_objects.rs
@@ -878,9 +878,6 @@ impl IndexifyState {
                     .map_err(|e| StateMachineError::DatabaseError(e.to_string()))
             })
             .unwrap_or_else(|| Ok(TaskAnalytics::default()))?;
-        if prev_task.is_none() {
-            task_analytics.pending();
-        }
         match prev_task {
             Some(prev_task) => {
                 if !prev_task.terminal_state() && new_task.terminal_state() {

--- a/src/state/store/state_machine_objects.rs
+++ b/src/state/store/state_machine_objects.rs
@@ -12,6 +12,7 @@ use indexify_internal_api::{
     ContentOffset,
     ExtractionGraphNode,
     ServerTaskType,
+    TaskAnalytics,
 };
 use internal_api::{
     v1,
@@ -815,48 +816,28 @@ impl IndexifyState {
         Ok(())
     }
 
-    fn set_tasks(
-        &self,
-        db: &OptimisticTransactionDB,
-        txn: &rocksdb::Transaction<OptimisticTransactionDB>,
-        tasks: &Vec<Task>,
-    ) -> Result<(), StateMachineError> {
-        // content_id -> Set(Extraction Policy Ids)
-        for task in tasks {
-            let serialized_task = JsonEncoder::encode(task)?;
-            txn.put_cf(
-                StateMachineColumns::Tasks.cf(db),
-                task.id.clone(),
-                &serialized_task,
-            )
-            .map_err(|e| StateMachineError::DatabaseError(e.to_string()))?;
-            self.update_content_extraction_policy_state(
-                db,
-                txn,
-                &task.content_metadata.id,
-                &task.extraction_policy_id,
-                SystemTime::UNIX_EPOCH,
-            )?;
-        }
-        Ok(())
-    }
-
     fn update_tasks(
         &self,
         db: &OptimisticTransactionDB,
         txn: &rocksdb::Transaction<OptimisticTransactionDB>,
-        tasks: Vec<&Task>,
+        tasks: Vec<Task>,
         update_time: SystemTime,
     ) -> Result<(), StateMachineError> {
         for task in tasks {
-            let serialized_task = JsonEncoder::encode(task)?;
+            let serialized_task = JsonEncoder::encode(&task)?;
+            let prev_task: Option<Task> = get_from_cf(db, StateMachineColumns::Tasks, &task.id)
+                .map_err(|e| StateMachineError::DatabaseError(e.to_string()))?;
             txn.put_cf(
                 StateMachineColumns::Tasks.cf(db),
                 task.id.clone(),
                 &serialized_task,
             )
             .map_err(|e| StateMachineError::DatabaseError(e.to_string()))?;
-            if task.terminal_state() {
+
+            // Mark the completion time if the task is terminal
+            // If the task is newly created, we need to add an entry to the content metadata
+            // that a new task was created for that content.
+            if task.terminal_state() || update_time == SystemTime::UNIX_EPOCH {
                 self.update_content_extraction_policy_state(
                     db,
                     txn,
@@ -865,7 +846,63 @@ impl IndexifyState {
                     update_time,
                 )?;
             }
+
+            self.update_task_analytics(db, txn, prev_task, &task)
+                .map_err(|e| {
+                    StateMachineError::DatabaseError(format!(
+                        "Error updating task analytics for task {}: {}",
+                        task.id, e
+                    ))
+                })?;
         }
+        Ok(())
+    }
+
+    fn update_task_analytics(
+        &self,
+        db: &OptimisticTransactionDB,
+        txn: &rocksdb::Transaction<OptimisticTransactionDB>,
+        prev_task: Option<Task>,
+        new_task: &Task,
+    ) -> Result<(), StateMachineError> {
+        let key = format!(
+            "{}_{}_{}",
+            new_task.namespace, new_task.extraction_graph_name, new_task.extraction_policy_id
+        );
+        let task_analytics = db
+            .get_cf(StateMachineColumns::TaskAnalytics.cf(db), key.clone())
+            .map_err(|e| StateMachineError::DatabaseError(e.to_string()))?;
+        let mut task_analytics: TaskAnalytics = task_analytics
+            .map(|db_vec| {
+                JsonEncoder::decode(&db_vec)
+                    .map_err(|e| StateMachineError::DatabaseError(e.to_string()))
+            })
+            .unwrap_or_else(|| Ok(TaskAnalytics::default()))?;
+        if prev_task.is_none() {
+            task_analytics.pending();
+        }
+        match prev_task {
+            Some(prev_task) => {
+                if prev_task.terminal_state() && new_task.terminal_state() {
+                    if new_task.outcome == TaskOutcome::Success {
+                        task_analytics.success();
+                    } else {
+                        task_analytics.fail();
+                    }
+                }
+            }
+            None => {
+                task_analytics.pending();
+            }
+        }
+
+        let serialized_task_analytics = JsonEncoder::encode(&task_analytics)?;
+        txn.put_cf(
+            StateMachineColumns::TaskAnalytics.cf(db),
+            key,
+            &serialized_task_analytics,
+        )
+        .map_err(|e| StateMachineError::DatabaseError(e.to_string()))?;
         Ok(())
     }
 
@@ -1390,7 +1427,7 @@ impl IndexifyState {
                 }
             }
             RequestPayload::CreateTasks { tasks } => {
-                self.set_tasks(db, &txn, tasks)?;
+                self.update_tasks(db, &txn, tasks.clone(), SystemTime::UNIX_EPOCH)?;
                 for task in tasks {
                     self.inc_root_ref_count(task.content_metadata.get_root_id());
                 }
@@ -1442,7 +1479,7 @@ impl IndexifyState {
                 executor_id,
                 update_time,
             } => {
-                self.update_tasks(db, &txn, vec![task], *update_time)?;
+                self.update_tasks(db, &txn, vec![task.clone()], *update_time)?;
 
                 if task.terminal_state() {
                     self.metrics

--- a/src/state/store/state_machine_objects.rs
+++ b/src/state/store/state_machine_objects.rs
@@ -883,7 +883,7 @@ impl IndexifyState {
         }
         match prev_task {
             Some(prev_task) => {
-                if prev_task.terminal_state() && new_task.terminal_state() {
+                if !prev_task.terminal_state() && new_task.terminal_state() {
                     if new_task.outcome == TaskOutcome::Success {
                         task_analytics.success();
                     } else {

--- a/src/task_allocator/planner/load_aware_distributor.rs
+++ b/src/task_allocator/planner/load_aware_distributor.rs
@@ -317,7 +317,7 @@ mod tests {
             id: id.to_string(),
             extractor: extractor.to_string(),
             extraction_graph_name: extractor_graph_name.to_string(),
-            extraction_policy_id: policy.to_string(),
+            extraction_policy_name: policy.to_string(),
             output_index_table_mapping: HashMap::new(),
             namespace: "default".to_string(),
             content_metadata: content,

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -179,7 +179,7 @@ pub mod db_utils {
         task: &Task,
         id: &str,
     ) -> Result<internal_api::ContentMetadata, anyhow::Error> {
-        let policy = coordinator.get_extraction_policy(task.extraction_policy_id.clone())?;
+        let policy = coordinator.get_extraction_policy(task.extraction_policy_name.clone())?;
         let mut content =
             test_mock_content_metadata(id, task.content_metadata.get_root_id(), &policy.graph_name);
         content.parent_id = Some(task.content_metadata.id.clone());


### PR DESCRIPTION
* Use pre-fetch while iterating (Before - 3.25 seconds while working with a database of 100k rows, after: 18 milliseconds).
* Remove scanning the whole database for getting total count
* Create a reverse index for total tasks, content, etc. 