### PR TITLE
fix: postgres pod crashes and add initdb

### DIFF
--- a/operations/k8s/helm/local.yaml
+++ b/operations/k8s/helm/local.yaml
@@ -76,6 +76,7 @@ postgresql:
   image:
     repository: pgvector/pgvector
     tag: pg16
+    debug: true
   primary:
     containerSecurityContext:
       readOnlyRootFilesystem: false
@@ -84,4 +85,5 @@ postgresql:
         initdb.sh: |
           #!/bin/bash
           echo "Creating database indexify..."
+          export PGPASSWORD=indexify   
           psql -U postgres -c "CREATE DATABASE indexify;"

--- a/operations/k8s/helm/local.yaml
+++ b/operations/k8s/helm/local.yaml
@@ -68,15 +68,20 @@ minio:
 
 postgresql:
   enabled: true
-
   fullnameOverride: vector-store
-
   auth:
     enablePostgresUser: true
     postgresPassword: indexify
-
     database: indexify
-
   image:
-    repository: thomasr/pgvector
+    repository: pgvector/pgvector
     tag: pg16
+  primary:
+    containerSecurityContext:
+      readOnlyRootFilesystem: false
+    initdb:
+      scripts:
+        initdb.sh: |
+          #!/bin/bash
+          echo "Creating database indexify..."
+          psql -U postgres -c "CREATE DATABASE indexify;"


### PR DESCRIPTION
This avoid postgres pod to fail due to read-only file system and wrong image + add init script to create indexify database