### PR TITLE
add: video of pipeline

### DIFF
--- a/docs/docs/getting-started-basic.mdx
+++ b/docs/docs/getting-started-basic.mdx
@@ -33,6 +33,10 @@ Before we begin, make sure you have:
 
 ## Setup
 
+The following video shows the end-to-end pipeline
+
+![getting-started-basic](https://github.com/user-attachments/assets/c669e190-5803-4f30-831c-9ad7fe1185fd)
+
 You'll need three terminal windows open for this tutorial: one for downloading and running the Indexify Server, another for running Indexify extractors to handle structured extraction, chunking, and embedding, and a third for running Python scripts to load and query data from the Indexify server.
 
 ![Indexify-Terminals](https://github.com/user-attachments/assets/b1bb37cc-7d52-48b9-aa9b-f2c8e997203a)


### PR DESCRIPTION
Adding the video of the End-to-End pipeline

GIF exports from Arcade are of lower-quality

Any way to add videos directly?