### PR TITLE
backward compatibility for Task change

### DIFF
--- a/crates/indexify_internal_api/src/lib.rs
+++ b/crates/indexify_internal_api/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod utils;
 pub mod v1;
 pub mod v2;
+pub mod v3;
 use std::{
     collections::{hash_map::DefaultHasher, BTreeMap, HashMap, HashSet},
     fmt::{self, Display},

--- a/crates/indexify_internal_api/src/v1.rs
+++ b/crates/indexify_internal_api/src/v1.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, time::SystemTime};
+use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
 
@@ -125,24 +125,6 @@ pub struct Task {
     pub input_params: serde_json::Value,
     pub outcome: crate::TaskOutcome,
     pub index_tables: Vec<String>,
-}
-
-impl From<Task> for super::Task {
-    fn from(task: Task) -> Self {
-        super::Task {
-            content_metadata: task.content_metadata.clone().into(),
-            id: task.id,
-            extractor: task.extractor,
-            extraction_policy_name: task.extraction_policy_id,
-            extraction_graph_name: task.extraction_graph_name,
-            output_index_table_mapping: task.output_index_table_mapping,
-            namespace: task.namespace,
-            input_params: task.input_params,
-            outcome: task.outcome,
-            index_tables: task.index_tables,
-            creation_time: SystemTime::UNIX_EPOCH,
-        }
-    }
 }
 
 fn from_str_to_json(value: &str) -> serde_json::Value {

--- a/crates/indexify_internal_api/src/v2.rs
+++ b/crates/indexify_internal_api/src/v2.rs
@@ -1,9 +1,25 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, time::SystemTime};
 
 use derive_builder::Builder;
 use serde::{Deserialize, Serialize};
 
 use super::{ExtractionGraphId, ExtractionGraphName};
+
+#[derive(Serialize, Debug, Deserialize, Clone, PartialEq)]
+pub struct Task {
+    pub id: String,
+    pub extractor: String,
+    pub extraction_policy_id: String,
+    pub extraction_graph_name: String,
+    pub output_index_table_mapping: HashMap<String, String>,
+    pub namespace: String,
+    pub content_metadata: super::ContentMetadata,
+    pub input_params: serde_json::Value,
+    pub outcome: super::TaskOutcome,
+    pub index_tables: Vec<String>, // list of index tables that this content may be present in
+    #[serde(default = "super::default_creation_time")]
+    pub creation_time: SystemTime,
+}
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq, Deserialize, Default)]
 pub struct ExtractionPolicy {

--- a/crates/indexify_internal_api/src/v3.rs
+++ b/crates/indexify_internal_api/src/v3.rs
@@ -1,0 +1,1 @@
+pub use super::v2::Task;

--- a/src/caching/caches_extension.rs
+++ b/src/caching/caches_extension.rs
@@ -19,6 +19,7 @@ pub struct ExtractContentCacheKey {
 }
 pub type CacheTS<K, V> = Arc<RwLock<Box<dyn Cache<K, V>>>>;
 
+#[allow(dead_code)]
 #[derive(Clone)]
 pub struct Caches {
     pub cache_extract_content: Arc<RwLock<Box<dyn Cache<ExtractContentCacheKey, ExtractResponse>>>>,

--- a/src/caching/traits.rs
+++ b/src/caching/traits.rs
@@ -4,6 +4,7 @@ use serde::{de::DeserializeOwned, Serialize};
 
 use super::prelude::IndexifyCachingError;
 
+#[allow(dead_code)]
 #[async_trait]
 pub trait Cache<K, V>: Send + Sync
 where

--- a/src/state/store/compat/convert_v1.rs
+++ b/src/state/store/compat/convert_v1.rs
@@ -1,0 +1,35 @@
+use anyhow::anyhow;
+use indexify_internal_api::{v1, *};
+use rocksdb::OptimisticTransactionDB;
+
+use crate::state::store::{
+    serializer::{JsonEncode, JsonEncoder},
+    StateMachineColumns,
+};
+
+pub fn convert_v1_task(
+    task: v1::Task,
+    db: &OptimisticTransactionDB,
+) -> Result<Task, anyhow::Error> {
+    let policy = db
+        .get_cf(
+            StateMachineColumns::ExtractionPolicies.cf(db),
+            &task.extraction_policy_id,
+        )?
+        .ok_or_else(|| anyhow!("Extraction policy not found"))?;
+    let policy: ExtractionPolicy =
+        JsonEncoder::decode(&policy).map_err(|e| anyhow!("Failed to decode policy: {:?}", e))?;
+    Ok(Task {
+        id: task.id,
+        extractor: task.extractor,
+        extraction_policy_name: policy.name,
+        extraction_graph_name: task.extraction_graph_name,
+        output_index_table_mapping: task.output_index_table_mapping,
+        namespace: task.namespace,
+        content_metadata: task.content_metadata.into(),
+        input_params: task.input_params,
+        outcome: task.outcome,
+        index_tables: task.index_tables,
+        creation_time: std::time::UNIX_EPOCH,
+    })
+}

--- a/src/state/store/compat/convert_v2.rs
+++ b/src/state/store/compat/convert_v2.rs
@@ -1,16 +1,13 @@
-use std::fmt::Debug;
-
 use anyhow::anyhow;
 use indexify_internal_api::{v2, ExtractionGraph, ExtractionPolicy};
 use openraft::{StorageError, StorageIOError};
-use rocksdb::{ColumnFamily, IteratorMode, OptimisticTransactionDB};
-use serde::de::DeserializeOwned;
+use rocksdb::OptimisticTransactionDB;
 use tracing::info;
 
-use super::v2 as req_v2;
+use super::{convert_column, v2 as req_v2};
 use crate::state::{
     store::{
-        serializer::{JsonEncode, JsonEncoder},
+        compat::init_task_analytics,
         StateMachineColumns,
         CURRENT_STORE_VERSION,
         LOG_STORE_LOGS_COLUMN,
@@ -18,29 +15,6 @@ use crate::state::{
     },
     NodeId,
 };
-
-// This assumes that key value does not change with conversion.
-fn convert_column<T, U>(
-    db: &OptimisticTransactionDB,
-    cf: &ColumnFamily,
-    convert: impl Fn(T) -> U,
-) -> Result<(), StorageError<NodeId>>
-where
-    T: DeserializeOwned,
-    U: serde::Serialize + Debug,
-{
-    for val in db.iterator_cf(cf, IteratorMode::Start) {
-        let (key, value) = val.map_err(|e| StorageIOError::read_state_machine(&e))?;
-        let value: T =
-            JsonEncoder::decode(&value).map_err(|e| StorageIOError::read_state_machine(&e))?;
-        let value: U = convert(value);
-        let value =
-            &JsonEncoder::encode(&value).map_err(|e| StorageIOError::read_state_machine(&e))?;
-        db.put_cf(cf, &key, value)
-            .map_err(|e| StorageIOError::read_state_machine(&e))?;
-    }
-    Ok(())
-}
 
 // TODO: handle crashes during conversion
 pub fn convert_v2(
@@ -51,19 +25,32 @@ pub fn convert_v2(
     convert_column(
         db,
         StateMachineColumns::ExtractionGraphs.cf(db),
-        |graph: v2::ExtractionGraph| -> ExtractionGraph { graph.into() },
+        |graph: v2::ExtractionGraph| -> Result<ExtractionGraph, _> { Ok(graph.into()) },
     )?;
     convert_column(
         db,
         StateMachineColumns::ExtractionPolicies.cf(db),
-        |policy: v2::ExtractionPolicy| -> ExtractionPolicy { policy.into() },
+        |policy: v2::ExtractionPolicy| -> Result<ExtractionPolicy, _> { Ok(policy.into()) },
+    )?;
+    convert_column(
+        db,
+        StateMachineColumns::Tasks.cf(db),
+        |task: v2::Task| -> Result<_, _> {
+            req_v2::convert_v2_task(task, db).map_err(|e| StorageError::IO {
+                source: StorageIOError::read_state_machine(e),
+            })
+        },
     )?;
 
     let cf = log_db
         .cf_handle(LOG_STORE_LOGS_COLUMN)
         .ok_or_else(|| StorageIOError::read_state_machine(anyhow!("log_db logs cf not found")))?;
 
-    convert_column(log_db, cf, req_v2::convert_log_entry)?;
+    convert_column(log_db, cf, |e| {
+        req_v2::convert_log_entry(e, db).map_err(|e| StorageError::IO {
+            source: StorageIOError::read_state_machine(e),
+        })
+    })?;
 
     db.put_cf(
         StateMachineColumns::RaftState.cf(db),
@@ -71,6 +58,8 @@ pub fn convert_v2(
         CURRENT_STORE_VERSION.to_be_bytes(),
     )
     .map_err(|e| StorageIOError::read_state_machine(&e))?;
+
+    init_task_analytics(db)?;
 
     Ok(())
 }

--- a/src/state/store/compat/convert_v3.rs
+++ b/src/state/store/compat/convert_v3.rs
@@ -1,0 +1,45 @@
+use anyhow::anyhow;
+use indexify_internal_api::v3;
+use openraft::{StorageError, StorageIOError};
+use rocksdb::OptimisticTransactionDB;
+use tracing::info;
+
+use super::{convert_column, convert_v2_task, init_task_analytics, v3 as req_v3};
+use crate::state::{
+    store::{StateMachineColumns, CURRENT_STORE_VERSION, LOG_STORE_LOGS_COLUMN, STORE_VERSION},
+    NodeId,
+};
+
+pub fn convert_v3(
+    db: &OptimisticTransactionDB,
+    log_db: &OptimisticTransactionDB,
+) -> Result<(), StorageError<NodeId>> {
+    info!("Converting store to v{} from v3", CURRENT_STORE_VERSION);
+
+    convert_column(db, StateMachineColumns::Tasks.cf(db), |task: v3::Task| {
+        Ok(convert_v2_task(task, db).map_err(|e| StorageError::IO {
+            source: StorageIOError::read_state_machine(e),
+        })?)
+    })?;
+
+    let cf = log_db
+        .cf_handle(LOG_STORE_LOGS_COLUMN)
+        .ok_or_else(|| StorageIOError::read_state_machine(anyhow!("log_db logs cf not found")))?;
+
+    convert_column(log_db, cf, |e| {
+        req_v3::convert_log_entry(e, db).map_err(|e| StorageError::IO {
+            source: StorageIOError::read_state_machine(e),
+        })
+    })?;
+
+    db.put_cf(
+        StateMachineColumns::RaftState.cf(db),
+        STORE_VERSION,
+        CURRENT_STORE_VERSION.to_be_bytes(),
+    )
+    .map_err(|e| StorageIOError::read_state_machine(&e))?;
+
+    init_task_analytics(db)?;
+
+    Ok(())
+}

--- a/src/state/store/compat/mod.rs
+++ b/src/state/store/compat/mod.rs
@@ -1,4 +1,79 @@
-mod convert_v2;
-mod v2;
+use std::fmt::Debug;
 
+use openraft::{StorageError, StorageIOError};
+use rocksdb::{ColumnFamily, IteratorMode, OptimisticTransactionDB};
+use serde::de::DeserializeOwned;
+
+use super::{JsonEncode, JsonEncoder};
+use crate::state::{NodeId, StateMachineColumns};
+
+mod convert_v1;
+mod convert_v2;
+mod convert_v3;
+mod v2;
+mod v3;
+
+pub use convert_v1::convert_v1_task;
 pub use convert_v2::convert_v2;
+pub use convert_v3::convert_v3;
+use indexify_internal_api::{Task, TaskAnalytics, TaskOutcome};
+pub(crate) use v2::convert_v2_task;
+
+// This assumes that key value does not change with conversion.
+fn convert_column<T, U>(
+    db: &OptimisticTransactionDB,
+    cf: &ColumnFamily,
+    convert: impl Fn(T) -> Result<U, StorageError<NodeId>>,
+) -> Result<(), StorageError<NodeId>>
+where
+    T: DeserializeOwned,
+    U: serde::Serialize + Debug,
+{
+    for val in db.iterator_cf(cf, IteratorMode::Start) {
+        let (key, value) = val.map_err(|e| StorageIOError::read_state_machine(&e))?;
+        let value: T =
+            JsonEncoder::decode(&value).map_err(|e| StorageIOError::read_state_machine(&e))?;
+        let value: U = convert(value)?;
+        let value =
+            &JsonEncoder::encode(&value).map_err(|e| StorageIOError::read_state_machine(&e))?;
+        db.put_cf(cf, &key, value)
+            .map_err(|e| StorageIOError::read_state_machine(&e))?;
+    }
+    Ok(())
+}
+
+pub fn init_task_analytics(db: &OptimisticTransactionDB) -> Result<(), StorageError<NodeId>> {
+    let iter = db.iterator_cf(StateMachineColumns::Tasks.cf(db), IteratorMode::Start);
+    for val in iter {
+        let (_, value) = val.map_err(|e| StorageIOError::read_state_machine(&e))?;
+        let task: Task =
+            JsonEncoder::decode(&value).map_err(|e| StorageIOError::read_state_machine(&e))?;
+        let key = format!(
+            "{}_{}_{}",
+            task.namespace, task.extraction_graph_name, task.extraction_policy_name
+        );
+        let task_analytics = db
+            .get_cf(StateMachineColumns::TaskAnalytics.cf(db), key.clone())
+            .map_err(|e| StorageIOError::read_state_machine(&e))?;
+        let mut task_analytics: TaskAnalytics = task_analytics
+            .map(|db_vec| {
+                JsonEncoder::decode(&db_vec).map_err(|e| StorageIOError::read_state_machine(&e))
+            })
+            .unwrap_or_else(|| Ok(TaskAnalytics::default()))?;
+        match task.outcome {
+            TaskOutcome::Success => task_analytics.success(),
+            TaskOutcome::Failed => task_analytics.fail(),
+            TaskOutcome::Unknown => task_analytics.pending(),
+        }
+        let serialized_task_analytics = JsonEncoder::encode(&task_analytics)
+            .map_err(|e| StorageIOError::write_state_machine(&e))?;
+        db.put_cf(
+            StateMachineColumns::TaskAnalytics.cf(db),
+            key,
+            &serialized_task_analytics,
+        )
+        .map_err(|e| StorageIOError::write_state_machine(&e))?;
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
Fix backward compatibility for the change in Task structure. Convert policy id to policy name on startup. Initialize task counters to match existing tasks.