### PR TITLE
sending extracted features to coordinator

### DIFF
--- a/crates/indexify_internal_api/src/lib.rs
+++ b/crates/indexify_internal_api/src/lib.rs
@@ -1002,6 +1002,9 @@ pub struct ContentMetadata {
     /// monotonically increasing change id
     #[serde(default)]
     pub change_offset: ContentOffset,
+
+    #[serde(default)]
+    pub extracted_metadata: serde_json::Value,
 }
 
 impl ContentMetadata {
@@ -1051,6 +1054,7 @@ impl TryFrom<ContentMetadata> for indexify_coordinator::ContentMetadata {
             hash: value.hash,
             extraction_policy_ids: value.extraction_policy_ids,
             extraction_graph_names: value.extraction_graph_names,
+            extracted_metadata: value.extracted_metadata.to_string(),
         })
     }
 }
@@ -1092,6 +1096,7 @@ impl TryFrom<indexify_coordinator::ContentMetadata> for ContentMetadata {
             extraction_policy_ids: value.extraction_policy_ids,
             extraction_graph_names: value.extraction_graph_names,
             change_offset: ContentOffset(0),
+            extracted_metadata: serde_json::from_str(&value.extracted_metadata)?,
         })
     }
 }
@@ -1123,6 +1128,7 @@ impl Default for ContentMetadata {
             hash: "test_hash".to_string(),
             extraction_graph_names: vec![],
             change_offset: ContentOffset(0),
+            extracted_metadata: serde_json::Value::Null,
         }
     }
 }

--- a/crates/indexify_internal_api/src/v1.rs
+++ b/crates/indexify_internal_api/src/v1.rs
@@ -83,6 +83,7 @@ pub struct ContentMetadata {
     pub hash: String,
     pub extraction_policy_ids: HashMap<super::ExtractionPolicyId, u64>,
     pub extraction_graph_names: Vec<super::ExtractionGraphName>,
+    pub extracted_metadata: serde_json::Value,
 }
 
 impl From<ContentMetadata> for super::ContentMetadata {
@@ -109,6 +110,7 @@ impl From<ContentMetadata> for super::ContentMetadata {
             hash: metadata.hash,
             content_type: metadata.content_type,
             change_offset: super::ContentOffset(0),
+            extracted_metadata: metadata.extracted_metadata,
         }
     }
 }

--- a/crates/indexify_proto/src/indexify_coordinator.rs
+++ b/crates/indexify_proto/src/indexify_coordinator.rs
@@ -618,6 +618,8 @@ pub struct ContentMetadata {
     pub root_content_id: ::prost::alloc::string::String,
     #[prost(string, repeated, tag = "14")]
     pub extraction_graph_names: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+    #[prost(string, tag = "15")]
+    pub extracted_metadata: ::prost::alloc::string::String,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]

--- a/protos/coordinator_service.proto
+++ b/protos/coordinator_service.proto
@@ -464,6 +464,7 @@ message ContentMetadata {
     map<string, uint64> extraction_policy_ids = 12;
     string root_content_id = 13;
     repeated string extraction_graph_names = 14;
+    string extracted_metadata = 15;
 }
 
 message ContentStreamItem {

--- a/src/api.rs
+++ b/src/api.rs
@@ -478,6 +478,7 @@ pub struct ContentMetadata {
     pub source: String,
     pub size: u64,
     pub hash: String,
+    pub extracted_metadata: serde_json::Value,
 }
 
 impl TryFrom<indexify_coordinator::ContentMetadata> for ContentMetadata {
@@ -500,6 +501,7 @@ impl TryFrom<indexify_coordinator::ContentMetadata> for ContentMetadata {
             size: value.size_bytes,
             hash: value.hash,
             extraction_graph_names: value.extraction_graph_names,
+            extracted_metadata: serde_json::from_str(&value.extracted_metadata)?,
         })
     }
 }
@@ -520,6 +522,7 @@ impl From<indexify_internal_api::ContentMetadata> for ContentMetadata {
             size: value.size_bytes,
             hash: value.hash,
             extraction_graph_names: value.extraction_graph_names,
+            extracted_metadata: value.extracted_metadata,
         }
     }
 }

--- a/src/data_manager.rs
+++ b/src/data_manager.rs
@@ -15,6 +15,7 @@ use indexify_internal_api::{self as internal_api};
 use indexify_proto::indexify_coordinator::{self, CreateContentStatus, ListActiveContentsRequest};
 use mime::Mime;
 use nanoid::nanoid;
+use serde_json::json;
 use sha2::{Digest, Sha256};
 use tracing::{error, info};
 
@@ -476,6 +477,7 @@ impl DataManager {
             extraction_policy_ids: HashMap::new(),
             root_content_id: "".to_string(),
             extraction_graph_names: extraction_graph_names.clone(),
+            extracted_metadata: "null".to_string(),
         };
         let req: indexify_coordinator::CreateContentRequest =
             indexify_coordinator::CreateContentRequest {
@@ -677,6 +679,7 @@ impl DataManager {
             hash: content_hash,
             extraction_policy_ids: HashMap::new(),
             extraction_graph_names: extraction_graph_names.to_vec(),
+            extracted_metadata: json!({}).to_string(),
         })
     }
 

--- a/src/ingest_extracted_content.rs
+++ b/src/ingest_extracted_content.rs
@@ -174,6 +174,12 @@ impl ContentStateWriting {
                     .root_content_metadata
                     .clone()
                     .unwrap_or(self.task.content_metadata.clone().unwrap().try_into()?);
+                let mut extracted_metadata = serde_json::json!({});
+                for feature in &payload.features {
+                    if let FeatureType::Metadata = feature.feature_type {
+                        extracted_metadata[&feature.name] = feature.data.clone();
+                    }
+                }
                 let content_metadata = indexify_coordinator::ContentMetadata {
                     id: id.clone(),
                     file_name: frame_state.file_name.clone(),
@@ -189,6 +195,7 @@ impl ContentStateWriting {
                     hash: content_hash,
                     extraction_policy_ids: HashMap::new(),
                     extraction_graph_names: vec![self.extraction_policy.graph_name.clone()],
+                    extracted_metadata: serde_json::to_string(&extracted_metadata)?,
                 };
                 state
                     .data_manager


### PR DESCRIPTION
* Metadata features from extracted content are now saved in the coordinator to enable the following use cases - 
    * Show where some text in a document came from 
    * In the future enable the scheduler to dynamically filter on extracted data. Ex - classify an image, and add that as metadata, second stage could be embedding and adding things into indexes based on that 