### PR TITLE
send new tasks to executor without waiting for heartbeat

### DIFF
--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -611,7 +611,7 @@ pub mod coordinator {
                             .unwrap();
                         for (executor_id, tasks) in counts.iter() {
                             observer.observe(
-                                tasks.len() as u64,
+                                tasks.tasks.len() as u64,
                                 &[KeyValue::new("executor_id", executor_id.to_string())],
                             );
                         }

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -622,6 +622,18 @@ impl App {
         self.state_machine.get_executor_running_task_count().await
     }
 
+    pub async fn subscribe_to_new_tasks(&self, executor_id: &str) -> broadcast::Receiver<()> {
+        self.state_machine
+            .data
+            .indexify_state
+            .unfinished_tasks_by_executor
+            .write()
+            .unwrap()
+            .entry(executor_id.to_string())
+            .or_default()
+            .subscribe()
+    }
+
     pub async fn unfinished_tasks_by_extractor(
         &self,
         extractor: &str,


### PR DESCRIPTION
Send tasks to executor whenever a new task is added or executor completes a task.