### PR TITLE
Feat: coordinator ha

### DIFF
--- a/operations/k8s/helm/Chart.yaml
+++ b/operations/k8s/helm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: helm
 description: Indexify
 type: application
-version: 0.1.0
+version: 0.1.1
 
 dependencies:
   - name: minio

--- a/operations/k8s/helm/local.yaml
+++ b/operations/k8s/helm/local.yaml
@@ -27,7 +27,9 @@ api:
   image: tensorlake/indexify:latest
 
 coordinator:
+  enabled: true
   image: tensorlake/indexify:latest
+  replicas: 2
 
 extractors:
   - image: tensorlake/chunk-extractor:latest

--- a/operations/k8s/helm/templates/_helpers.tpl
+++ b/operations/k8s/helm/templates/_helpers.tpl
@@ -32,3 +32,6 @@ app.kubernetes.io/managed-by: {{ .global.Release.Service }}
 {{- end }}
 {{- end }}
 {{- end }}
+{{- define "coordinator.fullname" -}}
+coordinator
+{{- end -}}

--- a/operations/k8s/helm/templates/api-config.yaml
+++ b/operations/k8s/helm/templates/api-config.yaml
@@ -1,3 +1,4 @@
+{{- $statefulsetName := .Values.coordinator.name }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -7,9 +8,9 @@ metadata:
     {{- include "labels" (dict "name" "indexify" "component" "config" "global" $) | nindent 4 }}
 data:
   config.yaml: |-
-    coordinator_addr: coordinator:8950
+    coordinator_addr: {{ $statefulsetName }}-0.{{ $statefulsetName }}.{{ $.Release.Namespace }}.svc.cluster.local:8950
     raft_port: 8970
-    seed_node: localhost:8970
+    seed_node: {{ $statefulsetName }}-0.{{ $statefulsetName }}.{{ $.Release.Namespace }}.svc.cluster.local:8970
     node_id: 0
 
     state_store:

--- a/operations/k8s/helm/templates/api-config.yaml
+++ b/operations/k8s/helm/templates/api-config.yaml
@@ -8,7 +8,7 @@ metadata:
     {{- include "labels" (dict "name" "indexify" "component" "config" "global" $) | nindent 4 }}
 data:
   config.yaml: |-
-    coordinator_addr: {{ $statefulsetName }}-0.{{ $statefulsetName }}.{{ $.Release.Namespace }}.svc.cluster.local:8950
+    coordinator_addr: coordinator:8950
     raft_port: 8970
     seed_node: {{ $statefulsetName }}-0.{{ $statefulsetName }}.{{ $.Release.Namespace }}.svc.cluster.local:8970
     node_id: 0

--- a/operations/k8s/helm/templates/coordinator.yaml
+++ b/operations/k8s/helm/templates/coordinator.yaml
@@ -1,56 +1,89 @@
 {{- with .Values.coordinator }}
 {{- if .enabled }}
+{{- $statefulsetName := .name }}
+{{- $replicaCount := .replicas | int }}
+{{- range $i, $e := until $replicaCount }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $statefulsetName }}-config-{{ $i }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    {{- include "labels" (dict "name" $statefulsetName "component" "config" "global" $) | nindent 4 }}
+data:
+  config.yaml: |-
+    coordinator_addr: {{ $statefulsetName }}-0.{{ $statefulsetName }}.{{ $.Release.Namespace }}.svc.cluster.local:8950
+    raft_port: 8970
+    seed_node: {{ $statefulsetName }}-0.{{ $statefulsetName }}.{{ $.Release.Namespace }}.svc.cluster.local:8970
+    node_id: {{ $i }}
+    state_store:
+      path: /data/state
+    db_url: {{ $.Values.dbURL }}
+    index_config:
+      {{- $.Values.indexConfig| toYaml | nindent 6 }}
+    metadata_storage:
+      {{- $.Values.metadataStorage | toYaml | nindent 6 }}
+    blob_storage:
+      {{- $.Values.blobStore.config | toYaml | nindent 6 }}
+{{- end }}
 ---
 apiVersion: v1
 kind: Service
 metadata:
   name: coordinator
 spec:
+  clusterIP: None
   ports:
     - port: 8950
+      name: coordinator
+      targetPort: 8950
+    - port: 8970
+      name: seed
+      targetPort: 8970
   selector:
-    {{- include "labels" (dict "name" "coordinator" "component" "coordinator" "global" $) | nindent 4 }}
+    app: coordinator
 ---
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
-  name: coordinator
+  name: {{ .name }}
   labels:
-    {{- include "labels" (dict "name" "coordinator" "component" "coordinator" "global" $) | nindent 4 }}
+    {{- include "labels" (dict "name" .name "component" "coordinator" "global" $) | nindent 4 }}
 spec:
-  replicas: 1
+  serviceName: {{ .name }}
+  replicas: {{ .replicas }}
   selector:
     matchLabels:
-    {{- include "labels" (dict "name" "coordinator" "component" "coordinator" "global" $) | nindent 6 }}
+      app: {{ .name }}
   template:
     metadata:
       labels:
-        {{- include "labels" (dict "name" "coordinator" "component" "coordinator" "global" $) | nindent 8 }}
-
+        app: {{ .name }}
     spec:
       containers:
         - name: indexify
           image: {{ .image }}
-
           command: ['indexify']
           args:
             - coordinator
             - --config-path
-            - ./config/config.yaml
-
+            - /etc/coordinator/config.yaml
           volumeMounts:
-            - mountPath: /indexify/config
-              name: config
+            {{- range $i, $e := until $replicaCount }}
+            - mountPath: /etc/coordinator
+              name: config-{{ $i }}
               readOnly: true
+            {{- end }}
             - mountPath: /data
               name: data
-
       volumes:
-        - name: config
+        {{- range $i, $e := until $replicaCount }}
+        - name: config-{{ $i }}
           configMap:
-            name: indexify
+            name: {{ $statefulsetName }}-config-{{ $i }}
+        {{- end }}
         - name: data
           emptyDir: {}
-
 {{- end }}
 {{- end }}

--- a/operations/k8s/helm/templates/coordinator.yaml
+++ b/operations/k8s/helm/templates/coordinator.yaml
@@ -1,6 +1,6 @@
 {{- with .Values.coordinator }}
 {{- if .enabled }}
-{{- $statefulsetName := .name }}
+{{- $statefulsetName := include "coordinator.fullname" . }}
 {{- $replicaCount := .replicas | int }}
 {{- range $i, $e := until $replicaCount }}
 ---
@@ -47,19 +47,19 @@ spec:
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: {{ .name }}
+  name: {{ include "coordinator.fullname" . }}
   labels:
-    {{- include "labels" (dict "name" .name "component" "coordinator" "global" $) | nindent 4 }}
+    {{- include "labels" (dict "name" "coordinator" "component" "coordinator" "global" $) | nindent 4 }}
 spec:
-  serviceName: {{ .name }}
+  serviceName: {{ include "coordinator.fullname" . }}
   replicas: {{ .replicas }}
   selector:
     matchLabels:
-      app: {{ .name }}
+      app: {{ include "coordinator.fullname" . }}
   template:
     metadata:
       labels:
-        app: {{ .name }}
+        app: {{ include "coordinator.fullname" . }}
     spec:
       containers:
         - name: indexify

--- a/operations/k8s/helm/templates/coordinator.yaml
+++ b/operations/k8s/helm/templates/coordinator.yaml
@@ -68,10 +68,15 @@ spec:
           args:
             - coordinator
             - --config-path
-            - /etc/coordinator/config.yaml
+            - /etc/$(POD_NAME)/config.yaml
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
           volumeMounts:
             {{- range $i, $e := until $replicaCount }}
-            - mountPath: /etc/coordinator
+            - mountPath: /etc/coordinator-{{ $i }}
               name: config-{{ $i }}
               readOnly: true
             {{- end }}

--- a/operations/k8s/helm/values.yaml
+++ b/operations/k8s/helm/values.yaml
@@ -35,7 +35,7 @@ coordinator:
 
   # The default number of replicas is 1.
   # To enable High Availability (HA), increase the number of replicas.
-  replicas: 1  # Change this value to 2 or more for HA
+  replicas: 2  # Change this value to 2 or more for HA
 
 extractors:
   # - image: tensorlake/chunker:latest

--- a/operations/k8s/helm/values.yaml
+++ b/operations/k8s/helm/values.yaml
@@ -35,7 +35,7 @@ coordinator:
 
   # The default number of replicas is 1.
   # To enable High Availability (HA), increase the number of replicas.
-  replicas: 2  # Change this value to 2 or more for HA
+  replicas: 1  # Change this value to 2 or more for HA
 
 extractors:
   # - image: tensorlake/chunker:latest

--- a/operations/k8s/helm/values.yaml
+++ b/operations/k8s/helm/values.yaml
@@ -30,7 +30,6 @@ api:
 
 coordinator:
   enabled: true
-  name: coordinator
   image: tensorlake/indexify:stable
 
   # The default number of replicas is 1.

--- a/operations/k8s/helm/values.yaml
+++ b/operations/k8s/helm/values.yaml
@@ -30,8 +30,12 @@ api:
 
 coordinator:
   enabled: true
-
+  name: coordinator
   image: tensorlake/indexify:stable
+
+  # The default number of replicas is 1.
+  # To enable High Availability (HA), increase the number of replicas.
+  replicas: 1  # Change this value to 2 or more for HA
 
 extractors:
   # - image: tensorlake/chunker:latest


### PR DESCRIPTION
### Enable High Availability (HA) in Kubernetes for Coordinator

This PR introduces changes to enable High Availability (HA) in Kubernetes by leveraging StatefulSets and headless services. The key goal is to allow identification of individual replicas and ensure each replica has its own service, which can be achieved by replacing the existing Deployment with a StatefulSet.

#### Key Changes:
- **Convert Deployment to StatefulSet**: The Kubernetes Deployment for the coordinator has been converted to a StatefulSet to support stable network identities.
- **Dynamic ConfigMap Generation**: ConfigMaps are dynamically generated to assign unique `node_id`s to each replica. The first replica (`coordinator-0`) is designated as the `seed_node`.
- **StatefulSet ConfigMap Mounting**: The StatefulSet dynamically mounts the corresponding ConfigMap for each replica, ensuring that each pod has its own configuration.
- **Headless Service**: The Service is now configured as a headless service (`clusterIP: None`), allowing direct communication with individual pods.
- **Service Selector**: The Service selector has been updated to match the `app:` label, ensuring proper routing to the correct pods.

### Local Testing

The changes were tested on a local Kubernetes cluster with the following results:

- **Coordinator StatefulSet**: The StatefulSet for the coordinator successfully deployed multiple replicas. The logs confirm that the coordinator pods are running and coordinating as expected.

```bash
➜  TENSORLAKE_WORKSPACE kubectl get pods -n indexify -l app=coordinator
NAME            READY   STATUS    RESTARTS   AGE
coordinator-0   1/1     Running   0          18m
coordinator-1   1/1     Running   0          18m
```

- **API Deployment**: The API deployment was also confirmed to be running successfully.

```bash
➜  TENSORLAKE_WORKSPACE kubectl get pods -n indexify -l app.kubernetes.io/component=api
NAME                   READY   STATUS    RESTARTS   AGE
api-6f7d65c588-8q4dd   1/1     Running   0          17m
```

- **Coordinator Logs**: The logs from the `coordinator` StatefulSet show that the coordinator service is running and the leader has been established.

```bash
➜  TENSORLAKE_WORKSPACE kubectl logs statefulset/coordinator -n indexify
Found 2 pods, using pod/coordinator-1
Running with tracing filter info
2024-08-18T22:08:45.246398Z  INFO indexify::cmd::coordinator: starting indexify coordinator, version: git branch: main - sha:2608f783cc6f10e9d0e725bd4e0289781252b4f1
...
2024-08-18T22:08:45.401516Z  INFO indexify::coordinator_service: leader change detected: true
```

```bash
root@coordinator-0:/indexify# grep seed /etc/coordinator/config.yaml
seed_node: coordinator-0.coordinator.indexify.svc.cluster.local:8970
```
```bash
root@coordinator-1:/indexify# grep seed /etc/coordinator/config.yaml
seed_node: coordinator-0.coordinator.indexify.svc.cluster.local:8970
```

- **API Logs**: The logs from the `api` deployment indicate that the API server is running and successfully connecting to the coordinator service.

```bash
➜  TENSORLAKE_WORKSPACE kubectl logs deployment/api -n indexify 
Running with tracing filter info
2024-08-18T22:10:20.449254Z  INFO indexify::cmd::server: starting indexify server, version: git branch: main - sha:2608f783cc6f10e9d0e725bd4e0289781252b4f1
...
2024-08-18T22:10:20.453345Z  INFO indexify::coordinator_client: connecting without TLS to coordinator service, address: coordinator:8950
```

**NOTE:** This was deployed with a new helm release, I removed the one that was using deployment and static configmpa.

