### PR TITLE
feat(coordinator): improve HA behavior

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -590,7 +590,7 @@ dependencies = [
  "futures-core",
  "futures-io",
  "futures-lite 1.13.0",
- "gloo-timers",
+ "gloo-timers 0.2.6",
  "kv-log-macro",
  "log",
  "memchr",
@@ -1276,6 +1276,17 @@ dependencies = [
  "futures-util",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "backon"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82adeb1361d27e002e8ad1074e079860e9b5ef937e8453aa6a56d9b10e31e8d5"
+dependencies = [
+ "fastrand 2.0.2",
+ "gloo-timers 0.3.0",
+ "tokio",
 ]
 
 [[package]]
@@ -2961,6 +2972,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "gloo-timers"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "gluesql"
 version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3089,6 +3112,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "headers"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "322106e6bd0cba2d5ead589ddb8150a13d7c4217cf80d7c4f682ca994ccc6aa9"
+dependencies = [
+ "base64 0.21.7",
+ "bytes",
+ "headers-core",
+ "http 1.1.0",
+ "httpdate",
+ "mime",
+ "sha1",
+]
+
+[[package]]
+name = "headers-core"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
+dependencies = [
+ "http 1.1.0",
+]
+
+[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3198,12 +3245,12 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0475f8b2ac86659c21b64320d5d653f9efe42acd2a4e560073ec61a155a34f1d"
+checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
 dependencies = [
  "bytes",
- "futures-core",
+ "futures-util",
  "http 1.1.0",
  "http-body 1.0.0",
  "pin-project-lite",
@@ -3282,6 +3329,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-http-proxy"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d06dbdfbacf34d996c6fb540a71a684a7aae9056c71951163af8a8a4c07b9a4"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "headers",
+ "http 1.1.0",
+ "hyper 1.2.0",
+ "hyper-rustls 0.27.2",
+ "hyper-util",
+ "pin-project-lite",
+ "rustls-native-certs 0.7.0",
+ "tokio",
+ "tokio-rustls 0.26.0",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-rustls"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3315,6 +3382,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ee4be2c948921a1a5320b629c4193916ed787a7f7f293fd3f7f5a6c9de74155"
+dependencies = [
+ "futures-util",
+ "http 1.1.0",
+ "hyper 1.2.0",
+ "hyper-util",
+ "log",
+ "rustls 0.23.5",
+ "rustls-native-certs 0.7.0",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.26.0",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-timeout"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3324,6 +3410,19 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-io-timeout",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3203a961e5c83b6f5498933e78b6b263e208c197b63e9c6c53cc82ffd3f63793"
+dependencies = [
+ "hyper 1.2.0",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
 ]
 
 [[package]]
@@ -3417,6 +3516,7 @@ dependencies = [
  "axum-streams",
  "axum-tracing-opentelemetry",
  "axum-typed-websockets",
+ "backon",
  "base64 0.21.7",
  "byte-unit 5.1.4",
  "byteorder",
@@ -3438,6 +3538,8 @@ dependencies = [
  "indexify_ui",
  "itertools 0.12.1",
  "jsonschema",
+ "k8s-openapi",
+ "kube",
  "lance",
  "lancedb",
  "local-ip-address",
@@ -3682,6 +3784,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonpath-rust"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d8fe85bd70ff715f31ce8c739194b423d79811a19602115d611a3ec85d6200"
+dependencies = [
+ "lazy_static",
+ "once_cell",
+ "pest",
+ "pest_derive",
+ "regex",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
 name = "jsonschema"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3707,6 +3824,83 @@ dependencies = [
  "time",
  "url",
  "uuid",
+]
+
+[[package]]
+name = "k8s-openapi"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19501afb943ae5806548bc3ebd7f3374153ca057a38f480ef30adfde5ef09755"
+dependencies = [
+ "base64 0.22.1",
+ "chrono",
+ "serde",
+ "serde-value",
+ "serde_json",
+]
+
+[[package]]
+name = "kube"
+version = "0.93.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0365920075af1a2d23619c1ca801c492f2400157de42627f041a061716e76416"
+dependencies = [
+ "k8s-openapi",
+ "kube-client",
+ "kube-core",
+]
+
+[[package]]
+name = "kube-client"
+version = "0.93.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d81336eb3a5b10a40c97a5a97ad66622e92bad942ce05ee789edd730aa4f8603"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "chrono",
+ "either",
+ "futures",
+ "home",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "http-body-util",
+ "hyper 1.2.0",
+ "hyper-http-proxy",
+ "hyper-rustls 0.27.2",
+ "hyper-timeout 0.5.1",
+ "hyper-util",
+ "jsonpath-rust",
+ "k8s-openapi",
+ "kube-core",
+ "pem",
+ "rustls 0.23.5",
+ "rustls-pemfile 2.1.1",
+ "secrecy",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "thiserror",
+ "tokio",
+ "tokio-util",
+ "tower",
+ "tower-http",
+ "tracing",
+]
+
+[[package]]
+name = "kube-core"
+version = "0.93.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cce373a74d787d439063cdefab0f3672860bd7bac01a38e39019177e764a0fe6"
+dependencies = [
+ "chrono",
+ "form_urlencoded",
+ "http 1.1.0",
+ "k8s-openapi",
+ "serde",
+ "serde_json",
+ "thiserror",
 ]
 
 [[package]]
@@ -5121,6 +5315,15 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ordered-float"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "ordered-float"
 version = "3.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1e1c390732d15f1d48471625cd92d154e66db2c56645e29a9cd26f4699f72dc"
@@ -5231,6 +5434,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e459365e590736a54c3fa561947c84837534b8e9af6fc5bf781307e82658fae"
+dependencies = [
+ "base64 0.22.1",
+ "serde",
+]
+
+[[package]]
 name = "pem-rfc7468"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5244,6 +5457,51 @@ name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+
+[[package]]
+name = "pest"
+version = "2.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd53dff83f26735fdc1ca837098ccf133605d794cdae66acfc2bfac3ec809d95"
+dependencies = [
+ "memchr",
+ "thiserror",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a548d2beca6773b1c244554d36fcf8548a8a58e74156968211567250e48e49a"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c93a82e8d145725dcbaf44e5ea887c8a869efdcc28706df2d08c69e17077183"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.58",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a941429fea7e08bedec25e4f6785b6ffaacc6b755da98df5ef3e7dcf4a124c4f"
+dependencies = [
+ "once_cell",
+ "pest",
+ "sha2",
+]
 
 [[package]]
 name = "petgraph"
@@ -6416,6 +6674,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
+name = "secrecy"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
+dependencies = [
+ "serde",
+ "zeroize",
+]
+
+[[package]]
 name = "security-framework"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6454,6 +6722,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde-value"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
+dependencies = [
+ "ordered-float 2.10.1",
+ "serde",
 ]
 
 [[package]]
@@ -7450,7 +7728,7 @@ dependencies = [
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.28",
- "hyper-timeout",
+ "hyper-timeout 0.4.1",
  "percent-encoding",
  "pin-project",
  "prost 0.11.9",
@@ -7481,7 +7759,7 @@ dependencies = [
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.28",
- "hyper-timeout",
+ "hyper-timeout 0.4.1",
  "percent-encoding",
  "pin-project",
  "prost 0.12.6",
@@ -7536,11 +7814,13 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
 dependencies = [
+ "base64 0.21.7",
  "bitflags 2.5.0",
  "bytes",
  "http 1.1.0",
  "http-body 1.0.0",
  "http-body-util",
+ "mime",
  "pin-project-lite",
  "tower-layer",
  "tower-service",
@@ -7814,6 +8094,12 @@ dependencies = [
  "quote",
  "syn 2.0.58",
 ]
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
 
 [[package]]
 name = "uncased"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,8 @@ axum-server = { git = "https://github.com/grafbase/axum-server", branch = "rustl
 
 [workspace]
 members = [
-    ".", "crates/filter",
+    ".",
+    "crates/filter",
     "crates/indexify_internal_api",
     "crates/indexify_proto",
     "crates/indexify_ui",
@@ -31,7 +32,6 @@ axum-tracing-opentelemetry = "0.16"
 axum-server = { version = "0.6.0", features = ["tls-rustls"] }
 axum-typed-websockets = "0.6.0"
 axum-streams = { version = "0.12.0" }
-backtrace = "0.3"
 base64 = "0.21.0"
 bytes = "1"
 byteorder = "1"
@@ -66,7 +66,6 @@ opensearch = { version = "2", default-features = false, features = [
 opentelemetry = { version = "0.22", features = ["metrics"] }
 pgvector = { version = "0.3", features = ["sqlx"] }
 prost = { version = "0.12.6" }
-prost-types = { version = "0.12" }
 prost-wkt = "0.5.1"
 prost-wkt-types = { version = "0.5.1" }
 qdrant-client = { version = "1.9.0" }
@@ -88,7 +87,11 @@ rust-embed = { version = "8.2.0", features = [
     "debug-embed",
     "interpolate-folder-path",
 ] }
-rustls = { version = "0.23", default-features=false, features = ["std", "tls12", "logging"] }
+rustls = { version = "0.23", default-features = false, features = [
+    "std",
+    "tls12",
+    "logging",
+] }
 rustls-pemfile = { version = "2.0.0" }
 rusqlite = { version = "0.30.0", features = ["bundled", "serde_json"] }
 serde = { version = "1", features = ["derive"] }
@@ -246,6 +249,9 @@ opentelemetry-datadog = { workspace = true }
 indexify_ui = { path = "crates/indexify_ui" }
 axum-extra = { version = "0.9.3", features = ["query"] }
 byte-unit = "5.1.4"
+kube = "0.93.1"
+k8s-openapi = { version = "0.22.0", features = ["earliest"] }
+backon = "1.1.0"
 
 [dev-dependencies]
 tracing-test = { version = "0.2", features = ["no-env-filter"] }

--- a/dockerfiles/Dockerfile.local
+++ b/dockerfiles/Dockerfile.local
@@ -1,25 +1,43 @@
-FROM tensorlake/builder AS builder
-
-FROM node:latest as ui-builder
-
+FROM lukemathwalker/cargo-chef:latest-rust-slim-bookworm AS chef
 WORKDIR /app
+RUN apt-get update && apt-get install -y \
+    software-properties-common unzip \
+    build-essential make cmake ca-certificates \
+    curl pkg-config git \
+    sqlite3 clang gcc g++ \
+    protobuf-compiler
+RUN RUN curl -sL https://deb.nodesource.com/setup_22.x | bash && \
+    apt-get install -y \
+    nodejs \
+    npm
 
-COPY ./ui .
+FROM chef AS planner
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
 
-RUN npm install && npm run build
+FROM chef AS rust-builder
+COPY --from=planner /app/recipe.json recipe.json
+COPY rust-toolchain.toml .
+RUN cargo chef cook --release --recipe-path recipe.json
+COPY . .
+RUN cargo build --release --bin indexify
 
-FROM ubuntu:22.04
+FROM ubuntu:22.04 AS runner
 
 RUN apt update
 
-RUN apt install -y libssl-dev python3-dev ca-certificates
+RUN apt-get update && apt install -y \
+    curl \
+    libssl-dev \
+    python3-dev \
+    ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
 
 RUN update-ca-certificates
 
 WORKDIR /indexify
 
-COPY --from=builder /indexify-build/target/release/indexify ./
-COPY --from=ui-builder ./app/build ./ui/build
+COPY --from=rust-builder /app/target/release/indexify ./
 
 COPY sample_config.yaml ./config/indexify.yaml
 

--- a/docs/operations/configuration.mdx
+++ b/docs/operations/configuration.mdx
@@ -148,21 +148,23 @@ tls:
   cert_file: .dev-tls/server.crt  # Path to the server certificate
   key_file: .dev-tls/server.key   # Path to the server private key
 ```
-### HA configuration 
 
-To setup mulitple coordinator nodes for high availability configuration, start with a single node, called a seed node. Create a separate configuration file for each additional coordinator instance. Each node should have a unique node_id field in configuration file. seed_node field should be set to ip address and port of the original coordinator node. 
+### HA configuration
 
-Seed node:
+To run multiple coordinators in a high availability configuration, you'll want
+to have a way for them to discover themselves. Set `seed_node` to the address
+that can be used for this. Note that the only requirement is that the returned
+node is "ready" as defined by `localhost:8960/status`. For dynamic environments,
+put a load balancer in front of all coordinator nodes and enable/disable their
+endpoints based off the status of the raft cluster.
+
+Note: it is important that *one* of the nodes is started with
+`--initialize` the first time the cluster is started. This provides an
+initial leader to form the cluster around. You'll likely want to no longer use
+this flag after the cluster is formed.
 
 ```yaml
 raft_port: 8970
 node_id: 0
-seed_node: localhost:8970
-```
-
-New node (replace 10.0.0.10 with actual seed node IP address, 8970 should match configured raft_port of the seed node):
-
-```yaml
-node_id: 1
-seed_node: 10.0.0.10:8970
+seed_node: my-dicovery-address:8970
 ```

--- a/docs/operations/kubernetes.mdx
+++ b/docs/operations/kubernetes.mdx
@@ -1,8 +1,5 @@
 If you'd like to try with your own cluster, check out the
-[instructions][operations/k8s]. They'll walk you through an ephemeral setup
-using a local cluster. To get Indexify into production, you'll want to modify
-the YAML so that it works with your environment. In particular, make sure to pay
-attention to the dependencies.
+[instructions][operations/k8s].
 
 [operations/k8s]:
   https://github.com/tensorlakeai/indexify/tree/main/operations/k8s

--- a/operations/k8s/helm/local.yaml
+++ b/operations/k8s/helm/local.yaml
@@ -25,23 +25,17 @@ api:
     enabled: true
 
   image: tensorlake/indexify:latest
-  nodeSelector: {}
 
 coordinator:
   image: tensorlake/indexify:latest
-  nodeSelector: {}
 
 extractors:
   - image: tensorlake/chunk-extractor:latest
     name: chunker
-    nodeSelector: {}
   - image: tensorlake/minilm-l6:latest
     name: minilm-l6
-    nodeSelector: {}
-  - image: tensorlake/pdfextractor:latest 
+  - image: tensorlake/pdfextractor:latest
     name: pdfextractor
-    nodeSelector: {}
-
 
 extraObjects:
   - |
@@ -93,5 +87,5 @@ postgresql:
         initdb.sh: |
           #!/bin/bash
           echo "Creating database indexify..."
-          export PGPASSWORD=indexify   
+          export PGPASSWORD=indexify
           psql -U postgres -c "CREATE DATABASE indexify;"

--- a/operations/k8s/helm/templates/_helpers.tpl
+++ b/operations/k8s/helm/templates/_helpers.tpl
@@ -32,3 +32,11 @@ app.kubernetes.io/managed-by: {{ .global.Release.Service }}
 {{- end }}
 {{- end }}
 {{- end }}
+
+{{- define "quorum" -}}
+{{- if eq (mod . 2) 0  }}
+  {{- fail "must be an odd number" }}
+{{- else }}
+{{- . -}}
+{{- end }}
+{{- end }}

--- a/operations/k8s/helm/templates/api.yaml
+++ b/operations/k8s/helm/templates/api.yaml
@@ -20,7 +20,7 @@ metadata:
   labels:
     {{- include "labels" (dict "name" "api" "component" "api" "global" $) | nindent 4 }}
 spec:
-  replicas: 1
+  replicas: {{ .replicas | default 1 }}
   selector:
     matchLabels:
       {{- include "labels" (dict "name" "api" "component" "api" "global" $) | nindent 6 }}
@@ -33,7 +33,7 @@ spec:
       {{- if .nodeSelector }}
       nodeSelector:
         {{- toYaml .nodeSelector | nindent 8 }}
-      {{- end }}     
+      {{- end }}
       containers:
         - name: indexify
           image: {{ .image }}

--- a/operations/k8s/helm/templates/config.yaml
+++ b/operations/k8s/helm/templates/config.yaml
@@ -9,7 +9,9 @@ data:
   config.yaml: |-
     coordinator_addr: coordinator:8950
     raft_port: 8970
-    seed_node: localhost:8970
+    seed_node: coordinator:8970
+
+    # This is overridden by command line flags on startup in the coordinator.
     node_id: 0
 
     state_store:

--- a/operations/k8s/helm/templates/coordinator.yaml
+++ b/operations/k8s/helm/templates/coordinator.yaml
@@ -2,45 +2,106 @@
 {{- if .enabled }}
 ---
 apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: coordinator
+  labels:
+    {{- include "labels" (dict "name" "coordinator" "component" "coordinator" "global" $) | nindent 4 }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: coordinator
+  labels:
+    {{- include "labels" (dict "name" "coordinator" "component" "coordinator" "global" $) | nindent 4 }}
+rules:
+  - apiGroups:
+    - discovery.k8s.io
+    resources:
+    - endpointslices
+    verbs:
+    - list
+  - apiGroups: [""]
+    resources:
+    - services
+    verbs:
+    - get
+  - apiGroups: [""]
+    resources:
+    - pods
+    verbs:
+    - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: coordinator
+  labels:
+    {{- include "labels" (dict "name" "coordinator" "component" "coordinator" "global" $) | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: coordinator
+roleRef:
+  kind: Role
+  name: coordinator
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: v1
 kind: Service
 metadata:
   name: coordinator
 spec:
   ports:
     - port: 8950
+      name: coordinator
+    - port: 8970
+      name: raft
   selector:
     {{- include "labels" (dict "name" "coordinator" "component" "coordinator" "global" $) | nindent 4 }}
 ---
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: coordinator
   labels:
     {{- include "labels" (dict "name" "coordinator" "component" "coordinator" "global" $) | nindent 4 }}
 spec:
-  replicas: 1
+  replicas: {{ include "quorum" (default 1 .replicas) }}
+
+  # Let raft figure things out, otherwise scaling by 1 causes an inability to update anything - as nothing is ready
+  podManagementPolicy: Parallel
+
   selector:
     matchLabels:
     {{- include "labels" (dict "name" "coordinator" "component" "coordinator" "global" $) | nindent 6 }}
+
   template:
     metadata:
       labels:
         {{- include "labels" (dict "name" "coordinator" "component" "coordinator" "global" $) | nindent 8 }}
-
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/path: /metrics
+        prometheus.io/port: "8960"
     spec:
       {{- if .nodeSelector }}
       nodeSelector:
         {{- toYaml .nodeSelector | nindent 8 }}
-      {{- end }}    
+      {{- end }}
+      serviceAccountName: coordinator
       containers:
         - name: indexify
           image: {{ .image }}
 
-          command: ['indexify']
+          command: ["/bin/bash", "-ce", "-o", "pipefail"]
+
+          # See the discovery command help for an explanation of how the seed node is chosen.
           args:
-            - coordinator
-            - --config-path
-            - ./config/config.yaml
+            - seed="$(indexify discovery coordinator)";
+              indexify coordinator
+                --config-path ./config/config.yaml
+                $(if [ "$seed" == "$(hostname -i)" ]; then echo "--initialize"; fi)
+                --node-id "$(hostname | rev | cut -d- -f1 | rev)"
 
           volumeMounts:
             - mountPath: /indexify/config
@@ -49,12 +110,38 @@ spec:
             - mountPath: /data
               name: data
 
+          livenessProbe:
+            httpGet:
+              path: /metrics
+              port: 8960
+
+          readinessProbe:
+            httpGet:
+              path: /state
+              port: 8960
+
       volumes:
         - name: config
           configMap:
             name: indexify
+        {{ if not .persistence }}
         - name: data
           emptyDir: {}
+        {{- end }}
+
+  {{ with .persistence}}
+  volumeClaimTemplates:
+  - metadata:
+      name: data
+      labels:
+        {{- include "labels" (dict "name" "coordinator" "component" "coordinator" "global" $) | nindent 8 }}
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      storageClassName: {{ .storageClass | default "standard" }}
+      resources:
+        requests:
+          storage: 1Gi
+  {{- end }}
 
 {{- end }}
 {{- end }}

--- a/operations/k8s/helm/values.yaml
+++ b/operations/k8s/helm/values.yaml
@@ -22,21 +22,33 @@ blobStore:
 
 api:
   enabled: true
+  # replicas: 1
 
   image: tensorlake/indexify:stable
 
   ingress:
     enabled: false
 
+  #   nodeselector:
+  #     gpu: "true"
+
 coordinator:
   enabled: true
+  # replicas: 1 # must be an odd number
 
   image: tensorlake/indexify:stable
+  #   nodeselector:
+  #     gpu: "true"
+
+  # persistence:
+  #   storageClass: 'standard'
 
 extractors:
   # - image: tensorlake/chunker:latest
   #   name: chunker
   #   replicas: 1
+  #   nodeselector:
+  #     gpu: "true"
 
 extraObjects:
 

--- a/sample_config.yaml
+++ b/sample_config.yaml
@@ -67,7 +67,7 @@ tls:
   cert_file: .dev-tls/server.crt # Path to the server certificate
   key_file: .dev-tls/server.key # Path to the server private key
 
-seed_node: localhost:8970
+# seed_node: localhost:8970
 node_id: 0
 
 cache:

--- a/src/cmd/discovery.rs
+++ b/src/cmd/discovery.rs
@@ -1,0 +1,121 @@
+use anyhow::Result;
+use clap::Args as ClapArgs;
+use itertools::Itertools;
+use k8s_openapi::{
+    api::{
+        core::v1::{Pod, PodStatus, Service, ServiceSpec},
+        discovery::v1::EndpointSlice,
+    },
+    apimachinery::pkg::apis::meta::v1::LabelSelector,
+};
+use kube::{api::ListParams, core::Selector, Api, ResourceExt};
+
+use super::GlobalArgs;
+
+/// Discover the seed node to bootstrap the cluster. This has been implemented
+/// for Kubernetes.
+///
+/// If there are healthy pods, it will return the service name. If there are no
+/// healthy pods, it will return the hostname of the *newest* pod which can be
+/// itself. This helps maintain state in the following scenarios:
+///
+/// 1. A deployment updates a single pod at a time. The new pod will use the
+///    normal service to bootstrap.
+/// 1. A pod is restarted. The pod will use the normal service to bootstrap.
+/// 1. A new deployment is created. The replicas will use the *first* pod to be
+///    created to bootstrap.
+///
+/// Note: if you are not using persistent volumes, you may loose data if all the
+/// pods restart at the same time.
+#[derive(Debug, ClapArgs)]
+pub struct Args {
+    /// Service to use for discovery. This will be used if there are some ready
+    /// endpoints.
+    service: String,
+}
+
+impl Args {
+    pub async fn run(self, _: GlobalArgs) {
+        match run(self.service.as_str()).await {
+            Ok(service) => println!("{}", service),
+            Err(e) => {
+                eprintln!("Error running discovery: {}", e);
+                std::process::exit(1);
+            }
+        }
+    }
+}
+
+async fn by_endpoints(client: kube::Client, service: &str) -> Result<Option<String>> {
+    let slices = Api::<EndpointSlice>::default_namespaced(client.clone())
+        .list(
+            &ListParams::default()
+                .labels(format!("kubernetes.io/service-name={}", service).as_str()),
+        )
+        .await?;
+
+    let endpoints = slices
+        .into_iter()
+        .flat_map(|slice| slice.endpoints)
+        .filter(|endpoint| {
+            endpoint
+                .conditions
+                .as_ref()
+                .map(|c| c.ready.unwrap_or_default())
+                .unwrap_or_default()
+        })
+        .collect::<Vec<_>>();
+
+    if endpoints.is_empty() {
+        return Ok(None);
+    }
+
+    Ok(Some(service.to_string()))
+}
+
+async fn by_pods(client: kube::Client, service: &str) -> Result<String> {
+    let service_resource = Api::<Service>::default_namespaced(client.clone())
+        .get(service)
+        .await?;
+
+    let Some(ServiceSpec { selector, .. }) = &service_resource.spec else {
+        return Err(anyhow::anyhow!("service {} has no selector", service));
+    };
+
+    let label_selector: Selector = LabelSelector {
+        match_labels: selector.clone(),
+        ..Default::default()
+    }
+    .try_into()?;
+
+    let Some(pod) = Api::<Pod>::default_namespaced(client.clone())
+        .list(&ListParams::default().labels_from(&label_selector))
+        .await?
+        .items
+        .into_iter()
+        .sorted_by_key(ResourceExt::creation_timestamp)
+        .next()
+    else {
+        return Err(anyhow::anyhow!("no pods found for {}", service,));
+    };
+
+    if let Some(PodStatus {
+        pod_ip: Some(pod_ip),
+        ..
+    }) = pod.status
+    {
+        return Ok(pod_ip);
+    }
+
+    Err(anyhow::anyhow!("pod {} has no IP", pod.name_any()))
+}
+
+async fn run(service: &str) -> Result<String> {
+    let client = kube::Client::try_default().await?;
+
+    if let Some(service) = by_endpoints(client.clone(), service).await? {
+        return Ok(service);
+    }
+
+    by_pods(client.clone(), service).await
+}

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -1,6 +1,7 @@
 use clap::{Args, Parser, Subcommand};
 
 mod coordinator;
+mod discovery;
 mod init_compose;
 mod init_config;
 mod server;
@@ -28,6 +29,7 @@ pub enum Commands {
     Coordinator(coordinator::Args),
     InitConfig(init_config::Args),
     InitCompose(init_compose::Args),
+    Discovery(discovery::Args),
 }
 
 /// The main CLI struct. This is the root of the CLI tree.
@@ -49,6 +51,7 @@ impl Cli {
             Commands::Coordinator(args) => args.run(self.global_args).await,
             Commands::InitConfig(args) => args.run(self.global_args).await,
             Commands::InitCompose(args) => args.run(self.global_args).await,
+            Commands::Discovery(args) => args.run(self.global_args).await,
         }
     }
 }

--- a/src/coordinator.rs
+++ b/src/coordinator.rs
@@ -925,7 +925,7 @@ mod tests {
         )
         .await
         .expect("failed to initialize state");
-        shared_state.initialize_raft().await.unwrap();
+        shared_state.initialize_raft(config.node_id).await.unwrap();
         let coordinator = crate::coordinator::Coordinator::new(
             shared_state.clone(),
             coordinator_client,

--- a/src/main.rs
+++ b/src/main.rs
@@ -154,7 +154,7 @@ fn setup_tracing(trace_type: &str) -> Result<()> {
 pub(crate) fn setup_fmt_tracing() {
     let env_filter = tracing_subscriber::EnvFilter::try_from_default_env()
         .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info"));
-    println!("Running with tracing filter {}", env_filter);
+    eprintln!("Running with tracing filter {}", env_filter);
     let subscriber = tracing_subscriber::Registry::default().with(
         tracing_subscriber::fmt::layer()
             .with_writer(std::io::stderr)

--- a/src/server.rs
+++ b/src/server.rs
@@ -6,7 +6,7 @@ use std::{
     time::{Duration, SystemTime},
 };
 
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Context, Result};
 use axum::{
     body::Body,
     extract::{DefaultBodyLimit, Multipart, Path, Query, State},
@@ -385,7 +385,8 @@ impl Server {
             axum_server::bind(self.addr)
                 .handle(handle)
                 .serve(app.into_make_service())
-                .await?;
+                .await
+                .with_context(|| format!("addr: {}", self.addr))?;
         }
 
         Ok(())
@@ -811,11 +812,11 @@ async fn update_labels(
         ("source" = Option<String>, Query, description = "Filter by source, either extraction policy name or 'ingestion' for top level content"),
         ("parent_id" = Option<String>, Query, description = "Filter by parent ID"),
         ("ingested_content_id" = Option<String>, Query, description = "Filter by ingested content ID"),
-        ("labels_filter" = Option<Vec<String>>, Query, description = "Filter by labels. 
-        Filter expression is the name of the label, comparison operator, and desired value, e.g. &labels_filter=key>=value. 
+        ("labels_filter" = Option<Vec<String>>, Query, description = "Filter by labels.
+        Filter expression is the name of the label, comparison operator, and desired value, e.g. &labels_filter=key>=value.
         Multiple expressions can be specified as separate query parameters."),
-        ("start_id" = Option<String>, Query, description = "Pagination start ID. 
-        Omit to start from beginning. To continue iteration, 
+        ("start_id" = Option<String>, Query, description = "Pagination start ID.
+        Omit to start from beginning. To continue iteration,
         specify id of the last content in the previous response"),
         ("limit" = Option<u32>, Query, description = "Maximum number of items to return"),
     ),
@@ -1639,8 +1640,8 @@ async fn extraction_graph_analytics(
         ("extraction_policy" = String, Path, description = "Extraction policy name"),
         ("content_id" = Option<String>, Query, description = "Filter by content ID"),
         ("outcome" = Option<String>, Query, description = "Filter by task outcome"),
-        ("start_id" = Option<String>, Query, description = "Pagination start ID. 
-        Omit to start from beginning. To continue iteration, 
+        ("start_id" = Option<String>, Query, description = "Pagination start ID.
+        Omit to start from beginning. To continue iteration,
         specify id of the last task in the previous response"),
         ("limit" = Option<u32>, Query, description = "Maximum number of items to return"),
     ),

--- a/src/server_config.rs
+++ b/src/server_config.rs
@@ -425,7 +425,9 @@ pub struct ServerConfig {
     pub tls: Option<TlsConfig>,
     pub coordinator_tls: Option<CoordinatorTls>,
     pub coordinator_client_tls: Option<CoordinatorClientTls>,
-    pub seed_node: String,
+    pub seed_node: Option<String>,
+    #[serde(default)]
+    pub initialize_raft: bool,
     pub node_id: u64,
     /// cache is the configuration for the server-side cache.
     #[serde(default)]
@@ -454,7 +456,8 @@ impl Default for ServerConfig {
             tls: None,
             coordinator_tls: None,
             coordinator_client_tls: None,
-            seed_node: "localhost:8970".into(),
+            seed_node: None,
+            initialize_raft: false,
             node_id: 0,
             cache: ServerCacheConfig::default(),
             state_store: StateStoreConfig::default(),

--- a/src/task_allocator/planner/load_aware_distributor.rs
+++ b/src/task_allocator/planner/load_aware_distributor.rs
@@ -406,7 +406,7 @@ mod tests {
         )
         .await
         .unwrap();
-        shared_state.initialize_raft().await.unwrap();
+        shared_state.initialize_raft(config.node_id).await.unwrap();
 
         let task_ids: HashSet<TaskId> = shared_state
             .state_machine
@@ -441,7 +441,7 @@ mod tests {
         )
         .await
         .unwrap();
-        shared_state.initialize_raft().await.unwrap();
+        shared_state.initialize_raft(config.node_id).await.unwrap();
 
         // Add extractors and extractor bindings and ensure that we are creating tasks
         shared_state
@@ -498,7 +498,7 @@ mod tests {
         )
         .await
         .unwrap();
-        shared_state.initialize_raft().await.unwrap();
+        shared_state.initialize_raft(config.node_id).await.unwrap();
 
         let text_extractor = {
             let mut extractor = mock_extractor();
@@ -733,7 +733,7 @@ mod tests {
         )
         .await
         .unwrap();
-        shared_state.initialize_raft().await.unwrap();
+        shared_state.initialize_raft(config.node_id).await.unwrap();
 
         let text_extractor = {
             let mut extractor = mock_extractor();

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -53,7 +53,7 @@ impl RaftTestCluster {
                 state_store: StateStoreConfig {
                     path: Some(format!("/tmp/indexify-test/raft/{}/{}", append, i)),
                 },
-                seed_node: seed_node.clone(),
+                seed_node: Some(seed_node.clone()),
                 ..Default::default()
             });
 
@@ -83,7 +83,7 @@ impl RaftTestCluster {
                     self.append, new_node_id
                 )),
             },
-            seed_node,
+            seed_node: Some(seed_node),
             ..Default::default()
         });
         let garbage_collector = GarbageCollector::new();
@@ -251,7 +251,7 @@ impl RaftTestCluster {
             .shared_state;
 
         seed_node
-            .initialize_raft()
+            .initialize_raft(self.seed_node_id)
             .await
             .map_err(|e| anyhow::anyhow!("Error initializing raft: {}", e))?;
 


### PR DESCRIPTION
- Allow nodes to have the same ports.
- Add voters instead of setting all nodes. This
  prevents possible split brain scenarios.
- Remove nodes with the same node id but different
  addresses.
- Allow overriding node_id as part of running
  `coordinator`.
- Allow specifying if a node is the "initial" one.
  This means that during initial cluster
  formation, it will be the leader. No other nodes
  call `initialize` for the raft cluster.
- Add a `discovery` command to find other nodes in
  the raft cluster. This only works with
  Kubernetes and uses the endpoints API. If
  endpoints are available for a service, use the
  service name. If there are no endpoints
  available, use the IP address of the *oldest*
  pod. This ends up being used in the StatefulSet
  command to set `--initialize`.
- Add a "readiness" endpoint for the coordinator
  `:8960/state` which returns the current state of
  the running node. This includes what type of
  node it is (Leader, Follower) and the nodes in
  the cluster. It will only return a 200 if the
  node is a leader/follower/candidate (aka has
  voting rights). Any learners or nodes
  experiencing runtime issues will return a 503.
- Update the helm chart to support HA.
    - Switch to StatefulSet's from Deployments.
    - Allow attaching persistent volumes to each
      instance.
    - Introduce liveness and readiness probes.
    - Add prometheus scrape metrics by default.