### PR TITLE
feat: filter incompatible executors

### DIFF
--- a/python-sdk/indexify/functions_sdk/graph.py
+++ b/python-sdk/indexify/functions_sdk/graph.py
@@ -97,7 +97,7 @@ class ComputeGraphMetadata(BaseModel):
     nodes: Dict[str, NodeMetadata]
     edges: Dict[str, List[str]]
     accumulator_zero_values: Dict[str, bytes] = {}
-    runtime_information: RuntimeInformation = {}
+    runtime_information: RuntimeInformation
 
     def get_input_payload_serializer(self):
         return get_serializer(self.start_node.compute_fn.payload_encoder)

--- a/server/data_model/src/lib.rs
+++ b/server/data_model/src/lib.rs
@@ -214,8 +214,8 @@ impl Default for GraphVersion {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct RuntimeInformation {
-    pub major_version: u32,
-    pub minor_version: u32,
+    pub major_version: u8,
+    pub minor_version: u8,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/server/data_model/src/lib.rs
+++ b/server/data_model/src/lib.rs
@@ -213,6 +213,12 @@ impl Default for GraphVersion {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct RuntimeInformation {
+    pub major_version: u32,
+    pub minor_version: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct ComputeGraph {
     pub namespace: String,
     pub name: String,
@@ -223,6 +229,7 @@ pub struct ComputeGraph {
     pub start_fn: Node,
     pub nodes: HashMap<String, Node>,
     pub edges: HashMap<String, Vec<String>>,
+    pub runtime_information: RuntimeInformation,
 }
 
 impl ComputeGraph {

--- a/server/data_model/src/test_objects.rs
+++ b/server/data_model/src/test_objects.rs
@@ -10,6 +10,7 @@ pub mod tests {
         Node,
         Node::Compute,
         NodeOutput,
+        RuntimeInformation,
     };
     use crate::{
         DataPayload,
@@ -164,6 +165,10 @@ pub mod tests {
             },
             created_at: 5,
             start_fn: Compute(fn_a),
+            runtime_information: RuntimeInformation {
+                major_version: 3,
+                minor_version: 10,
+             },
         }
     }
 
@@ -198,6 +203,10 @@ pub mod tests {
             },
             created_at: 5,
             start_fn: Compute(fn_a),
+            runtime_information: RuntimeInformation {
+                major_version: 3,
+                minor_version: 10,
+             },
         }
     }
 
@@ -226,6 +235,10 @@ pub mod tests {
             version: crate::GraphVersion(1),
             created_at: 5,
             start_fn: Compute(fn_a),
+            runtime_information: RuntimeInformation {
+                major_version: 3,
+                minor_version: 10,
+             },
         }
     }
 

--- a/server/data_model/src/test_objects.rs
+++ b/server/data_model/src/test_objects.rs
@@ -168,7 +168,7 @@ pub mod tests {
             runtime_information: RuntimeInformation {
                 major_version: 3,
                 minor_version: 10,
-             },
+            },
         }
     }
 
@@ -206,7 +206,7 @@ pub mod tests {
             runtime_information: RuntimeInformation {
                 major_version: 3,
                 minor_version: 10,
-             },
+            },
         }
     }
 
@@ -238,7 +238,7 @@ pub mod tests {
             runtime_information: RuntimeInformation {
                 major_version: 3,
                 minor_version: 10,
-             },
+            },
         }
     }
 

--- a/server/src/http_objects.rs
+++ b/server/src/http_objects.rs
@@ -7,7 +7,6 @@ use axum::{
 use data_model::{ComputeGraphCode, GraphVersion};
 use indexify_utils::get_epoch_time_in_ms;
 use serde::{Deserialize, Serialize};
-use tracing::info;
 use utoipa::ToSchema;
 
 #[derive(Debug, ToSchema)]

--- a/server/src/http_objects.rs
+++ b/server/src/http_objects.rs
@@ -256,8 +256,6 @@ impl ComputeGraph {
         }
         let start_fn: data_model::Node = self.start_node.into();
 
-        info!("runtime_information: {:?}", self.runtime_information);
-
         let compute_graph = data_model::ComputeGraph {
             name: self.name,
             namespace: self.namespace,

--- a/server/src/http_objects.rs
+++ b/server/src/http_objects.rs
@@ -208,8 +208,8 @@ impl From<data_model::Node> for Node {
 
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
 pub struct RuntimeInformation {
-    pub major_version: u32,
-    pub minor_version: u32,
+    pub major_version: u8,
+    pub minor_version: u8,
 }
 
 impl From<RuntimeInformation> for data_model::RuntimeInformation {

--- a/server/task_scheduler/src/lib.rs
+++ b/server/task_scheduler/src/lib.rs
@@ -4,7 +4,7 @@ use anyhow::{anyhow, Result};
 use data_model::{ExecutorId, Node, ReduceTask, RuntimeInformation, Task};
 use rand::seq::SliceRandom;
 use state_store::{requests::TaskPlacement, IndexifyState};
-use tracing::{error_span, info};
+use tracing::{error, info};
 
 pub mod task_creator;
 
@@ -80,7 +80,7 @@ impl TaskScheduler {
                     }
                     info!("executor {} has python_minor_version label", executor.id);
                 } else {
-                    error_span!("failed to parse python_minor_version label");
+                    error!("failed to parse python_minor_version label");
                     continue;
                 }
             }

--- a/server/task_scheduler/src/lib.rs
+++ b/server/task_scheduler/src/lib.rs
@@ -1,4 +1,4 @@
-use std::{sync::Arc};
+use std::sync::Arc;
 
 use anyhow::{anyhow, Result};
 use data_model::{ExecutorId, Node, ReduceTask, RuntimeInformation, Task};
@@ -58,17 +58,24 @@ impl TaskScheduler {
         Ok(task_allocations)
     }
 
-    fn filter_executors(&self, node: &Node, runtime_information: &RuntimeInformation) -> Result<Vec<ExecutorId>> {
+    fn filter_executors(
+        &self,
+        node: &Node,
+        runtime_information: &RuntimeInformation,
+    ) -> Result<Vec<ExecutorId>> {
         let executors = self.indexify_state.reader().get_all_executors()?;
         let mut filtered_executors = Vec::new();
 
         for executor in &executors {
             let raw_minor_version = executor.labels.get("python_minor_version");
-            if let Some (minor_version) = raw_minor_version {
+            if let Some(minor_version) = raw_minor_version {
                 let minor_version = serde_json::from_value::<u8>(minor_version.clone());
                 if let Ok(minor_version) = minor_version {
                     if minor_version != runtime_information.minor_version {
-                        info!("skipping executor {} because python version does not match", executor.id);
+                        info!(
+                            "skipping executor {} because python version does not match",
+                            executor.id
+                        );
                         continue;
                     }
                     info!("executor {} has python_minor_version label", executor.id);


### PR DESCRIPTION
## Description

This PR adds additional information to the execution of a task using the Python SDK. During my tests, my workflows ere failing due to a Python version mismatch.

Indexify will now identify the version run by the user, and filter out executors which can't run the Python version to avoid errors.

## How to run

1. Upgrade the Indexify CLI package.
2. Install it in our virtualenv.
3. Build indexify server locally.
4. Add an executor
5. Run the example from the README using python3.10 -> this should work.
6. Runt he example from the README using python3.12 -> the task won't get scheduled.