### PR TITLE
don't generate event if task was already completed

### DIFF
--- a/server/state_store/src/lib.rs
+++ b/server/state_store/src/lib.rs
@@ -221,8 +221,15 @@ impl IndexifyState {
                 state_changes
             }
             requests::RequestPayload::FinalizeTask(finalize_task) => {
-                let state_changes = self.finalize_task(&finalize_task).await?;
-                state_machine::mark_task_completed(self.db.clone(), &txn, finalize_task.clone())?;
+                let state_changes = if state_machine::mark_task_completed(
+                    self.db.clone(),
+                    &txn,
+                    finalize_task.clone(),
+                )? {
+                    self.finalize_task(&finalize_task).await?
+                } else {
+                    Vec::new()
+                };
                 tasks_finalized
                     .entry(finalize_task.executor_id.clone())
                     .or_default()

--- a/server/state_store/src/state_machine.rs
+++ b/server/state_store/src/state_machine.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, sync::Arc};
+use std::{collections::HashMap, sync::Arc, vec};
 
 use anyhow::{anyhow, Result};
 use data_model::{
@@ -602,11 +602,13 @@ pub fn allocate_tasks(
     Ok(())
 }
 
+/// Returns true if the task was marked as completed.
+/// If task was already completed, returns false.
 pub fn mark_task_completed(
     db: Arc<TransactionDB>,
     txn: &Transaction<TransactionDB>,
     req: FinalizeTaskRequest,
-) -> Result<()> {
+) -> Result<bool> {
     let task_key = format!(
         "{}|{}|{}|{}|{}",
         req.namespace, req.compute_graph, req.invocation_id, req.compute_fn, req.task_id
@@ -616,7 +618,7 @@ pub fn mark_task_completed(
         .ok_or(anyhow!("Task not found: {}", &req.task_id))?;
     let mut task = JsonEncoder::decode::<Task>(&task)?;
     if task.terminal_state() {
-        return Ok(());
+        return Ok(false);
     }
     let graph_ctx_key = format!(
         "{}|{}|{}",
@@ -686,7 +688,7 @@ pub fn mark_task_completed(
         task.key(),
         task_bytes,
     )?;
-    Ok(())
+    Ok(true)
 }
 
 pub(crate) fn save_state_changes(


### PR DESCRIPTION
If task completion is duplicate, no new events should be generated to avoid processing reference count decrement and generating new tasks another time.