### PR TITLE
fix: s3 and helm dep

### DIFF
--- a/operations/k8s/helm/Chart.yaml
+++ b/operations/k8s/helm/Chart.yaml
@@ -4,8 +4,8 @@ description: Indexify
 type: application
 version: 0.1.0
 
-# dependencies:
-#   - name: minio
-#     repository: https://charts.min.io/
-#     condition: minio.enabled
-#     version: 5.2.0
+dependencies:
+  - name: minio
+    repository: https://charts.min.io/
+    condition: minio.enabled
+    version: 5.2.0

--- a/operations/k8s/helm/Chart.yaml
+++ b/operations/k8s/helm/Chart.yaml
@@ -4,12 +4,8 @@ description: Indexify
 type: application
 version: 0.1.0
 
-dependencies:
-  - name: minio
-    repository: https://charts.min.io/
-    condition: minio.enabled
-    version: 5.2.0
-  - name: postgresql
-    repository: https://charts.bitnami.com/bitnami
-    condition: postgresql.enabled
-    version: 15.5.9
+# dependencies:
+#   - name: minio
+#     repository: https://charts.min.io/
+#     condition: minio.enabled
+#     version: 5.2.0

--- a/operations/k8s/helm/local.yaml
+++ b/operations/k8s/helm/local.yaml
@@ -24,7 +24,7 @@ executors:
     replicas: 1
 
 minio:
-  enabled: false
+  enabled: true
   fullnameOverride: blob-store
   persistence:
     enabled: false

--- a/operations/k8s/helm/local.yaml
+++ b/operations/k8s/helm/local.yaml
@@ -14,7 +14,7 @@ server:
   image: tensorlake/indexify-server:latest
   ingress:
     enabled: true
-  persistance:
+  persistence:
     storageClassName: 'local-path'
     size: 1Gi
 

--- a/operations/k8s/helm/local.yaml
+++ b/operations/k8s/helm/local.yaml
@@ -1,6 +1,6 @@
 blobStore:
   allowHTTP: true
-  # endpoint: http://blob-store:9000
+  endpoint: http://blob-store:9000
   credentialSecret: blob-creds
   config:
     backend: s3

--- a/operations/k8s/helm/local.yaml
+++ b/operations/k8s/helm/local.yaml
@@ -1,12 +1,14 @@
 blobStore:
   allowHTTP: true
-  endpoint: http://blob-store:9000
+  # endpoint: http://blob-store:9000
   credentialSecret: blob-creds
   config:
     backend: s3
     s3:
       bucket: indexify
       region: us-east-1
+      accessKey: 
+      secretKey: 
 
 server:
   image: tensorlake/indexify-server:latest
@@ -22,7 +24,7 @@ executors:
     replicas: 1
 
 minio:
-  enabled: true
+  enabled: false
   fullnameOverride: blob-store
   persistence:
     enabled: false

--- a/operations/k8s/helm/templates/config.yaml
+++ b/operations/k8s/helm/templates/config.yaml
@@ -1,0 +1,13 @@
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: indexify
+  labels:
+    {{- include "labels" (dict "name" "indexify" "component" "config" "global" $) | nindent 4 }}
+data:
+  config.yaml: |-
+    listen_addr: 0.0.0.0:8900
+    state_store_path: /tmp/indexify/state
+    blob_storage:
+      {{- .Values.blobStore.config | toYaml | nindent 6 }}

--- a/operations/k8s/helm/templates/config.yaml
+++ b/operations/k8s/helm/templates/config.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: indexify
+  name: indexify-server
   labels:
     {{- include "labels" (dict "name" "indexify" "component" "config" "global" $) | nindent 4 }}
 data:

--- a/operations/k8s/helm/templates/secret.yaml
+++ b/operations/k8s/helm/templates/secret.yaml
@@ -14,7 +14,7 @@ stringData:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: blob-store
+  name: blob-creds
 type: Opaque
 stringData:
   AWS_ACCESS_KEY_ID: {{ .Values.blobStore.config.s3.accessKey }}

--- a/operations/k8s/helm/templates/server.yaml
+++ b/operations/k8s/helm/templates/server.yaml
@@ -23,7 +23,6 @@ spec:
     metadata:
       labels:
         {{- include "labels" (dict "name" "server" "component" "server" "global" $) | nindent 8 }}
-
     spec:
       {{- if .nodeSelector }}
       nodeSelector:
@@ -32,15 +31,23 @@ spec:
       containers:
         - name: indexify
           image: {{ .image }}
+          command: ["indexify-server"]
+          args: ["--config", "/indexify/config/config.yaml"]
+
+          {{- if  $.Values.blobStore }}
+          volumeMounts:
+            - name: config
+              mountPath: /indexify/config
+              readOnly: true
+            {{- if not $.Values.blobStore.config.s3 }}
+            - name: data
+              mountPath: /tmp/indexify-blob-storage
+            {{- end }}
+          {{- end }}  
+
           env:
             {{- include "blobStore.env" $.Values | nindent 12 }}
-
-          {{- if not $.Values.blobStore.config }}
-          volumeMounts:
-            - mountPath: /tmp/indexify-blob-storage
-              name: data
-          {{- end}}
-
+          
           livenessProbe:
             httpGet:
               path: /
@@ -51,7 +58,12 @@ spec:
               path: /
               port: 8900
 
-  {{- with .persistance }}
+      volumes:
+        - name: config
+          configMap:
+            name: indexify
+
+  {{- with .persistence }}
   volumeClaimTemplates:
   - metadata:
       name: data

--- a/operations/k8s/helm/templates/server.yaml
+++ b/operations/k8s/helm/templates/server.yaml
@@ -34,16 +34,12 @@ spec:
           command: ["indexify-server"]
           args: ["--config", "/indexify/config/config.yaml"]
 
-          {{- if  $.Values.blobStore }}
           volumeMounts:
             - name: config
               mountPath: /indexify/config
               readOnly: true
-            {{- if not $.Values.blobStore.config.s3 }}
             - name: data
-              mountPath: /tmp/indexify-blob-storage
-            {{- end }}
-          {{- end }}  
+              mountPath: /tmp/indexify/state
 
           env:
             {{- include "blobStore.env" $.Values | nindent 12 }}
@@ -61,7 +57,7 @@ spec:
       volumes:
         - name: config
           configMap:
-            name: indexify
+            name: indexify-server
 
   {{- with .persistence }}
   volumeClaimTemplates:

--- a/operations/k8s/helm/values.yaml
+++ b/operations/k8s/helm/values.yaml
@@ -13,7 +13,7 @@ server:
   image: tensorlake/indexify-server:latest
   ingress:
     enabled: false
-  persistance: {}
+  persistence: {}
     # storageClassName: 'local-path'
     # size: 1Gi
 


### PR DESCRIPTION
The pr enables users to set their own configurations via k8s . 

I have focused on enabling to set s3 bucket and region via this and I was able to see the outputs store in s3 which was earlier only storing in disk even tho user sets the s3 config

For testing: I used ```local.yaml``` for installing k8s except the change that I kept 

```yaml 
minio:
    enabled: false
```

and blobstore

```yaml
blobStore:
  allowHTTP: true
  credentialSecret: blob-creds
  config:
    backend: s3
    s3:
      bucket: indexify
      region: us-east-1
      accessKey: 
      secretKey: 
```
