### PR TITLE
feat: add labels to helm chart entities

### DIFF
--- a/operations/k8s/helm/local.yaml
+++ b/operations/k8s/helm/local.yaml
@@ -18,6 +18,8 @@ server:
 
 executors:
   - name: indexify-executor
+    labels:
+      executor-name: default-executor
     image: tensorlake/indexify-executor-default:latest
     replicas: 1
 

--- a/operations/k8s/helm/templates/executor.yaml
+++ b/operations/k8s/helm/templates/executor.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .name | replace "-" "" }}
+  name: {{ .name }}
   labels:
     {{- include "labels" (dict "name" .name "component" "executors" "global" $) | nindent 4 }}
 spec:
@@ -15,9 +15,12 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .name | replace "-" "" }}
+  name: {{ .name }}
   labels:
     {{- include "labels" (dict "name" .name "component" "executors" "global" $) | nindent 4 }}
+    {{- with .labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end}}
 spec:
   replicas: {{ default .replicas 1 }}
   selector:

--- a/operations/k8s/helm/templates/server.yaml
+++ b/operations/k8s/helm/templates/server.yaml
@@ -15,6 +15,9 @@ metadata:
   name: indexify-server
   labels:
     {{- include "labels" (dict "name" "server" "component" "server" "global" $) | nindent 4 }}
+    {{- with .labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end}}
 spec:
   selector:
     matchLabels:
@@ -23,7 +26,9 @@ spec:
     metadata:
       labels:
         {{- include "labels" (dict "name" "server" "component" "server" "global" $) | nindent 8 }}
-
+        {{- with .pod.labels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end}}
     spec:
       {{- if .nodeSelector }}
       nodeSelector:
@@ -57,6 +62,9 @@ spec:
       name: data
       labels:
         {{- include "labels" (dict "name" "server" "component" "server" "global" $) | nindent 8 }}
+        {{- with .labels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       accessModes: [ "ReadWriteOnce" ]
       storageClassName: {{ .storageClassName | default "standard" }}

--- a/operations/k8s/helm/values.yaml
+++ b/operations/k8s/helm/values.yaml
@@ -11,15 +11,20 @@ blobStore:
 
 server:
   image: tensorlake/indexify-server:latest
+  labels: {}
   ingress:
     enabled: false
+  pod: {}
+    # labels: {}
   persistance: {}
+    # labels: {}
     # storageClassName: 'local-path'
     # size: 1Gi
 
 executors:
-  # Executors is 
+  # Executors is
   - name: indexify-executor
+    labels: {}
     image: tensorlake/indexify-executor-default:latest
     replicas: 1
 


### PR DESCRIPTION
## Background

This PR solves the issue raised in https://github.com/tensorlakeai/indexify/issues/929. It adds awareness of labels to the following entities:

1. Indexify server.
2. Any executor.
3. Indexify's server Pod.
4. Indexify's server volume claim.

## Steps to reproduce

1. Modify the `local.yaml` file with any label in any of: `.server.labels`, `.server.pod.labels`, `executors[n].labels`, `.server.persistence.labels`.
2. Run `helm template local -f local.yaml .`