### PR TITLE
fix: creating namespaces with graph

### DIFF
--- a/python-sdk/indexify/http_client.py
+++ b/python-sdk/indexify/http_client.py
@@ -205,6 +205,10 @@ class IndexifyClient:
         # Create a new client instance with the specified server address
         client = cls(service_url=server_addr)
 
+        if namespace in cls.namespaces:
+            client.namespace = namespace
+            return client
+
         try:
             # Create the new namespace using the client
             client.create_namespace(namespace)

--- a/python-sdk/indexify/remote_graph.py
+++ b/python-sdk/indexify/remote_graph.py
@@ -3,7 +3,7 @@ from typing import Any, List, Optional
 from indexify.functions_sdk.graph import Graph
 
 from .http_client import IndexifyClient
-from .settings import DEFAULT_SERVICE_URL
+from .settings import DEFAULT_SERVICE_URL,DEFAULT_NAMESPACE
 
 
 class RemoteGraph:
@@ -11,9 +11,10 @@ class RemoteGraph:
         self,
         name: str,
         server_url: Optional[str] = DEFAULT_SERVICE_URL,
+        namespace: Optional[str] = DEFAULT_NAMESPACE
     ):
         self._name = name
-        self._client = IndexifyClient(service_url=server_url)
+        self._client = IndexifyClient(service_url=server_url).create_namespace(namespace)
 
     def run(self, block_until_done: bool = False, **kwargs) -> str:
         """

--- a/python-sdk/indexify/settings.py
+++ b/python-sdk/indexify/settings.py
@@ -1,2 +1,3 @@
 DEFAULT_SERVICE_URL = "http://localhost:8900"
 DEFAULT_SERVICE_URL_HTTPS = "https://localhost:8900"
+DEFAULT_NAMESPACE = "default"


### PR DESCRIPTION
Users can tell indexify to create namespace when they deploy graph , if its already available it will use that namespace .

Also this fixes indexify not having default namespace when its already using it

closes #928 