### PR TITLE
chore: remove exception_msg from logs API

### DIFF
--- a/python-sdk/indexify/executor/function_worker.py
+++ b/python-sdk/indexify/executor/function_worker.py
@@ -35,7 +35,6 @@ class FunctionOutput(BaseModel):
     router_output: Optional[RouterOutput]
     reducer: bool = False
     success: bool = True
-    exception: Optional[str] = None
     stdout: str = ""
     stderr: str = ""
 
@@ -131,7 +130,6 @@ def _run_function(
     router_output = None
     fn_output = None
     has_failed = False
-    exception_msg = None
     print(
         f"[bold] function_worker: [/bold] invoking function {fn_name} in graph {graph_name}"
     )
@@ -153,10 +151,8 @@ def _run_function(
                 is_reducer = fn.indexify_function.accumulate is not None
         except Exception as e:
             import sys
-
             print(traceback.format_exc(), file=sys.stderr)
             has_failed = True
-            exception_msg = str(e)
 
     # WARNING - IF THIS FAILS, WE WILL NOT BE ABLE TO RECOVER
     # ANY LOGS
@@ -164,7 +160,6 @@ def _run_function(
         return FunctionOutput(
             fn_outputs=None,
             router_output=None,
-            exception=exception_msg,
             stdout=stdout_capture.getvalue(),
             stderr=stderr_capture.getvalue(),
             reducer=is_reducer,

--- a/python-sdk/indexify/executor/task_reporter.py
+++ b/python-sdk/indexify/executor/task_reporter.py
@@ -37,17 +37,6 @@ class TaskReporter:
                 ("node_outputs", (nanoid.generate(), io.BytesIO(output_bytes)))
             )
 
-        if completed_task.errors:
-            print(
-                f"[bold]task-reporter[/bold] uploading error of size: {len(completed_task.errors)}"
-            )
-            fn_outputs.append(
-                (
-                    "exception_msg",
-                    (nanoid.generate(), io.BytesIO(completed_task.errors.encode())),
-                )
-            )
-
         if completed_task.stdout:
             print(
                 f"[bold]task-reporter[/bold] uploading stdout of size: {len(completed_task.stdout)}"

--- a/server/data_model/src/lib.rs
+++ b/server/data_model/src/lib.rs
@@ -252,7 +252,6 @@ pub struct DataPayload {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct TaskDiagnostics {
-    pub exception: Option<DataPayload>,
     pub stdout: Option<DataPayload>,
     pub stderr: Option<DataPayload>,
 }

--- a/server/state_store/src/scanner.rs
+++ b/server/state_store/src/scanner.rs
@@ -341,11 +341,6 @@ impl StateReader {
                             return Ok(Some(stderr));
                         }
                     }
-                    "exception_msg" => {
-                        if let Some(exception_msg) = diagnostics.exception {
-                            return Ok(Some(exception_msg));
-                        }
-                    }
                     _ => {
                         return Err(anyhow::anyhow!("Invalid file type"));
                     }


### PR DESCRIPTION
## Background

The exception_msg is bundled into the graph's stderr. Is not needed to create a new file, or send it with the diagnostics payload.

## How to test this

I tried to make the readme example fail on purpose, but I am seeing these errors in the server's logs

```
2024-10-13T19:15:52.353313Z  INFO state_store::state_machine: Marking invocation finished: default sequence_summer d4ab4d1f48859bff
default|sequence_summer|d4ab4d1f48859bff|generate_numbers
2024-10-13T19:15:52.354043Z ERROR indexify_server::http_objects: API Error: 500 Internal Server Error - diagnostic payload not found
default|sequence_summer|d4ab4d1f48859bff|generate_numbers
2024-10-13T19:15:52.354961Z ERROR indexify_server::http_objects: API Error: 500 Internal Server Error - diagnostic payload not found
```