### PR TITLE
feat: support ingress annotations in the helm chart

### DIFF
--- a/operations/k8s/helm/Chart.lock
+++ b/operations/k8s/helm/Chart.lock
@@ -2,8 +2,5 @@ dependencies:
 - name: minio
   repository: https://charts.min.io/
   version: 5.2.0
-- name: postgresql
-  repository: https://charts.bitnami.com/bitnami
-  version: 15.5.9
-digest: sha256:ee83ff7af660cf54c6334f06256b4eef3028050c289fce1b98fc563e69d4b41a
-generated: "2024-06-23T08:13:06.901871-07:00"
+digest: sha256:d47eef3ed8adcdfbc9fa429591e081aa6f886d68cbb9b27e92e72c2de2aae871
+generated: "2024-10-15T20:15:37.274227+02:00"

--- a/operations/k8s/helm/Chart.yaml
+++ b/operations/k8s/helm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: helm
 description: Indexify
 type: application
-version: 0.1.0
+version: 0.2.0
 
 dependencies:
   - name: minio

--- a/operations/k8s/helm/local.yaml
+++ b/operations/k8s/helm/local.yaml
@@ -7,13 +7,14 @@ blobStore:
     s3:
       bucket: indexify
       region: us-east-1
-      accessKey: 
-      secretKey: 
+      accessKey:
+      secretKey:
 
 server:
   image: tensorlake/indexify-server:latest
   ingress:
     enabled: true
+    annotations: {}
   persistence:
     storageClassName: 'local-path'
     size: 1Gi

--- a/operations/k8s/helm/templates/ingress.yaml
+++ b/operations/k8s/helm/templates/ingress.yaml
@@ -4,6 +4,10 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: ingress
+  {{- if .Values.server.ingress.annotations}}
+  annotations:
+    {{- toYaml .Values.server.ingress.annotations | nindent 4 }}
+  {{- end }}
   labels:
     app.kubernetes.io/component: api
 spec:

--- a/operations/k8s/helm/templates/server.yaml
+++ b/operations/k8s/helm/templates/server.yaml
@@ -43,7 +43,7 @@ spec:
 
           env:
             {{- include "blobStore.env" $.Values | nindent 12 }}
-          
+
           livenessProbe:
             httpGet:
               path: /

--- a/operations/k8s/helm/values.yaml
+++ b/operations/k8s/helm/values.yaml
@@ -1,24 +1,24 @@
 blobStore:
   # allowHTTP: true
   # endpoint: http://blob-store:9000
-  credentialSecret: blob-store
+  credentialSecret: blob-creds
   config:
     backend: s3
     s3: {}
     #  accessKey: null
     #  secretKey: null
 
-
 server:
   image: tensorlake/indexify-server:latest
   ingress:
     enabled: false
+    annotations: {}
   persistence: {}
     # storageClassName: 'local-path'
     # size: 1Gi
 
 executors:
-  # Executors is 
+  # Executors is an array of executor configurations.
   - name: indexify-executor
     image: tensorlake/indexify-executor-default:latest
     replicas: 1


### PR DESCRIPTION
The ingress resource often needs cloud-specific annotations for proper configuration. This PR introduces those.