### PR TITLE
feat: task logs download endpoint

### DIFF
--- a/server/data_model/src/lib.rs
+++ b/server/data_model/src/lib.rs
@@ -538,6 +538,19 @@ impl Task {
         )
     }
 
+    pub fn key_from(
+        namespace: &str,
+        compute_graph: &str,
+        invocation_id: &str,
+        fn_name: &str,
+        id: &str,
+    ) -> String {
+        format!(
+            "{}|{}|{}|{}|{}",
+            namespace, compute_graph, invocation_id, fn_name, id
+        )
+    }
+
     pub fn key_output(&self, output_id: &str) -> String {
         format!("{}|{}|{}", self.namespace, self.id, output_id)
     }

--- a/server/src/routes.rs
+++ b/server/src/routes.rs
@@ -48,7 +48,7 @@ use download::{
 };
 use internal_ingest::ingest_files_from_executor;
 use invoke::{invoke_with_file, invoke_with_object, rerun_compute_graph};
-use logs::download_logs;
+use logs::{download_logs, download_task_logs};
 
 use crate::{
     executors::ExecutorManager,
@@ -216,6 +216,7 @@ pub fn create_routes(route_state: RouteState) -> Router {
             "/namespaces/:namespace/compute_graphs/:compute_graph/invocations/:invocation_id/fn/:fn_name/logs/:file",
             get(download_logs).with_state(route_state.clone()),
         )
+        .route("/namespaces/:namespace/compute_graphs/:compute_graph/invocations/:invocation_id/fn/:fn_name/tasks/:task_id/logs/:file", get(download_task_logs).with_state(route_state.clone()))
         .route(
             "/internal/ingest_files",
             post(ingest_files_from_executor).with_state(route_state.clone()),


### PR DESCRIPTION
# Background

Customers need to download logs from tasks to get better context on how their compute graph finished up. At the moment, they cannot filter logs for a specific task, they need to download for every task in an execution.

This PR introduces the API endpoint to enable this workflow.

## How to reproduce

To reproduce, run:

1. Modify the `examples/readme/workflow.py` by adding some print statements in the indexify functions.
2. Run the workflow with a local revision of the indexify server.
3. Hit the following endpoint: GET - `/namespaces/{namespace}/compute_graphs/{compute_graph}/invocations/{invocation_id}/fn/{fn_name}/tasks/{task_id}/logs/{file}` i.e. `/namespaces/default/compute_graph/sequence_number/invocations/HERE_UUID/fn/add/tasks/HERE_UUID/logs/stdout`.

### Screenshots

![Screenshot from 2024-10-19 20-51-04](https://github.com/user-attachments/assets/3fd4e336-fbea-40a0-8013-64de5c74ca31)
