### PR TITLE
improve error logging

### DIFF
--- a/python-sdk/indexify/executor/runtime_probes.py
+++ b/python-sdk/indexify/executor/runtime_probes.py
@@ -5,7 +5,6 @@ from typing import Any, Dict, Tuple
 
 from pydantic import BaseModel
 
-
 DEFAULT_EXECUTOR = "tensorlake/indexify-executor-default"
 
 

--- a/python-sdk/indexify/functions_sdk/graph_definition.py
+++ b/python-sdk/indexify/functions_sdk/graph_definition.py
@@ -1,7 +1,8 @@
 from typing import Dict, List, Optional
 
-from indexify.functions_sdk.image import ImageInformation
 from pydantic import BaseModel
+
+from indexify.functions_sdk.image import ImageInformation
 
 from .object_serializer import get_serializer
 

--- a/python-sdk/indexify/functions_sdk/image.py
+++ b/python-sdk/indexify/functions_sdk/image.py
@@ -1,5 +1,7 @@
-from pydantic import BaseModel
 from typing import List
+
+from pydantic import BaseModel
+
 
 def python_version_to_image(python_version):
     if python_version.startswith("3.9"):
@@ -49,7 +51,7 @@ class Image:
             image_name=self._image_name,
             tag=self._tag,
             base_image=self._base_image,
-            run_strs=self._run_strs
+            run_strs=self._run_strs,
         )
 
 
@@ -68,4 +70,3 @@ DEFAULT_IMAGE_3_11 = (
     .tag("3.11")
     .run("pip install indexify")
 )
-

--- a/python-sdk/tests/test_functions.py
+++ b/python-sdk/tests/test_functions.py
@@ -20,7 +20,7 @@ class TestFunctionWrapper(unittest.TestCase):
             return "hello"
 
         extractor_wrapper = IndexifyFunctionWrapper(extractor_a)
-        result = extractor_wrapper.run_fn({"url": "foo"})
+        result, err = extractor_wrapper.run_fn({"url": "foo"})
         self.assertEqual(result[0], "hello")
 
     def test_get_output_model(self):
@@ -64,7 +64,7 @@ class TestFunctionWrapper(unittest.TestCase):
             return [func_a]
 
         router_wrapper = IndexifyFunctionWrapper(router_fn)
-        result = router_wrapper.run_router({"url": "foo"})
+        result, err = router_wrapper.run_router({"url": "foo"})
         self.assertEqual(result, ["func_a"])
 
     def test_accumulate(self):
@@ -77,7 +77,7 @@ class TestFunctionWrapper(unittest.TestCase):
             return acc
 
         wrapper = IndexifyFunctionWrapper(accumulate_fn)
-        result = wrapper.run_fn(acc=AccumulatedState(x=12), input={"x": 1})
+        result, err = wrapper.run_fn(acc=AccumulatedState(x=12), input={"x": 1})
         self.assertEqual(result[0].x, 13)
 
     # FIXME: Partial extractor is not working

--- a/python-sdk/tests/test_graph_behaviours.py
+++ b/python-sdk/tests/test_graph_behaviours.py
@@ -193,6 +193,7 @@ class TestGraphBehaviors(unittest.TestCase):
             if x % 2 == 0:
                 return x
             return None
+
         @indexify_function()
         def add_two(x: int) -> int:
             return x + 2


### PR DESCRIPTION
[x ] Run `make fmt`.
[ x] `pip install -e .`, start server and executor, cd to `python-sdk/tests`, `python test_graph_behaviours.py`.


Improved logging to not include indexify_functions related frames in stack trace if user defined function fails. 

Had to remove caching from local execution, have to bring it back again. The code was fragile and I was not able to figure out what was breaking. 

## Before 
```
stderr:
 Traceback (most recent call last):
  File "/private/tmp/ve/lib/python3.11/site-packages/indexify/executor/function_worker.py", line 139, in _run_function
    fn_output = fn.invoke_fn_ser(fn_name, input, init_value)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/private/tmp/ve/lib/python3.11/site-packages/indexify/functions_sdk/indexify_functions.py", line 239, in invoke_fn_ser
    outputs: Optional[List[Any]] = self.run_fn(input, acc=acc)
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/private/tmp/ve/lib/python3.11/site-packages/indexify/functions_sdk/indexify_functions.py", line 220, in run_fn
    extracted_data = self.indexify_function.run(*args, **kwargs)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/private/tmp/ve/lib/python3.11/site-packages/indexify/functions_sdk/indexify_functions.py", line 153, in run
    return fn(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^
  File "/Users/diptanuc/foo.py", line 10, in summarize_text
    from openai import OpenAI
ModuleNotFoundError: No module named 'openai'
```

## After 
```
stderr:
 Traceback (most recent call last):
  File "/Users/diptanuc/foo.py", line 11, in summarize_text
    completion = OpenAI().chat.completions.create(
  File "/Users/diptanuc/Projects/getstarted/ve/lib/python3.10/site-packages/openai/_client.py", line 105, in __init__
    raise OpenAIError(
openai.OpenAIError: The api_key client option must be set either by passing api_key to the client or by setting the OPENAI_API_KEY environment variable
```
