### PR TITLE
feature(api): enforcing namespace existence on all namespaced routes

### DIFF
--- a/server/state_store/src/scanner.rs
+++ b/server/state_store/src/scanner.rs
@@ -423,6 +423,11 @@ impl StateReader {
         .collect::<Result<Vec<(String, V)>, _>>()
     }
 
+    pub fn get_namespace(&self, namespace: &str) -> Result<Option<Namespace>> {
+        let ns = self.get_from_cf(&IndexifyObjectsColumns::Namespaces, namespace)?;
+        Ok(ns)
+    }
+
     pub fn get_all_namespaces(&self) -> Result<Vec<Namespace>> {
         let (namespaces, _) = self.get_rows_from_cf_with_limits::<Namespace>(
             &[],


### PR DESCRIPTION
Fixes https://github.com/tensorlakeai/indexify/issues/928

This PR adds middleware to validate the existence of namespaces for all external API calls under `/namespaces/:namespace/...`. It also automatically creates the default namespace required by the Python SDK on server initialization.

### Initialization
<img width="680" alt="image" src="https://github.com/user-attachments/assets/191aa8e6-0a87-408a-821c-de2bc19333f8">

### API Errors

Note: Server initialization to cause this.

<img width="1048" alt="image" src="https://github.com/user-attachments/assets/32d274d8-775f-4e50-9000-4594c57660ca">

### SDK Error

<img width="1048" alt="image" src="https://github.com/user-attachments/assets/0f067e5f-1fd7-41ac-97d2-d45d80125894">


## Implementation

Adding a middleware to all namespaces routes required nesting them in order to ensure the middleware was only evaluated when needed.

The default namespace creation checks for the existing of the namespace in order to not overwrite an existing default namespace. Overwriting would overwrite the creation time of the namespace.

## Testing



## PR Checks

Note: I also deleted all storage and caches.

[x] Run `make fmt`.
[x] `pip install -e .`, start server and executor, cd to `python-sdk/tests`, `python test_graph_behaviours.py`.
```
Ran 7 tests in 1.667s

OK
```
