### PR TITLE
reporting size of output and showing executor version in UI

### DIFF
--- a/python-sdk/indexify/executor/agent.py
+++ b/python-sdk/indexify/executor/agent.py
@@ -2,6 +2,7 @@ import asyncio
 import json
 import ssl
 from concurrent.futures.process import BrokenProcessPool
+from importlib.metadata import version
 from typing import Dict, List, Optional
 
 import httpx
@@ -314,8 +315,10 @@ class ExtractorAgent:
                 # rewrite the image name
                 pass
 
+            executor_version = version("indexify")
             data = ExecutorMetadata(
                 id=self._executor_id,
+                executor_version=executor_version,
                 addr="",
                 image_name=runtime_probe.image_name,
                 labels=runtime_probe.labels,

--- a/python-sdk/indexify/executor/api_objects.py
+++ b/python-sdk/indexify/executor/api_objects.py
@@ -18,6 +18,7 @@ class Task(BaseModel):
 
 class ExecutorMetadata(BaseModel):
     id: str
+    executor_version: str
     addr: str
     image_name: str
     labels: Dict[str, Any]

--- a/python-sdk/indexify/executor/task_reporter.py
+++ b/python-sdk/indexify/executor/task_reporter.py
@@ -30,7 +30,9 @@ class TaskReporter:
         fn_outputs = []
         for output in completed_task.outputs or []:
             output_bytes = MsgPackSerializer.serialize(output)
-            print(f"[bold]task-reporter[/bold] uploading output of size: {len(output_bytes)}")
+            print(
+                f"[bold]task-reporter[/bold] uploading output of size: {len(output_bytes)} bytes"
+            )
             fn_outputs.append(
                 ("node_outputs", (nanoid.generate(), io.BytesIO(output_bytes)))
             )

--- a/python-sdk/indexify/functions_sdk/graph.py
+++ b/python-sdk/indexify/functions_sdk/graph.py
@@ -96,9 +96,9 @@ class Graph:
             return self
 
         if issubclass(indexify_fn, IndexifyFunction) and indexify_fn.accumulate:
-            self.accumulator_zero_values[
-                indexify_fn.name
-            ] = indexify_fn.accumulate().model_dump()
+            self.accumulator_zero_values[indexify_fn.name] = (
+                indexify_fn.accumulate().model_dump()
+            )
 
         self.nodes[indexify_fn.name] = indexify_fn
         return self

--- a/python-sdk/indexify/functions_sdk/indexify_functions.py
+++ b/python-sdk/indexify/functions_sdk/indexify_functions.py
@@ -206,9 +206,9 @@ class RouterCallResult(BaseModel):
 
 class IndexifyFunctionWrapper:
     def __init__(self, indexify_function: Union[IndexifyFunction, IndexifyRouter]):
-        self.indexify_function: Union[
-            IndexifyFunction, IndexifyRouter
-        ] = indexify_function()
+        self.indexify_function: Union[IndexifyFunction, IndexifyRouter] = (
+            indexify_function()
+        )
 
     def get_output_model(self) -> Any:
         if not isinstance(self.indexify_function, IndexifyFunction):

--- a/python-sdk/pyproject.toml
+++ b/python-sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "indexify"
-version = "0.2.18"
+version = "0.2.19"
 description = "Python Client for Indexify"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 license = "Apache 2.0"

--- a/server/data_model/src/lib.rs
+++ b/server/data_model/src/lib.rs
@@ -669,9 +669,16 @@ impl TaskAnalytics {
     }
 }
 
+// FIXME Remove in next release
+fn default_executor_ver() -> String {
+    "0.2.17".to_string()
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct ExecutorMetadata {
     pub id: ExecutorId,
+    #[serde(default = "default_executor_ver")]
+    pub executor_version: String,
     pub image_name: String,
     pub addr: String,
     pub labels: HashMap<String, serde_json::Value>,

--- a/server/data_model/src/test_objects.rs
+++ b/server/data_model/src/test_objects.rs
@@ -260,6 +260,7 @@ pub mod tests {
     pub fn mock_executor() -> ExecutorMetadata {
         ExecutorMetadata {
             id: mock_executor_id(),
+            executor_version: "1.0.0".to_string(),
             image_name: TEST_EXECUTOR_IMAGE_NAME.to_string(),
             addr: "".to_string(),
             labels: Default::default(),

--- a/server/src/executors.rs
+++ b/server/src/executors.rs
@@ -92,6 +92,7 @@ mod tests {
         let ex = Arc::new(ExecutorManager::new(indexify_state.clone()).await);
         let executor = ExecutorMetadata {
             id: ExecutorId::new("test".to_string()),
+            executor_version: "1.0".to_string(),
             image_name: "test".to_string(),
             addr: "".to_string(),
             labels: Default::default(),
@@ -114,6 +115,7 @@ mod tests {
         let ex = Arc::new(ExecutorManager::new(indexify_state.clone()).await);
         let executor = ExecutorMetadata {
             id: ExecutorId::new("test".to_string()),
+            executor_version: "1.0".to_string(),
             image_name: "test".to_string(),
             addr: "".to_string(),
             labels: Default::default(),

--- a/server/src/http_objects.rs
+++ b/server/src/http_objects.rs
@@ -491,6 +491,7 @@ pub struct InvocationId {
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
 pub struct ExecutorMetadata {
     pub id: String,
+    pub executor_version: String,
     pub addr: String,
     pub image_name: String,
     pub labels: HashMap<String, serde_json::Value>,
@@ -500,6 +501,7 @@ impl From<data_model::ExecutorMetadata> for ExecutorMetadata {
     fn from(executor: data_model::ExecutorMetadata) -> Self {
         Self {
             id: executor.id.to_string(),
+            executor_version: executor.executor_version,
             addr: executor.addr,
             image_name: executor.image_name,
             labels: executor.labels,

--- a/server/src/routes.rs
+++ b/server/src/routes.rs
@@ -246,7 +246,7 @@ pub fn create_routes(route_state: RouteState) -> Router {
                 .on_failure(()),
         )
         .layer(cors)
-        .layer(DefaultBodyLimit::max(usize::MAX))
+        .layer(DefaultBodyLimit::disable())
 }
 
 async fn index() -> &'static str {
@@ -582,6 +582,7 @@ async fn executor_tasks(
         .executor_manager
         .register_executor(data_model::ExecutorMetadata {
             id: executor_id.clone(),
+            executor_version: payload.executor_version.clone(),
             image_name: payload.image_name.clone(),
             addr: payload.addr.clone(),
             labels: payload.labels.clone(),

--- a/server/ui/src/components/cards/ExecutorsCard.tsx
+++ b/server/ui/src/components/cards/ExecutorsCard.tsx
@@ -22,6 +22,7 @@ const ExecutorsCard = ({ executors }: { executors: ExecutorMetadata[] }) => {
             <TableRow>
               <TableCell>Image Name</TableCell>
               <TableCell>ID</TableCell>
+              <TableCell>Version</TableCell>
               <TableCell>Address</TableCell>
               <TableCell>Labels</TableCell>
             </TableRow>
@@ -36,6 +37,7 @@ const ExecutorsCard = ({ executors }: { executors: ExecutorMetadata[] }) => {
                   </Box>
                 </TableCell>
                 <TableCell>{executor.id}</TableCell>
+                <TableCell>{executor.executor_version}</TableCell>
                 <TableCell>{executor.addr}</TableCell>
                 <TableCell>
                   <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>

--- a/server/ui/src/types.ts
+++ b/server/ui/src/types.ts
@@ -97,6 +97,7 @@ export interface ComputeGraphCreateType {
 
 export interface ExecutorMetadata {
   id: string;
+  executor_version: string;
   addr: string;
   image_name: string;
   labels: Record<string, any>;


### PR DESCRIPTION
[ ] Run `make fmt`.
[ ] `pip install -e .`, start server and executor, cd to `python-sdk/tests`, `python test_graph_behaviours.py`.

Tests
```
(ve) ~/indexify$ python python-sdk/tests/test_graph_behaviours.py 
.
----------------------------------------------------------------------
Ran 7 tests in 10.773s
```

Executor Output 
```
task-reporter uploading output of size: 4873 bytes
```

UI
<img width="1448" alt="Screenshot 2024-10-24 at 10 57 10 AM" src="https://github.com/user-attachments/assets/f507d91b-1e9f-4de9-b7e3-51025fe48a32">


