### PR TITLE
feature(sdk): faciliate using namespaces with remote graphs

### DIFF
--- a/python-sdk/indexify/remote_graph.py
+++ b/python-sdk/indexify/remote_graph.py
@@ -11,23 +11,41 @@ class RemoteGraph:
         self,
         name: str,
         server_url: Optional[str] = DEFAULT_SERVICE_URL,
+        client: Optional[IndexifyClient] = None,
     ):
+        """
+        Create a handle to call a RemoteGraph by name.
+
+        Note: Use the class methods RemoteGraph.deploy or RemoteGraph.by_name to create a RemoteGraph object.
+
+        :param name: The name of the graph.
+        :param server_url: The URL of the server where the graph will be registered.
+            Not used if client is provided.
+        :param client: The IndexifyClient used to communicate with the server.
+            Prefered over server_url.
+        """
         self._name = name
-        self._client = IndexifyClient(service_url=server_url)
+        if client:
+            self._client = client
+        else:
+            self._client = IndexifyClient(service_url=server_url)
 
     def run(self, block_until_done: bool = False, **kwargs) -> str:
         """
         Run the graph with the given inputs. The input is for the start function of the graph.
+
         :param block_until_done: If True, the function will block until the graph execution is complete.
         :param kwargs: The input to the start function of the graph. Pass the input as keyword arguments.
         :return: The invocation ID of the graph execution.
 
         Example:
-        @indexify_function()
-        def foo(x: int) -> int:
-            return x + 1
-        remote_graph = RemoteGraph.by_name("test")
-        invocation_id = remote_graph.run(x=1)
+
+            @indexify_function()
+            def foo(x: int) -> int:
+                return x + 1
+
+            remote_graph = RemoteGraph.by_name("test")
+            invocation_id = remote_graph.run(x=1)
         """
         return self._client.invoke_graph_with_object(
             self._name, block_until_done, **kwargs
@@ -36,6 +54,7 @@ class RemoteGraph:
     def rerun(self):
         """
         Rerun the graph with the given invocation ID.
+
         :param invocation_id: The invocation ID of the graph execution.
         """
         self._client.rerun_graph(self._name)
@@ -45,26 +64,38 @@ class RemoteGraph:
         cls,
         g: Graph,
         additional_modules=[],
-        server_url: Optional[str] = "http://localhost:8900",
+        server_url: Optional[str] = DEFAULT_SERVICE_URL,
+        client: Optional[IndexifyClient] = None,
     ):
         """
         Create a new RemoteGraph from a local Graph object.
+
         :param g: The local Graph object.
+        :param additional_modules: List of additional modules to be registered with the graph.
+            Needed for modules that are imported outside of an indexify function.
         :param server_url: The URL of the server where the graph will be registered.
+            Not used if client is provided.
+        :param client: The IndexifyClient used to communicate with the server.
+            Prefered over server_url.
         """
-        client = IndexifyClient(service_url=server_url)
+        if not client:
+            client = IndexifyClient(service_url=server_url)
         client.register_compute_graph(g, additional_modules)
-        return cls(name=g.name, server_url=server_url)
+        return cls(name=g.name, server_url=server_url, client=client)
 
     @classmethod
-    def by_name(cls, name: str, server_url: Optional[str] = "http://localhost:8900"):
+    def by_name(cls, name: str, server_url: Optional[str] = DEFAULT_SERVICE_URL, client: Optional[IndexifyClient] = None):
         """
         Create a handle to call a RemoteGraph by name.
+
         :param name: The name of the graph.
-        :param server_url: The URL of the server where the graph is registered.
+        :param server_url: The URL of the server where the graph will be registered.
+            Not used if client is provided.
+        :param client: The IndexifyClient used to communicate with the server.
+            Prefered over server_url.
         :return: A RemoteGraph object.
         """
-        return cls(name=name, server_url=server_url)
+        return cls(name=name, server_url=server_url, client=client)
 
     def output(
         self,
@@ -72,11 +103,14 @@ class RemoteGraph:
         fn_name: str,
     ) -> List[Any]:
         """
-        Returns the extracted objects by a graph for an ingested object. If the extractor name is provided, only the objects extracted by that extractor are returned.
-        If the extractor name is not provided, all the extracted objects are returned for the input object.
-        invocation_id: str: The ID of the ingested object
-        fn_name: Optional[str]: The name of the function whose output is to be returned if provided
-        return: List[Any]: Output of the function.
+        Returns the extracted objects by a graph for an ingested object.
+ 
+        - If the extractor name is provided, only the objects extracted by that extractor are returned.
+        - If the extractor name is not provided, all the extracted objects are returned for the input object.
+
+        :param invocation_id (str): The ID of the ingested object
+        :param fn_name (Optional[str]): The name of the function whose output is to be returned if provided
+        :return (List[Any]): Output of the function.
         """
 
         return self._client.graph_outputs(


### PR DESCRIPTION
This PR removes the need for any workaround to use namespaces by supporting a `IndexifyClient` in the `RemoteGraph` class methods.

Deploying, Running, Outputting will reuse the same client which can be configured with a namespace.

Some docstring formatting was also done.

# Testing

- [x] Manual testing passing client
	```python
	 client = IndexifyClient(namespace="object_detection")
     g = RemoteGraph.deploy(g, client=client)
    ```
- [x] Manual testing backward compatible
	```python
	g = RemoteGraph.deploy(g)
    ```
- [ ] Run `make fmt`.
  Not needed
- [x] `pip install -e .`, start server and executor, cd to `python-sdk/tests`, `python test_graph_behaviours.py`.

	```
	.
	----------------------------------------------------------------------
	Ran 7 tests in 1.578s
	
	OK
	```