### PR TITLE
Add Image Version to SDK and Server

### DIFF
--- a/python-sdk/indexify/cli.py
+++ b/python-sdk/indexify/cli.py
@@ -170,6 +170,9 @@ def executor(
     name_alias: Optional[str] = typer.Option(
         None, help="Name alias for the executor if it's spun up with the base image"
     ),
+    image_version: Optional[int] = typer.Option(
+        "1", help="Requested Image Version for this executor"
+    ),
 ):
     id = nanoid.generate()
     console.print(
@@ -179,7 +182,8 @@ def executor(
             f"Server address: {server_addr}\n"
             f"Executor ID: {id}\n"
             f"Executor cache: {executor_cache}\n"
-            f"Name Alias: {name_alias}",
+            f"Name Alias: {name_alias}"
+            f"Image Version: {image_version}\n",
             title="Agent Configuration",
             border_style="info",
         )
@@ -201,6 +205,7 @@ def executor(
         config_path=config_path,
         code_path=executor_cache,
         name_alias=name_alias,
+        image_version=image_version,
     )
 
     try:

--- a/python-sdk/indexify/executor/agent.py
+++ b/python-sdk/indexify/executor/agent.py
@@ -64,8 +64,10 @@ class ExtractorAgent:
         server_addr: str = "localhost:8900",
         config_path: Optional[str] = None,
         name_alias: Optional[str] = None,
+        image_version: Optional[int] = None,
     ):
         self.name_alias = name_alias
+        self.image_version = image_version
 
         self._probe = RuntimeProbes()
 
@@ -195,7 +197,7 @@ class ExtractorAgent:
                             task, self._protocol, self._server_addr
                         )
                         image_dependency_installer.executor_image_builder(
-                            image_info, self.name_alias
+                            image_info, self.name_alias, self.image_version
                         )
                         self._require_image_bootstrap = False
                     except Exception as e:
@@ -378,11 +380,18 @@ class ExtractorAgent:
                 else runtime_probe.image_name
             )
 
+            image_version: int = (
+                self.image_version
+                if self.image_version is not None
+                else runtime_probe.image_version
+            )
+
             data = ExecutorMetadata(
                 id=self._executor_id,
                 executor_version=executor_version,
                 addr="",
                 image_name=image_name,
+                image_version=image_version,
                 labels=runtime_probe.labels,
             ).model_dump()
 

--- a/python-sdk/indexify/executor/api_objects.py
+++ b/python-sdk/indexify/executor/api_objects.py
@@ -21,6 +21,7 @@ class ExecutorMetadata(BaseModel):
     executor_version: str
     addr: str
     image_name: str
+    image_version: int
     labels: Dict[str, Any]
 
 

--- a/python-sdk/indexify/executor/image_dependency_installer.py
+++ b/python-sdk/indexify/executor/image_dependency_installer.py
@@ -28,6 +28,7 @@ def _record_image_name(name: str):
     with open(file_path, "w") as file:
         file.write(name)
 
+
 def _record_image_version(version: int):
     dir_path = os.path.expanduser("~/.indexify/")
     file_path = os.path.expanduser("~/.indexify/image_version")
@@ -44,7 +45,9 @@ def _install_dependencies(run_str: str):
         raise Exception(f"Unable to install dep `{run_str}`")
 
 
-def executor_image_builder(image_info: ImageInformation, name_alias: str, image_version: int):
+def executor_image_builder(
+    image_info: ImageInformation, name_alias: str, image_version: int
+):
     console.print(Text("Attempting Executor Bootstrap.", style="red bold"))
 
     run_strs = image_info.run_strs
@@ -56,6 +59,11 @@ def executor_image_builder(image_info: ImageInformation, name_alias: str, image_
 
     console.print(Text("Install dependencies done.", style="red bold"))
 
-    console.print(Text(f"Recording image name {name_alias} and version {image_version}", style="red bold"))
+    console.print(
+        Text(
+            f"Recording image name {name_alias} and version {image_version}",
+            style="red bold",
+        )
+    )
     _record_image_name(name_alias)
     _record_image_version(image_version)

--- a/python-sdk/indexify/executor/image_dependency_installer.py
+++ b/python-sdk/indexify/executor/image_dependency_installer.py
@@ -20,20 +20,16 @@ custom_theme = Theme(
 console = Console(theme=custom_theme)
 
 
-def _record_image_name(name: str):
+def _record_image_name(name: str, version: int):
     dir_path = os.path.expanduser("~/.indexify/")
+
     file_path = os.path.expanduser("~/.indexify/image_name")
     os.makedirs(dir_path, exist_ok=True)
-
     with open(file_path, "w") as file:
         file.write(name)
 
-
-def _record_image_version(version: int):
-    dir_path = os.path.expanduser("~/.indexify/")
     file_path = os.path.expanduser("~/.indexify/image_version")
     os.makedirs(dir_path, exist_ok=True)
-
     with open(file_path, "w") as file:
         file.write(str(version))
 
@@ -65,5 +61,5 @@ def executor_image_builder(
             style="red bold",
         )
     )
-    _record_image_name(name_alias)
-    _record_image_version(image_version)
+
+    _record_image_name(name_alias, image_version)

--- a/python-sdk/indexify/executor/image_dependency_installer.py
+++ b/python-sdk/indexify/executor/image_dependency_installer.py
@@ -28,6 +28,14 @@ def _record_image_name(name: str):
     with open(file_path, "w") as file:
         file.write(name)
 
+def _record_image_version(version: int):
+    dir_path = os.path.expanduser("~/.indexify/")
+    file_path = os.path.expanduser("~/.indexify/image_version")
+    os.makedirs(dir_path, exist_ok=True)
+
+    with open(file_path, "w") as file:
+        file.write(str(version))
+
 
 def _install_dependencies(run_str: str):
     # Throw error to the caller if these subprocesses fail.
@@ -36,7 +44,7 @@ def _install_dependencies(run_str: str):
         raise Exception(f"Unable to install dep `{run_str}`")
 
 
-def executor_image_builder(image_info: ImageInformation, name_alias: str):
+def executor_image_builder(image_info: ImageInformation, name_alias: str, image_version: int):
     console.print(Text("Attempting Executor Bootstrap.", style="red bold"))
 
     run_strs = image_info.run_strs
@@ -48,5 +56,6 @@ def executor_image_builder(image_info: ImageInformation, name_alias: str):
 
     console.print(Text("Install dependencies done.", style="red bold"))
 
-    console.print(Text(f"Recording image name {name_alias}", style="red bold"))
+    console.print(Text(f"Recording image name {name_alias} and version {image_version}", style="red bold"))
     _record_image_name(name_alias)
+    _record_image_version(image_version)

--- a/python-sdk/indexify/executor/runtime_probes.py
+++ b/python-sdk/indexify/executor/runtime_probes.py
@@ -6,10 +6,12 @@ from typing import Any, Dict, Tuple
 from pydantic import BaseModel
 
 DEFAULT_EXECUTOR = "tensorlake/indexify-executor-default"
+DEFAULT_VERSION = 1
 
 
 class ProbeInfo(BaseModel):
     image_name: str
+    image_version: int
     python_major_version: int
     labels: Dict[str, Any] = {}
     is_default_executor: bool
@@ -18,6 +20,7 @@ class ProbeInfo(BaseModel):
 class RuntimeProbes:
     def __init__(self) -> None:
         self._image_name = self._read_image_name()
+        self._image_version = self._read_image_version()
         self._os_name = platform.system()
         self._architecture = platform.machine()
         (
@@ -31,6 +34,13 @@ class RuntimeProbes:
             with open(file_path, "r") as file:
                 return file.read().strip()
         return DEFAULT_EXECUTOR
+
+    def _read_image_version(self) -> int:
+        file_path = os.path.expanduser("~/.indexify/image_version")
+        if os.path.exists(file_path):
+            with open(file_path, "r") as file:
+                return int(file.read().strip())
+        return DEFAULT_VERSION
 
     def _get_python_version(self) -> Tuple[int, int]:
         version_info = sys.version_info

--- a/python-sdk/indexify/executor/runtime_probes.py
+++ b/python-sdk/indexify/executor/runtime_probes.py
@@ -60,6 +60,7 @@ class RuntimeProbes:
 
         return ProbeInfo(
             image_name=self._image_name,
+            image_version=self._image_version,
             python_major_version=self._python_version_major,
             labels=labels,
             is_default_executor=self._is_default_executor(),

--- a/python-sdk/indexify/executor/task_reporter.py
+++ b/python-sdk/indexify/executor/task_reporter.py
@@ -32,7 +32,7 @@ class TaskReporter:
             print(
                 f"[bold]task-reporter[/bold] uploading output of size: {len(output.payload)} bytes"
             )
-            output_bytes = MsgPackSerializer.serialize(output) 
+            output_bytes = MsgPackSerializer.serialize(output)
             fn_outputs.append(
                 ("node_outputs", (nanoid.generate(), io.BytesIO(output_bytes)))
             )

--- a/python-sdk/indexify/remote_graph.py
+++ b/python-sdk/indexify/remote_graph.py
@@ -84,7 +84,12 @@ class RemoteGraph:
         return cls(name=g.name, server_url=server_url, client=client)
 
     @classmethod
-    def by_name(cls, name: str, server_url: Optional[str] = DEFAULT_SERVICE_URL, client: Optional[IndexifyClient] = None):
+    def by_name(
+        cls,
+        name: str,
+        server_url: Optional[str] = DEFAULT_SERVICE_URL,
+        client: Optional[IndexifyClient] = None,
+    ):
         """
         Create a handle to call a RemoteGraph by name.
 
@@ -104,7 +109,7 @@ class RemoteGraph:
     ) -> List[Any]:
         """
         Returns the extracted objects by a graph for an ingested object.
- 
+
         - If the extractor name is provided, only the objects extracted by that extractor are returned.
         - If the extractor name is not provided, all the extracted objects are returned for the input object.
 

--- a/python-sdk/tests/image_bootstraper_test/test_graph_image_version.py
+++ b/python-sdk/tests/image_bootstraper_test/test_graph_image_version.py
@@ -1,0 +1,80 @@
+import unittest
+
+from indexify.functions_sdk.image import Image
+from pydantic import BaseModel
+from indexify import indexify_function, Graph, RemoteGraph
+from typing import List
+
+
+"""
+## What is this test?
+- This test is to verify that updating an existing graph (ie. version bump)
+doesn't break functionality. We want to test if the executor placement
+constraint is being honoured.
+
+## How to run this test
+- Make sure python version in executor and cli works.
+- Alias the executors,
+```
+docker run --network host -it indexify-python-sdk-dev indexify-cli executor \
+--name-alias tensorlake/indexify-executor-default --image-version 1
+```
+
+- Remove the local server cache (or name the graph to something else)
+
+- Check the executor log for the installation.
+- Check that the output is val[30].
+- Verify that the
+
+- Modify the run string for the method (see commented out images below)
+- Alias the executor with a version +1
+- Return the test to pass like above.
+- Repeat
+"""
+
+# Use default image
+# image1 = Image().name("tensorlake/indexify-executor-default")
+# image1 = Image().name("tensorlake/indexify-executor-default").run("ls /")
+# image1 = Image().name("tensorlake/indexify-executor-default").run("ls /one")
+
+
+class Total(BaseModel):
+    val: int = 0
+
+
+@indexify_function(image=image1)
+def generate_numbers(a: int) -> List[int]:
+    return [i for i in range(a)]
+
+
+@indexify_function(image=image1)
+def square(x: int) -> int:
+    return x**2
+
+
+@indexify_function(accumulate=Total, image=image1)
+def add(total: Total, new: int) -> Total:
+    total.val += new
+    return total
+
+
+class TestGraphImageBuilderWorking(unittest.TestCase):
+
+    def test_install_working_dependency(self):
+        g = Graph(
+            name="sequence_summer7",
+            start_node=generate_numbers,
+            description="Simple Sequence Summer",
+        )
+
+        g.add_edge(generate_numbers, square)
+        g.add_edge(square, add)
+
+        RemoteGraph.deploy(g)
+        graph = RemoteGraph.by_name("sequence_summer7")
+        invocation_id = graph.run(block_until_done=True, a=5)
+        assert graph.output(invocation_id, "add")[0].val == 30
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python-sdk/tests/image_bootstraper_test/test_graph_image_version.py
+++ b/python-sdk/tests/image_bootstraper_test/test_graph_image_version.py
@@ -35,7 +35,7 @@ docker run --network host -it indexify-python-sdk-dev indexify-cli executor \
 # Use default image
 # image1 = Image().name("tensorlake/indexify-executor-default")
 # image1 = Image().name("tensorlake/indexify-executor-default").run("ls /")
-# image1 = Image().name("tensorlake/indexify-executor-default").run("ls /one")
+image1 = Image().name("tensorlake/indexify-executor-default").run("ls /one")
 
 
 class Total(BaseModel):

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -637,6 +637,7 @@ dependencies = [
  "rand",
  "serde",
  "serde_json",
+ "sha2",
  "uuid",
 ]
 

--- a/server/data_model/Cargo.toml
+++ b/server/data_model/Cargo.toml
@@ -13,3 +13,4 @@ serde_json = { workspace = true }
 indexify_utils = { workspace = true }
 rand = {workspace=true}
 uuid = {workspace=true}
+sha2 = {workspace=true}

--- a/server/data_model/src/lib.rs
+++ b/server/data_model/src/lib.rs
@@ -86,7 +86,7 @@ pub struct ImageInformation {
     pub base_image: String,
     pub run_strs: Vec<String>,
     pub image_hash: String,
-    pub version: ImageVersion, // this maps with image_hash
+    pub version: ImageVersion, // this gets updated when the hash changes
 }
 
 impl ImageInformation {
@@ -95,7 +95,7 @@ impl ImageInformation {
         image_hasher.update(image_name.clone());
         image_hasher.update(tag.clone());
         image_hasher.update(base_image.clone());
-        image_hasher.update(run_strs.clone().join("-----"));
+        image_hasher.update(run_strs.clone().join(""));
 
         ImageInformation {
             image_name,

--- a/server/data_model/src/lib.rs
+++ b/server/data_model/src/lib.rs
@@ -173,6 +173,17 @@ impl Node {
         }
     }
 
+    pub fn image_version_assign(&mut self, image_version: u32) {
+        match self {
+            Node::Router(ref mut router) => {
+                router.image_information.version = ImageVersion(image_version);
+            }
+            Node::Compute(compute) => {
+                compute.image_information.version = ImageVersion(image_version);
+            }
+        }
+    }
+
     pub fn image_version_assign_next(&mut self) {
         match self {
             Node::Router(router) => {

--- a/server/data_model/src/test_objects.rs
+++ b/server/data_model/src/test_objects.rs
@@ -61,17 +61,14 @@ pub mod tests {
                     image_information,
                     ..Default::default()
                 }
-            },
-            _ => {
-                ComputeFn {
-                    name: name.to_string(),
-                    description: format!("description {}", name),
-                    fn_name: name.to_string(),
-                    image_name: TEST_EXECUTOR_IMAGE_NAME.to_string(),
-                    ..Default::default()
-                }
             }
-
+            _ => ComputeFn {
+                name: name.to_string(),
+                description: format!("description {}", name),
+                fn_name: name.to_string(),
+                image_name: TEST_EXECUTOR_IMAGE_NAME.to_string(),
+                ..Default::default()
+            },
         }
     }
 

--- a/server/data_model/src/test_objects.rs
+++ b/server/data_model/src/test_objects.rs
@@ -47,18 +47,36 @@ pub mod tests {
             .unwrap()
     }
 
-    fn test_compute_fn(name: &str) -> ComputeFn {
-        ComputeFn {
-            name: name.to_string(),
-            description: format!("description {}", name),
-            fn_name: name.to_string(),
-            image_name: TEST_EXECUTOR_IMAGE_NAME.to_string(),
-            ..Default::default()
+    fn test_compute_fn(name: &str, image_hash: Option<String>) -> ComputeFn {
+        match image_hash {
+            Some(image_hash) => {
+                let mut image_information = ImageInformation::default();
+                image_information.image_hash = image_hash.to_string();
+
+                ComputeFn {
+                    name: name.to_string(),
+                    description: format!("description {}", name),
+                    fn_name: name.to_string(),
+                    image_name: TEST_EXECUTOR_IMAGE_NAME.to_string(),
+                    image_information,
+                    ..Default::default()
+                }
+            },
+            _ => {
+                ComputeFn {
+                    name: name.to_string(),
+                    description: format!("description {}", name),
+                    fn_name: name.to_string(),
+                    image_name: TEST_EXECUTOR_IMAGE_NAME.to_string(),
+                    ..Default::default()
+                }
+            }
+
         }
     }
 
     fn reducer_fn(name: &str, reduce: bool) -> ComputeFn {
-        let mut compute_fn = test_compute_fn(name);
+        let mut compute_fn = test_compute_fn(name, None);
         compute_fn.reducer = reduce;
         compute_fn
     }
@@ -141,10 +159,11 @@ pub mod tests {
             .unwrap()
     }
 
-    pub fn mock_graph_a() -> ComputeGraph {
-        let fn_a = test_compute_fn("fn_a");
-        let fn_b = test_compute_fn("fn_b");
-        let fn_c = test_compute_fn("fn_c");
+    pub fn mock_graph_a(image_hash: Option<String>) -> ComputeGraph {
+        let fn_a = test_compute_fn("fn_a", image_hash.clone());
+        let fn_b = test_compute_fn("fn_b", image_hash.clone());
+        let fn_c = test_compute_fn("fn_c", image_hash.clone());
+
         ComputeGraph {
             namespace: TEST_NAMESPACE.to_string(),
             name: "graph_A".to_string(),
@@ -174,7 +193,7 @@ pub mod tests {
     }
 
     pub fn mock_graph_b() -> ComputeGraph {
-        let fn_a = test_compute_fn("fn_a");
+        let fn_a = test_compute_fn("fn_a", None);
         let router_x = DynamicEdgeRouter {
             name: "router_x".to_string(),
             description: "description router_x".to_string(),
@@ -191,10 +210,12 @@ pub mod tests {
                     "run 2".to_string(),
                     "run 3".to_string(),
                 ],
+                image_hash: "".to_string(),
+                version: Default::default(),
             },
         };
-        let fn_b = test_compute_fn("fn_b");
-        let fn_c = test_compute_fn("fn_c");
+        let fn_b = test_compute_fn("fn_b", None);
+        let fn_c = test_compute_fn("fn_c", None);
         ComputeGraph {
             namespace: TEST_NAMESPACE.to_string(),
             name: "graph_B".to_string(),
@@ -222,9 +243,9 @@ pub mod tests {
     }
 
     pub fn mock_graph_with_reducer() -> ComputeGraph {
-        let fn_a = test_compute_fn("fn_a");
+        let fn_a = test_compute_fn("fn_a", None);
         let fn_b = reducer_fn("fn_b", true);
-        let fn_c = test_compute_fn("fn_c");
+        let fn_c = test_compute_fn("fn_c", None);
         ComputeGraph {
             namespace: TEST_NAMESPACE.to_string(),
             name: "graph_R".to_string(),
@@ -264,6 +285,7 @@ pub mod tests {
             image_name: TEST_EXECUTOR_IMAGE_NAME.to_string(),
             addr: "".to_string(),
             labels: Default::default(),
+            image_version: 1,
         }
     }
 }

--- a/server/src/executors.rs
+++ b/server/src/executors.rs
@@ -94,6 +94,7 @@ mod tests {
             id: ExecutorId::new("test".to_string()),
             executor_version: "1.0".to_string(),
             image_name: "test".to_string(),
+            image_version: 1,
             addr: "".to_string(),
             labels: Default::default(),
         };
@@ -117,6 +118,7 @@ mod tests {
             id: ExecutorId::new("test".to_string()),
             executor_version: "1.0".to_string(),
             image_name: "test".to_string(),
+            image_version: 0,
             addr: "".to_string(),
             labels: Default::default(),
         };

--- a/server/src/gc.rs
+++ b/server/src/gc.rs
@@ -105,7 +105,7 @@ mod tests {
             info!("garbage collector shutdown");
         });
         // Create a compute graph
-        let compute_graph = mock_graph_a();
+        let compute_graph = mock_graph_a(None);
         state
             .write(StateMachineUpdateRequest {
                 payload: RequestPayload::CreateComputeGraph(CreateComputeGraphRequest {

--- a/server/src/http_objects.rs
+++ b/server/src/http_objects.rs
@@ -105,12 +105,12 @@ impl fmt::Debug for ImageInformation {
 
 impl From<ImageInformation> for data_model::ImageInformation {
     fn from(value: ImageInformation) -> Self {
-        data_model::ImageInformation {
-            image_name: value.image_name,
-            tag: value.tag,
-            base_image: value.base_image,
-            run_strs: value.run_strs,
-        }
+        data_model::ImageInformation::new(
+            value.image_name,
+            value.tag,
+            value.base_image,
+            value.run_strs,
+        )
     }
 }
 
@@ -494,6 +494,7 @@ pub struct ExecutorMetadata {
     pub executor_version: String,
     pub addr: String,
     pub image_name: String,
+    pub image_version: u32,
     pub labels: HashMap<String, serde_json::Value>,
 }
 
@@ -504,6 +505,7 @@ impl From<data_model::ExecutorMetadata> for ExecutorMetadata {
             executor_version: executor.executor_version,
             addr: executor.addr,
             image_name: executor.image_name,
+            image_version: executor.image_version,
             labels: executor.labels,
         }
     }

--- a/server/src/routes.rs
+++ b/server/src/routes.rs
@@ -636,6 +636,7 @@ async fn executor_tasks(
             image_name: payload.image_name.clone(),
             addr: payload.addr.clone(),
             labels: payload.labels.clone(),
+            image_version: payload.image_version,
         })
         .await;
     if let Err(e) = err {

--- a/server/src/system_tasks.rs
+++ b/server/src/system_tasks.rs
@@ -218,7 +218,7 @@ mod tests {
         let scheduler = Scheduler::new(state.clone());
         let mut executor = SystemTasksExecutor::new(state.clone(), shutdown_rx);
 
-        let graph = mock_graph_a();
+        let graph = mock_graph_a(None);
         let cg_request = CreateComputeGraphRequest {
             namespace: graph.namespace.clone(),
             compute_graph: graph.clone(),
@@ -566,7 +566,7 @@ mod tests {
         let scheduler = Scheduler::new(state.clone());
         let mut executor = SystemTasksExecutor::new(state.clone(), shutdown_rx);
 
-        let graph = mock_graph_a();
+        let graph = mock_graph_a(None);
         let cg_request = CreateComputeGraphRequest {
             namespace: graph.namespace.clone(),
             compute_graph: graph.clone(),

--- a/server/state_store/src/lib.rs
+++ b/server/state_store/src/lib.rs
@@ -718,24 +718,28 @@ mod tests {
         assert_eq!(nodes["fn_b"].image_hash(), "Old Hash");
         assert_eq!(nodes["fn_c"].image_hash(), "Old Hash");
 
-        // Update the graph
-        let compute_graph = mock_graph_a(Some("this is a new hash".to_string()));
-        _write_to_test_state_store(&indexify_state, compute_graph).await?;
+        for i in 2..4 {
+            // Update the graph
+            let new_hash = format!("this is a new hash {}", i);
+            let compute_graph = mock_graph_a(Some(new_hash.clone()));
 
-        // Read it again
-        let compute_graphs = _read_cgs_from_state_store(&indexify_state);
+            _write_to_test_state_store(&indexify_state, compute_graph).await?;
 
-        // Verify the name is the same. Verify the version is different.
-        assert!(compute_graphs.iter().any(|cg| cg.name == "graph_A"));
-        // println!("compute graph {:?}", compute_graphs[0]);
-        let nodes = &compute_graphs[0].nodes;
-        assert_eq!(nodes["fn_a"].image_hash(), "this is a new hash");
-        assert_eq!(nodes["fn_b"].image_hash(), "this is a new hash");
-        assert_eq!(nodes["fn_c"].image_hash(), "this is a new hash");
+            // Read it again
+            let compute_graphs = _read_cgs_from_state_store(&indexify_state);
 
-        assert_eq!(*nodes["fn_a"].image_version(), 2);
-        assert_eq!(*nodes["fn_b"].image_version(), 2);
-        assert_eq!(*nodes["fn_c"].image_version(), 2);
+            // Verify the name is the same. Verify the version is different.
+            assert!(compute_graphs.iter().any(|cg| cg.name == "graph_A"));
+            // println!("compute graph {:?}", compute_graphs[0]);
+            let nodes = &compute_graphs[0].nodes;
+            assert_eq!(nodes["fn_a"].image_hash(), new_hash.clone());
+            assert_eq!(nodes["fn_b"].image_hash(), new_hash.clone());
+            assert_eq!(nodes["fn_c"].image_hash(), new_hash.clone());
+
+            assert_eq!(*nodes["fn_a"].image_version(), i);
+            assert_eq!(*nodes["fn_b"].image_version(), i);
+            assert_eq!(*nodes["fn_c"].image_version(), i);
+        }
 
         Ok(())
     }

--- a/server/state_store/src/lib.rs
+++ b/server/state_store/src/lib.rs
@@ -595,6 +595,7 @@ pub fn task_stream(state: Arc<IndexifyState>, executor: ExecutorId, limit: usize
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
+
     use data_model::{
         test_objects::tests::{create_mock_task, mock_graph_a, TEST_NAMESPACE},
         ComputeGraph,
@@ -866,7 +867,10 @@ mod tests {
         compute_graphs
     }
 
-    async fn _write_to_test_state_store(indexify_state: &Arc<IndexifyState>, compute_graph: ComputeGraph) -> Result<()> {
+    async fn _write_to_test_state_store(
+        indexify_state: &Arc<IndexifyState>,
+        compute_graph: ComputeGraph,
+    ) -> Result<()> {
         indexify_state
             .write(StateMachineUpdateRequest {
                 payload: RequestPayload::CreateComputeGraph(CreateComputeGraphRequest {
@@ -874,6 +878,7 @@ mod tests {
                     compute_graph: compute_graph.clone(),
                 }),
                 state_changes_processed: vec![],
-            }).await
+            })
+            .await
     }
 }

--- a/server/state_store/src/state_machine.rs
+++ b/server/state_store/src/state_machine.rs
@@ -392,13 +392,15 @@ pub(crate) fn create_or_update_compute_graph(
         }
 
         for (node_name, node) in compute_graph.nodes.iter_mut() {
+            let existing_node = existing_compute_graph.nodes.get(node_name).unwrap();
+
             let existing_hash = existing_compute_graph
                 .nodes
                 .get(node_name)
                 .unwrap()
                 .image_hash();
             if node.image_hash() != existing_hash {
-                node.image_version_assign_next();
+                node.image_version_assign(existing_node.image_version() + 1);
             }
         }
     };

--- a/server/state_store/src/state_machine.rs
+++ b/server/state_store/src/state_machine.rs
@@ -1,4 +1,5 @@
 use std::{collections::HashMap, sync::Arc, vec};
+
 use anyhow::{anyhow, Result};
 use data_model::{
     ChangeType,

--- a/server/state_store/src/state_machine.rs
+++ b/server/state_store/src/state_machine.rs
@@ -397,10 +397,17 @@ pub(crate) fn create_or_update_compute_graph(
             let existing_hash = existing_compute_graph
                 .nodes
                 .get(node_name)
-                .unwrap()
+                .ok_or_else(|| {
+                    anyhow!(
+                        "unable to find function {} in graph {}",
+                        node_name,
+                        compute_graph.name
+                    )
+                })?
                 .image_hash();
+
             if node.image_hash() != existing_hash {
-                node.image_version_assign(existing_node.image_version() + 1);
+                node.set_image_version(existing_node.clone().image_version_next());
             }
         }
     };

--- a/server/state_store/src/state_machine.rs
+++ b/server/state_store/src/state_machine.rs
@@ -1,5 +1,4 @@
 use std::{collections::HashMap, sync::Arc, vec};
-
 use anyhow::{anyhow, Result};
 use data_model::{
     ChangeType,
@@ -372,7 +371,7 @@ pub(crate) fn delete_input_data_object(
     Ok(())
 }
 
-pub(crate) fn create_compute_graph(
+pub(crate) fn create_or_update_compute_graph(
     db: Arc<TransactionDB>,
     mut compute_graph: ComputeGraph,
 ) -> Result<()> {
@@ -389,6 +388,17 @@ pub(crate) fn create_compute_graph(
             compute_graph.start_fn != existing_compute_graph.start_fn
         {
             compute_graph.version = existing_compute_graph.version.next();
+        }
+
+        for (node_name, node) in compute_graph.nodes.iter_mut() {
+            let existing_hash = existing_compute_graph
+                .nodes
+                .get(node_name)
+                .unwrap()
+                .image_hash();
+            if node.image_hash() != existing_hash {
+                node.image_version_assign_next();
+            }
         }
     };
 

--- a/server/state_store/src/test_state_store.rs
+++ b/server/state_store/src/test_state_store.rs
@@ -47,7 +47,7 @@ pub mod tests {
         pub async fn with_simple_graph(&self) -> String {
             let cg_request = CreateComputeGraphRequest {
                 namespace: TEST_NAMESPACE.to_string(),
-                compute_graph: tests::mock_graph_a(),
+                compute_graph: tests::mock_graph_a(None),
             };
             self.indexify_state
                 .write(StateMachineUpdateRequest {

--- a/server/task_scheduler/src/lib.rs
+++ b/server/task_scheduler/src/lib.rs
@@ -117,7 +117,7 @@ impl TaskScheduler {
                 continue;
             }
 
-            if node.matches_executor(executor) {
+            if node.matches_executor(executor, &mut diagnostic_msgs) {
                 filtered_executors.push(executor.id.clone());
             }
         }


### PR DESCRIPTION
Add support for Image Version. Change SDK API to accept the new param on the executor. Change default value for probe. Setup ExecutorMetadata with the new param. Change Server API and Data Model for the new param. Add image hash and version bump logic to state store. Add unit test.

[x] Run `make fmt`.
[x] `pip install -e .`, start server and executor, cd to `python-sdk/tests`, `python test_graph_behaviours.py`.

Tested with then new test file using 3 aliased executors.