### PR TITLE
update agent and http client to show errors in response

### DIFF
--- a/python-sdk/indexify/executor/agent.py
+++ b/python-sdk/indexify/executor/agent.py
@@ -419,13 +419,14 @@ class ExtractorAgent:
                         json=data,
                         headers={"Content-Type": "application/json"},
                     ) as event_source:
+                        if not event_source.response.is_success:
+                            resp = await event_source.response.aread().decode('utf-8')
+                            console.print(f"failed to register: {str(resp)}")
+                            await asyncio.sleep(5)
+                            continue
                         console.print(
                             Text("executor registered successfully", style="bold green")
                         )
-                        if not event_source.response.is_success:
-                            console.print(f"failed to register: {event_source.response.text}")
-                            await asyncio.sleep(5)
-                            continue
                         async for sse in event_source.aiter_sse():
                             data = json.loads(sse.data)
                             tasks = []

--- a/python-sdk/indexify/executor/agent.py
+++ b/python-sdk/indexify/executor/agent.py
@@ -422,6 +422,10 @@ class ExtractorAgent:
                         console.print(
                             Text("executor registered successfully", style="bold green")
                         )
+                        if not event_source.response.is_success:
+                            console.print(f"failed to register: {event_source.response.text}")
+                            await asyncio.sleep(5)
+                            continue
                         async for sse in event_source.aiter_sse():
                             data = json.loads(sse.data)
                             tasks = []

--- a/python-sdk/indexify/http_client.py
+++ b/python-sdk/indexify/http_client.py
@@ -268,6 +268,8 @@ class IndexifyClient:
                 data=ser_input,
                 params=params,
             ) as event_source:
+                if not event_source.response.is_success:
+                    raise Exception(f"failed to invoke graph: {event_source.response.text}")
                 for sse in event_source.iter_sse():
                     obj = json.loads(sse.data)
                     for k, v in obj.items():

--- a/python-sdk/indexify/http_client.py
+++ b/python-sdk/indexify/http_client.py
@@ -269,7 +269,8 @@ class IndexifyClient:
                 params=params,
             ) as event_source:
                 if not event_source.response.is_success:
-                    raise Exception(f"failed to invoke graph: {event_source.response.text}")
+                    resp = event_source.response.read().decode("utf-8")
+                    raise Exception(f"failed to invoke graph: {resp}")
                 for sse in event_source.iter_sse():
                     obj = json.loads(sse.data)
                     for k, v in obj.items():


### PR DESCRIPTION
We should now see the actual errors from the http responses when SSE based calls fails and not see the cryptic Content Type should be event stream. 

Tested this by forcing the server to return an exception - 

```
File "/Users/diptanuc/Projects/indexify/python-sdk/ve/lib/python3.12/site-packages/indexify/http_client.py", line 273, in invoke_graph_with_object
    raise Exception(f"failed to invoke graph: {resp}")
Exception: failed to invoke graph: not implemented 111
```

[x] Run `make fmt`.
[x] `pip install -e .`, start server and executor, cd to `python-sdk/tests`, `python test_graph_behaviours.py`.
