### PR TITLE
feature: replay_running graph status field

### DIFF
--- a/.github/workflows/acceptance_tests.yaml
+++ b/.github/workflows/acceptance_tests.yaml
@@ -31,22 +31,13 @@ jobs:
               - 'python-sdk/**'
               - '.github/**'
 
-  test:
-    name: Run Tests
+  build:
+    name: Build
     needs: changes
     if: ${{ needs.changes.outputs.indexify == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      #   - name: Update APT package list
-      # run: sudo apt-get update || true # skip errors as temp workaround for https://github.com/tensorlakeai/indexify/actions/runs/8814655533/job/24194983960#step:3:33
-      - name: Install poetry
-        run: pipx install poetry
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: 3.11
-          cache: 'poetry'
       - name: Copy rust-toolchain
         run: cp server/rust-toolchain.toml .
       - name: Setup Rust
@@ -54,20 +45,44 @@ jobs:
         with:
           cache-directories: |
             server/target
-      - name: Install python dependencies
-        run: |
-          cd python-sdk
-          poetry install
       - name: Build indexify-server
         run: |
           cd server
           cargo build
+      - name: Upload indexify-server
+        uses: actions/upload-artifact@v4
+        with:
+          name: indexify-server
+          path: server/target/debug/indexify-server
+
+  local_acceptance_tests:
+    name: Run Local Acceptance Tests
+    needs: [changes, build]
+    if: ${{ needs.changes.outputs.indexify == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Download indexify-server
+        uses: actions/download-artifact@v4
+        with:
+          name: indexify-server
+      - name: Install poetry
+        run: pipx install poetry
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.11
+          cache: 'poetry'
+      - name: Install python dependencies
+        run: |
+          cd python-sdk
+          poetry install
       - name: Start Background Indexify Server
         uses: JarvusInnovations/background-action@v1
         with:
           run: |
-            cd server
-            RUST_LOG=debug cargo run &
+            chmod u+x ./indexify-server
+            RUST_LOG=debug ./indexify-server &
 
           wait-on: |
             tcp:localhost:8900
@@ -111,10 +126,116 @@ jobs:
                 sleep 5
             fi
           done
-      - name: Run Acceptance Tests
+
+      - name: Run Acceptance Tests (graph behaviours)
         run: |
           cd python-sdk
           export INDEXIFY_URL=http://localhost:8900
           poetry run python tests/test_graph_behaviours.py
+
+      - name: Run Acceptance Tests (update)
+        run: |
+          cd python-sdk
+          export INDEXIFY_URL=http://localhost:8900
           poetry run python tests/test_graph_update.py
+
+      - name: Run Acceptance Tests (validation)
+        run: |
+          cd python-sdk
+          export INDEXIFY_URL=http://localhost:8900
+          poetry run python tests/test_graph_validation.py
+
+  latest_release_acceptance_tests:
+    name: Run Latest Acceptance Tests
+    needs: [changes, build]
+    if: ${{ needs.changes.outputs.indexify == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Checkout latest
+        run: |
+          git fetch --tags
+          latestTag=$(git describe --tags "$(git rev-list --tags --max-count=1)")
+          git checkout $latestTag
+      - name: Download indexify-server
+        uses: actions/download-artifact@v4
+        with:
+          name: indexify-server
+      - name: Install poetry
+        run: pipx install poetry
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.11
+          cache: 'poetry'
+      - name: Install python dependencies
+        run: |
+          cd python-sdk
+          poetry install
+      - name: Start Background Indexify Server
+        uses: JarvusInnovations/background-action@v1
+        with:
+          run: |
+            chmod u+x ./indexify-server
+            RUST_LOG=debug ./indexify-server &
+
+          wait-on: |
+            tcp:localhost:8900
+
+          tail: true
+          wait-for: 30s
+          log-output: true
+          # always logging the output to debug test failures.
+          log-output-if: true
+      - name: Start Background Indexify Executor
+        uses: JarvusInnovations/background-action@v1
+        with:
+          run: |
+            cd python-sdk
+            poetry run indexify-cli executor &
+
+          wait-on: |
+            tcp:localhost:8900
+
+          tail: true
+          wait-for: 10s
+          log-output: true
+          # always logging the output to debug test failures.
+          log-output-if: true
+      - name: Wait for readiness
+        run: |
+          serverReady=false
+          counter=0
+          while [ "$serverReady" != true ]; do
+            output=$(curl --silent --fail http://localhost:8900/internal/executors | jq '. | length' 2>/dev/null)
+            if [[ $? -eq 0 && "$output" -ge 1 ]]; then
+                echo "Server ready with executors."
+                serverReady=true
+            else
+                echo 'Waiting for executors to join server...'
+                counter=$((counter+1))
+                if [ $counter -gt 6 ]; then
+                    echo "Timeout waiting for executors to join server."
+                    exit 1
+                fi
+                sleep 5
+            fi
+          done
+
+      - name: Run Acceptance Tests (graph behaviours)
+        run: |
+          cd python-sdk
+          export INDEXIFY_URL=http://localhost:8900
+          poetry run python tests/test_graph_behaviours.py
+
+      - name: Run Acceptance Tests (update)
+        run: |
+          cd python-sdk
+          export INDEXIFY_URL=http://localhost:8900
+          poetry run python tests/test_graph_update.py
+
+      - name: Run Acceptance Tests (validation)
+        run: |
+          cd python-sdk
+          export INDEXIFY_URL=http://localhost:8900
           poetry run python tests/test_graph_validation.py

--- a/python-sdk/Makefile
+++ b/python-sdk/Makefile
@@ -5,8 +5,8 @@ build:
 	@poetry build
 
 fmt:
-	black .
-	isort . --profile black
+	@poetry run black .
+	@poetry run isort . --profile black
 
 lint:
 	@poetry run pylint ./indexify

--- a/python-sdk/indexify/executor/function_worker.py
+++ b/python-sdk/indexify/executor/function_worker.py
@@ -15,10 +15,10 @@ from indexify.functions_sdk.data_objects import (
 from indexify.functions_sdk.indexify_functions import (
     FunctionCallResult,
     GraphInvocationContext,
-    IndexifyFunctionWrapper,
-    RouterCallResult,
-    IndexifyRouter,
     IndexifyFunction,
+    IndexifyFunctionWrapper,
+    IndexifyRouter,
+    RouterCallResult,
 )
 
 function_wrapper_map: Dict[str, IndexifyFunctionWrapper] = {}

--- a/python-sdk/indexify/functions_sdk/graph_definition.py
+++ b/python-sdk/indexify/functions_sdk/graph_definition.py
@@ -46,6 +46,7 @@ class ComputeGraphMetadata(BaseModel):
     edges: Dict[str, List[str]]
     accumulator_zero_values: Dict[str, bytes] = {}
     runtime_information: RuntimeInformation
+    replay_running: bool = False
 
     def get_input_payload_serializer(self):
         return get_serializer(self.start_node.compute_fn.encoder)

--- a/python-sdk/indexify/http_client.py
+++ b/python-sdk/indexify/http_client.py
@@ -197,6 +197,22 @@ class IndexifyClient:
         response = self._get(f"namespaces/{self.namespace}/compute_graphs/{name}")
         return ComputeGraphMetadata(**response.json())
 
+    def delete_graph(
+        self,
+        graph_name: str,
+    ) -> None:
+        """
+        Deletes a graph and all of its invocations from the namespace.
+
+        :param graph_name The name of the graph to delete.
+
+        WARNING: This operation is irreversible.
+        """
+        response = self._delete(
+            f"namespaces/{self.namespace}/compute_graphs/{graph_name}",
+        )
+        response.raise_for_status()
+
     def load_fn(self, name: str, fn_name: str) -> IndexifyFunction:
         response = self._get(
             f"internal/namespaces/{self.namespace}/compute_graphs/{name}/code"
@@ -265,8 +281,14 @@ class IndexifyClient:
             print(f"failed to fetch logs: {e}")
             return None
 
-    def rerun_graph(self, graph: str):
-        self._post(f"namespaces/{self.namespace}/compute_graphs/{graph}/rerun")
+    def replay_invocations(self, graph: str):
+        """
+        Replay all the invocations on the latest version of the graph.
+
+        This is useful to make all the previous input data go through
+        an updated graph.
+        """
+        self._post(f"namespaces/{self.namespace}/compute_graphs/{graph}/replay")
 
     def invoke_graph_with_object(
         self, graph: str, block_until_done: bool = False, **kwargs

--- a/python-sdk/indexify/remote_graph.py
+++ b/python-sdk/indexify/remote_graph.py
@@ -1,6 +1,6 @@
 from typing import Any, List, Optional
 
-from indexify.functions_sdk.graph import Graph
+from indexify.functions_sdk.graph import ComputeGraphMetadata, Graph
 
 from .http_client import IndexifyClient
 from .settings import DEFAULT_SERVICE_URL
@@ -51,13 +51,20 @@ class RemoteGraph:
             self._name, block_until_done, **kwargs
         )
 
-    def rerun(self):
+    def replay_runs(self):
         """
-        Rerun the graph with the given invocation ID.
+        Replay all the graph runs on the latest version of the graph.
 
-        :param invocation_id: The invocation ID of the graph execution.
+        This is useful to make all the previous input data go through
+        an updated graph.
         """
-        self._client.rerun_graph(self._name)
+        self._client.replay_invocations(self._name)
+
+    def metadata(self) -> ComputeGraphMetadata:
+        """
+        Get the metadata of the graph.
+        """
+        return self._client.graph(self._name)
 
     @classmethod
     def deploy(

--- a/python-sdk/tests/test_function_worker.py
+++ b/python-sdk/tests/test_function_worker.py
@@ -1,3 +1,4 @@
+import sys
 import tempfile
 import unittest
 from typing import List, Mapping, Union
@@ -12,7 +13,6 @@ from indexify.functions_sdk.indexify_functions import (
     IndexifyFunctionWrapper,
     indexify_function,
 )
-import sys
 
 
 @indexify_function()
@@ -75,7 +75,9 @@ class TestFunctionWorker(unittest.IsolatedAsyncioTestCase):
 
     async def test_function_worker_happy_path(self):
         with tempfile.NamedTemporaryFile(delete=True) as temp_file:
-            code_bytes = cloudpickle.dumps(self.g.serialize(additional_modules=[sys.modules[__name__]]))
+            code_bytes = cloudpickle.dumps(
+                self.g.serialize(additional_modules=[sys.modules[__name__]])
+            )
 
             temp_file.write(code_bytes)
             temp_file.flush()

--- a/python-sdk/tests/test_graph_behaviours.py
+++ b/python-sdk/tests/test_graph_behaviours.py
@@ -221,7 +221,6 @@ class TestGraphBehaviors(unittest.TestCase):
         output = graph.output(invocation_id, "simple_function")
         self.assertEqual(output, [MyObject(x="ab")])
 
-    @parameterized.expand([(False), (True)])
     def test_simple_function_in_namespace(self):
         graph = Graph(
             name="test_simple_function", description="test", start_node=simple_function

--- a/python-sdk/tests/test_graph_behaviours.py
+++ b/python-sdk/tests/test_graph_behaviours.py
@@ -2,15 +2,14 @@ import sys
 import unittest
 from pathlib import Path
 from typing import List, Union
+
 from parameterized import parameterized
-
-
 from pydantic import BaseModel
 
 from indexify import (
     Graph,
-    IndexifyFunction,
     IndexifyClient,
+    IndexifyFunction,
     Pipeline,
     RemoteGraph,
     RemotePipeline,

--- a/python-sdk/tests/test_graph_update.py
+++ b/python-sdk/tests/test_graph_update.py
@@ -3,7 +3,7 @@ import unittest
 
 from pydantic import BaseModel
 
-from indexify import RemoteGraph, IndexifyClient
+from indexify import IndexifyClient, RemoteGraph
 from indexify.functions_sdk.graph import Graph
 from indexify.functions_sdk.indexify_functions import indexify_function
 

--- a/server/data_model/src/lib.rs
+++ b/server/data_model/src/lib.rs
@@ -330,11 +330,17 @@ pub struct ComputeGraph {
     pub nodes: HashMap<String, Node>,
     pub edges: HashMap<String, Vec<String>>,
     pub runtime_information: RuntimeInformation,
+    #[serde(default)]
+    pub replay_running: bool,
 }
 
 impl ComputeGraph {
     pub fn key(&self) -> String {
-        format!("{}|{}", self.namespace, self.name)
+        ComputeGraph::key_from(&self.namespace, &self.name)
+    }
+
+    pub fn key_from(namespace: &str, name: &str) -> String {
+        format!("{}|{}", namespace, name)
     }
 }
 

--- a/server/data_model/src/test_objects.rs
+++ b/server/data_model/src/test_objects.rs
@@ -187,6 +187,7 @@ pub mod tests {
                 major_version: 3,
                 minor_version: 10,
             },
+            replay_running: false,
         }
     }
 
@@ -237,6 +238,7 @@ pub mod tests {
                 major_version: 3,
                 minor_version: 10,
             },
+            replay_running: false,
         }
     }
 
@@ -269,6 +271,7 @@ pub mod tests {
                 major_version: 3,
                 minor_version: 10,
             },
+            replay_running: false,
         }
     }
 

--- a/server/src/http_objects.rs
+++ b/server/src/http_objects.rs
@@ -276,7 +276,7 @@ pub struct ComputeGraph {
     #[serde(default = "get_epoch_time_in_ms")]
     pub created_at: u64,
     pub runtime_information: RuntimeInformation,
-    #[serde(default)]
+    #[serde(default, skip_deserializing)]
     pub replay_running: bool,
 }
 

--- a/server/src/http_objects.rs
+++ b/server/src/http_objects.rs
@@ -276,6 +276,8 @@ pub struct ComputeGraph {
     #[serde(default = "get_epoch_time_in_ms")]
     pub created_at: u64,
     pub runtime_information: RuntimeInformation,
+    #[serde(default)]
+    pub replay_running: bool,
 }
 
 impl ComputeGraph {
@@ -306,6 +308,7 @@ impl ComputeGraph {
             edges: self.edges.clone(),
             created_at: 0,
             runtime_information: self.runtime_information.into(),
+            replay_running: false,
         };
         Ok(compute_graph)
     }
@@ -331,6 +334,7 @@ impl From<data_model::ComputeGraph> for ComputeGraph {
             edges: compute_graph.edges,
             created_at: compute_graph.created_at,
             runtime_information: compute_graph.runtime_information.into(),
+            replay_running: compute_graph.replay_running,
         }
     }
 }

--- a/server/src/routes.rs
+++ b/server/src/routes.rs
@@ -61,7 +61,7 @@ use download::{
     download_invocation_payload,
 };
 use internal_ingest::ingest_files_from_executor;
-use invoke::{invoke_with_file, invoke_with_object, rerun_compute_graph};
+use invoke::{invoke_with_file, invoke_with_object, replay_compute_graph};
 use logs::download_task_logs;
 
 use crate::{
@@ -289,8 +289,8 @@ pub fn namespace_routes(route_state: RouteState) -> Router {
             post(invoke_with_object).with_state(route_state.clone()),
         )
         .route(
-            "/compute_graphs/:compute_graph/rerun",
-            post(rerun_compute_graph).with_state(route_state.clone()),
+            "/compute_graphs/:compute_graph/replay",
+            post(replay_compute_graph).with_state(route_state.clone()),
         )
         .route(
             "/compute_graphs/:compute_graph/invocations/:invocation_id",

--- a/server/src/routes/invoke.rs
+++ b/server/src/routes/invoke.rs
@@ -14,8 +14,8 @@ use state_store::{
     invocation_events::{InvocationFinishedEvent, InvocationStateChangeEvent},
     requests::{
         InvokeComputeGraphRequest,
+        ReplayComputeGraphRequest,
         RequestPayload,
-        RerunComputeGraphRequest,
         StateMachineUpdateRequest,
     },
 };
@@ -234,10 +234,10 @@ pub async fn invoke_with_object(
     )
 }
 
-/// Rerun compute graph with all existing payloads
+/// Replay compute graph with all existing payloads
 #[utoipa::path(
     post,
-    path = "/namespaces/{namespace}/compute_graphs/{compute_graph}/rerun",
+    path = "/namespaces/{namespace}/compute_graphs/{compute_graph}/replay",
     request_body(content_type = "application/json", content = inline(serde_json::Value)),
     tag = "ingestion",
     responses(
@@ -246,11 +246,11 @@ pub async fn invoke_with_object(
         (status = INTERNAL_SERVER_ERROR, description = "Internal Server Error")
     ),
 )]
-pub async fn rerun_compute_graph(
+pub async fn replay_compute_graph(
     Path((namespace, compute_graph)): Path<(String, String)>,
     State(state): State<RouteState>,
 ) -> Result<(), IndexifyAPIError> {
-    let request = RequestPayload::RerunComputeGraph(RerunComputeGraphRequest {
+    let request = RequestPayload::ReplayComputeGraph(ReplayComputeGraphRequest {
         namespace: namespace.clone(),
         compute_graph_name: compute_graph.clone(),
     });
@@ -262,7 +262,7 @@ pub async fn rerun_compute_graph(
         })
         .await
         .map_err(|e| {
-            IndexifyAPIError::internal_error(anyhow!("failed to create graph rerun task: {}", e))
+            IndexifyAPIError::internal_error(anyhow!("failed to create graph replay task: {}", e))
         })?;
     Ok(())
 }

--- a/server/state_store/src/lib.rs
+++ b/server/state_store/src/lib.rs
@@ -178,15 +178,11 @@ impl IndexifyState {
                 )?;
                 state_changes
             }
-            requests::RequestPayload::RerunComputeGraph(rerun_compute_graph_request) => {
-                tracing::info!(
-                    "rerun compute graph: {:?}",
-                    rerun_compute_graph_request.compute_graph_name
-                );
-                state_machine::rerun_compute_graph(
+            requests::RequestPayload::ReplayComputeGraph(replay_compute_graph_request) => {
+                state_machine::replay_compute_graph(
                     self.db.clone(),
                     &txn,
-                    rerun_compute_graph_request.clone(),
+                    replay_compute_graph_request.clone(),
                 )?;
                 let _ = self.system_tasks_tx.send(());
                 vec![]
@@ -207,11 +203,11 @@ impl IndexifyState {
                 )?;
                 vec![]
             }
-            requests::RequestPayload::RerunInvocation(rerun_invocation_request) => {
-                let mut state_changes = state_machine::rerun_invocation(
+            requests::RequestPayload::ReplayInvocation(replay_invocation_request) => {
+                let mut state_changes = state_machine::replay_invocation(
                     self.db.clone(),
                     &txn,
-                    rerun_invocation_request.clone(),
+                    replay_invocation_request.clone(),
                 )?;
                 for state_change in &mut state_changes {
                     let last_change_id = self
@@ -244,6 +240,7 @@ impl IndexifyState {
             requests::RequestPayload::CreateComputeGraph(req) => {
                 state_machine::create_or_update_compute_graph(
                     self.db.clone(),
+                    &txn,
                     req.compute_graph.clone(),
                 )?;
                 vec![]

--- a/server/state_store/src/requests.rs
+++ b/server/state_store/src/requests.rs
@@ -19,8 +19,8 @@ pub struct StateMachineUpdateRequest {
 
 pub enum RequestPayload {
     InvokeComputeGraph(InvokeComputeGraphRequest),
-    RerunComputeGraph(RerunComputeGraphRequest),
-    RerunInvocation(RerunInvocationRequest),
+    ReplayComputeGraph(ReplayComputeGraphRequest),
+    ReplayInvocation(ReplayInvocationRequest),
     FinalizeTask(FinalizeTaskRequest),
     CreateNameSpace(NamespaceRequest),
     CreateComputeGraph(CreateComputeGraphRequest),
@@ -48,7 +48,7 @@ pub struct RemoveSystemTaskRequest {
 }
 
 #[derive(Debug, Clone)]
-pub struct RerunInvocationRequest {
+pub struct ReplayInvocationRequest {
     pub namespace: String,
     pub compute_graph_name: String,
     pub graph_version: GraphVersion,
@@ -75,7 +75,7 @@ pub struct InvokeComputeGraphRequest {
 }
 
 #[derive(Debug, Clone)]
-pub struct RerunComputeGraphRequest {
+pub struct ReplayComputeGraphRequest {
     pub namespace: String,
     pub compute_graph_name: String,
 }


### PR DESCRIPTION
In this PR, we are exposing whether a graph replay (previously rerun) is running or not.

We are also renaming `rerun` to `replay` to reduce confusion between the `run` function and the previous `rerun` function.

The `RemoteGraph` method to trigger a replay is now called `replay_runs` and the `IndexifyClient` method is now called `replay_invocations`. To respect existing naming conventions differences in these two areas.

This enables:
```py
...
g.replay_runs()
i = 0
while g.metadata().replay_running:
    time.sleep(2)
output = g.output(invocation_id, fn_name="fn_name")
```

Full example:

<details>
<summary>Details</summary>

```py
import time

from pydantic import BaseModel

from indexify import RemoteGraph, IndexifyClient
from indexify.functions_sdk.graph import Graph
from indexify.functions_sdk.indexify_functions import indexify_function


class Object(BaseModel):
    x: str


@indexify_function()
def update(x: Object) -> Object:
    return Object(x=x.x + "b")


@indexify_function()
def update2(x: Object) -> Object:
    time.sleep(2)
    return Object(x=x.x + "c")


graph_name = "updategraph1"

g = Graph(name=graph_name, start_node=update)
g = RemoteGraph.deploy(g)

invocation_id = g.run(block_until_done=True, x=Object(x="a"))
output = g.output(invocation_id, fn_name="update")
self.assertEqual(output[0], Object(x="ab"))

g = Graph(name=graph_name, start_node=update2)
g = RemoteGraph.deploy(g)

g.replay_runs()
i = 0
while g.metadata().replay_running:
    time.sleep(2)
output = g.output(invocation_id, fn_name="update2")
self.assertEqual(output[0], Object(x="ac"))
```
</details>

## Testing

The `test_graph_update.py` file is now taking advantage of this new capability.

[x] Run `make fmt`.
[x] `pip install -e .`, start server and executor, cd to `python-sdk/tests`, `python test_graph_behaviours.py`.
