### PR TITLE
chore: append task's exception to stderr

### DIFF
--- a/python-sdk/indexify/executor/agent.py
+++ b/python-sdk/indexify/executor/agent.py
@@ -18,7 +18,6 @@ from rich.theme import Theme
 from indexify.functions_sdk.data_objects import (
     FunctionWorkerOutput,
     IndexifyData,
-    RouterOutput,
 )
 from indexify.functions_sdk.graph_definition import ComputeGraphMetadata
 from indexify.http_client import IndexifyClient
@@ -315,7 +314,7 @@ class ExtractorAgent:
                             task=async_task.task,
                             task_outcome="failure",
                             outputs=[],
-                            errors=str(async_task.exception()),
+                            stderr=str(async_task.exception()),
                         )
                         self._task_store.complete(outcome=completed_task)
                         continue
@@ -332,7 +331,6 @@ class ExtractorAgent:
                             task_outcome=task_outcome,
                             outputs=outputs.fn_outputs,
                             router_output=outputs.router_output,
-                            errors=outputs.exception,
                             stdout=outputs.stdout,
                             stderr=outputs.stderr,
                             reducer=outputs.reducer,

--- a/python-sdk/indexify/executor/function_worker.py
+++ b/python-sdk/indexify/executor/function_worker.py
@@ -178,7 +178,6 @@ def _run_function(
                 if router_call_result.traceback_msg is not None:
                     print(router_call_result.traceback_msg, file=sys.stderr)
                     has_failed = True
-                    stderr_capture.write(router_call_result.traceback_msg)
             else:
                 fn_call_result: FunctionCallResult = fn.invoke_fn_ser(
                     fn_name, input, init_value

--- a/python-sdk/indexify/executor/function_worker.py
+++ b/python-sdk/indexify/executor/function_worker.py
@@ -110,7 +110,6 @@ class FunctionWorker:
             # TODO - bring back running in a separate process
         except Exception as e:
             return FunctionWorkerOutput(
-                exception=str(e),
                 stdout=e.stdout,
                 stderr=e.stderr,
                 reducer=e.is_reducer,
@@ -120,7 +119,6 @@ class FunctionWorker:
         return FunctionWorkerOutput(
             fn_outputs=result.fn_outputs,
             router_output=result.router_output,
-            exception=result.exception,
             stdout=result.stdout,
             stderr=result.stderr,
             reducer=result.reducer,
@@ -187,7 +185,6 @@ def _run_function(
                 if fn_call_result.traceback_msg is not None:
                     print(fn_call_result.traceback_msg, file=sys.stderr)
                     has_failed = True
-                    stderr_capture.write(fn_call_result.traceback_msg)
         except Exception:
             print(traceback.format_exc(), file=sys.stderr)
             has_failed = True

--- a/python-sdk/indexify/executor/task_reporter.py
+++ b/python-sdk/indexify/executor/task_reporter.py
@@ -37,17 +37,6 @@ class TaskReporter:
                 ("node_outputs", (nanoid.generate(), io.BytesIO(output_bytes)))
             )
 
-        if completed_task.errors:
-            print(
-                f"[bold]task-reporter[/bold] uploading error of size: {len(completed_task.errors)}"
-            )
-            fn_outputs.append(
-                (
-                    "exception_msg",
-                    (nanoid.generate(), io.BytesIO(completed_task.errors.encode())),
-                )
-            )
-
         if completed_task.stdout:
             print(
                 f"[bold]task-reporter[/bold] uploading stdout of size: {len(completed_task.stdout)}"

--- a/python-sdk/indexify/executor/task_store.py
+++ b/python-sdk/indexify/executor/task_store.py
@@ -14,7 +14,6 @@ class CompletedTask(BaseModel):
     task_outcome: Literal["success", "failure"]
     outputs: Optional[List[IndexifyData]] = None
     router_output: Optional[RouterOutput] = None
-    errors: Optional[str] = None
     stdout: Optional[str] = None
     stderr: Optional[str] = None
     reducer: bool = False

--- a/python-sdk/indexify/functions_sdk/data_objects.py
+++ b/python-sdk/indexify/functions_sdk/data_objects.py
@@ -23,7 +23,6 @@ class IndexifyData(BaseModel):
 class FunctionWorkerOutput(BaseModel):
     fn_outputs: Optional[List[IndexifyData]]
     router_output: Optional[RouterOutput]
-    exception: Optional[str]
     stdout: Optional[str]
     stderr: Optional[str]
     reducer: bool = False

--- a/server/data_model/src/lib.rs
+++ b/server/data_model/src/lib.rs
@@ -352,7 +352,6 @@ pub struct DataPayload {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct TaskDiagnostics {
-    pub exception: Option<DataPayload>,
     pub stdout: Option<DataPayload>,
     pub stderr: Option<DataPayload>,
 }

--- a/server/state_store/src/scanner.rs
+++ b/server/state_store/src/scanner.rs
@@ -379,7 +379,7 @@ impl StateReader {
     pub fn get_unprocessed_state_changes(&self) -> Result<Vec<StateChange>> {
         let cf = IndexifyObjectsColumns::UnprocessedStateChanges.cf_db(&self.db);
         let iter = self.db.iterator_cf(&cf, IteratorMode::Start);
-    let mut state_changes = Vec::new();
+        let mut state_changes = Vec::new();
         let mut count = 0;
         for kv in iter {
             if let Ok((_, serialized_sc)) = kv {

--- a/server/state_store/src/scanner.rs
+++ b/server/state_store/src/scanner.rs
@@ -379,7 +379,7 @@ impl StateReader {
     pub fn get_unprocessed_state_changes(&self) -> Result<Vec<StateChange>> {
         let cf = IndexifyObjectsColumns::UnprocessedStateChanges.cf_db(&self.db);
         let iter = self.db.iterator_cf(&cf, IteratorMode::Start);
-        let mut state_changes = Vec::new();
+    let mut state_changes = Vec::new();
         let mut count = 0;
         for kv in iter {
             if let Ok((_, serialized_sc)) = kv {

--- a/server/state_store/src/state_machine.rs
+++ b/server/state_store/src/state_machine.rs
@@ -464,7 +464,6 @@ pub fn delete_compute_graph(
         match &value.diagnostics {
             Some(diagnostics) => {
                 [
-                    diagnostics.exception.clone(),
                     diagnostics.stdout.clone(),
                     diagnostics.stderr.clone(),
                 ]

--- a/server/state_store/src/state_machine.rs
+++ b/server/state_store/src/state_machine.rs
@@ -463,21 +463,18 @@ pub fn delete_compute_graph(
         // mark all diagnostics urls for gc.
         match &value.diagnostics {
             Some(diagnostics) => {
-                [
-                    diagnostics.stdout.clone(),
-                    diagnostics.stderr.clone(),
-                ]
-                .iter()
-                .flatten()
-                .try_for_each(|data| -> Result<()> {
-                    txn.put_cf(
-                        &IndexifyObjectsColumns::GcUrls.cf_db(&db),
-                        data.path.as_bytes(),
-                        [],
-                    )?;
+                [diagnostics.stdout.clone(), diagnostics.stderr.clone()]
+                    .iter()
+                    .flatten()
+                    .try_for_each(|data| -> Result<()> {
+                        txn.put_cf(
+                            &IndexifyObjectsColumns::GcUrls.cf_db(&db),
+                            data.path.as_bytes(),
+                            [],
+                        )?;
 
-                    Ok(())
-                })?;
+                        Ok(())
+                    })?;
             }
             None => {}
         }


### PR DESCRIPTION
The following changes have been made:

1. **Function Worker Refactor**: The handling and storage of exception messages have been removed from the function worker. Errors are now directed straight to the stderr output, enhancing the clarity of error reporting and streamlining the function execution flow.

2. **Task Diagnostics Improvement**: In the task diagnostics process, references to the `exception_msg` have been eliminated. The focus is now solely on `stdout` and `stderr`, leading to a more concise data payload. This adjustment simplifies the code structure and improves the clarity of diagnostics.

These modifications enhance the overall error handling process, making it more straightforward while reducing unnecessary complexity in the implementation. 

## Checklist

- [x] Run `make fmt`.
- [x] `pip install -e .`, start server and executor, cd to `python-sdk/tests`, `python test_graph_behaviours.py`.

### Results from test_graph_behaviours

----------------------------------------------------------------------
Ran 8 tests in 1.601s

OK

### Running a failing example

![image](https://github.com/user-attachments/assets/0fc80064-42db-4aba-bc5f-35db81d4116d)

![image](https://github.com/user-attachments/assets/3ca5b98c-be98-4f0e-9d0e-b74bb73d9816)

