### PR TITLE
bug(blob): fix support for AWS environment variables

### DIFF
--- a/server/blob_store/src/lib.rs
+++ b/server/blob_store/src/lib.rs
@@ -105,11 +105,13 @@ impl BlobStorage {
                 for (key, value) in opts.iter() {
                     s3_builder = s3_builder.with_config(*key, value.clone());
                 }
-                let s3_builder = s3_builder.with_conditional_put(S3ConditionalPut::Dynamo(DynamoCommit::new(
-                    ddb_table.unwrap(),
-                ))).build()
-                .expect("failed to create object store");
-                let(_, path) = parse_url_opts(url, opts)?;
+                let s3_builder = s3_builder
+                    .with_conditional_put(S3ConditionalPut::Dynamo(DynamoCommit::new(
+                        ddb_table.unwrap(),
+                    )))
+                    .build()
+                    .expect("failed to create object store");
+                let (_, path) = parse_url_opts(url, opts)?;
                 Ok((Box::new(s3_builder), path))
             }
             _ => Ok(parse_url(url)?),

--- a/server/sample_config.yaml
+++ b/server/sample_config.yaml
@@ -1,0 +1,7 @@
+state_store_path: indexify_server_state 
+listen_addr: 0.0.0.0:8900
+blob_storage:
+  path: "s3://indexifyblobs"
+  dynamodb_table: kvs_cas_table 
+
+

--- a/server/src/gc.rs
+++ b/server/src/gc.rs
@@ -93,8 +93,10 @@ mod tests {
         let state = IndexifyState::new(temp_dir.path().join("state"))
             .await
             .unwrap();
-        let config =
-            blob_store::BlobStorageConfig::new(temp_dir.path().join("blob").to_str().unwrap());
+        let config = blob_store::BlobStorageConfig::new(
+            temp_dir.path().join("blob").to_str().unwrap(),
+            None,
+        );
         let storage = Arc::new(BlobStorage::new(config)?);
         let (tx, rx) = watch::channel(());
         let mut gc = Gc::new(state.clone(), storage.clone(), rx);

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -37,6 +37,6 @@ async fn main() {
     };
     let service = Service::new(config);
     if let Err(err) = service.start().await {
-        error!("Error starting service: {}", err);
+        error!("Error starting service: {:?}", err);
     }
 }


### PR DESCRIPTION
## Context

<!--
In a few sentences or less, please explain the context behind this change to help answer why this change is needed.

If this is a bug fix, make sure to include "fixes #xxxx", or
"closes #xxxx".

Screenshots, logs, code or other visual aids are greatly appreciated.
 -->

https://github.com/tensorlakeai/indexify/pull/990 changed how blob_storage was configured. Doing so it made the S3 support default to instance metadata authentication.

## What

<!--
In a few sentences, please summarize the change to help reviewers.

Consider providing screenshots, logs, code or other visual aids to help the reviewer understand the approach taken.
-->

- Injecting AWS_ environment variables in config to support credential auth.
- Using the same object_store for blob and kvs storage
- Using a child key to the specify the kv storage path.

## Testing

<!--
Please include steps used to verify the change.

Consider providing screenshots, logs, code or other visual aids to help the reviewer in their testing.
-->

TODO

## Contribution Checklist

- [ ] If the python-sdk was changed, please run `make fmt` in `python-sdk/`.
- [ ] If the server was changed, please run `make fmt` in `server/`.
- [ ] Make sure all PR Checks are passing.
<!-- You can run the tests manually:
In `python-sdk/`, run the run `pip install -e .`, start the server and executor, `python test_graph_behaviours.py`.

