### PR TITLE
reading api key from environment variable

### DIFF
--- a/.github/workflows/acceptance_tests.yaml
+++ b/.github/workflows/acceptance_tests.yaml
@@ -114,6 +114,7 @@ jobs:
       - name: Run Acceptance Tests
         run: |
           cd python-sdk
+          export INDEXIFY_URL=http://localhost:8900
           poetry run python tests/test_graph_behaviours.py
           poetry run python tests/test_graph_update.py
           poetry run python tests/test_graph_validation.py

--- a/python-sdk/indexify/http_client.py
+++ b/python-sdk/indexify/http_client.py
@@ -47,6 +47,7 @@ class IndexifyClient:
         service_url: str = DEFAULT_SERVICE_URL,
         config_path: Optional[str] = None,
         namespace: str = "default",
+        api_key: Optional[str] = None,
         **kwargs,
     ):
         if os.environ.get("INDEXIFY_URL"):
@@ -74,6 +75,10 @@ class IndexifyClient:
         self._timeout = kwargs.get("timeout")
         self._graphs: Dict[str, Graph] = {}
         self._fns: Dict[str, IndexifyFunction] = {}
+        self._api_key = api_key
+        if not self._api_key:
+            print("API key not provided. Trying to fetch from environment TENSORLAKE_API_KEY variable")
+            self._api_key = os.getenv("TENSORLAKE_API_KEY")
 
     def _request(self, method: str, **kwargs) -> httpx.Response:
         try:
@@ -87,10 +92,9 @@ class IndexifyClient:
                 raise ApiException(response.text)
         except httpx.ConnectError:
             message = (
-                f"Make sure the server is running and accesible at {self._service_url}"
+                f"Make sure the server is running and accessible at {self._service_url}"
             )
             ex = ApiException(message=message)
-            print(ex)
             raise ex
         return response
 
@@ -140,17 +144,25 @@ class IndexifyClient:
             verify=verify_option,
         )
         return client
+    
+    def _add_api_key(self, kwargs):
+        if self._api_key:
+            kwargs["headers"] = {"Authorization": f"Bearer {self._api_key}"}
 
     def _get(self, endpoint: str, **kwargs) -> httpx.Response:
+        self._add_api_key(kwargs)
         return self._request("GET", url=f"{self._service_url}/{endpoint}", **kwargs)
 
     def _post(self, endpoint: str, **kwargs) -> httpx.Response:
+        self._add_api_key(kwargs)
         return self._request("POST", url=f"{self._service_url}/{endpoint}", **kwargs)
 
     def _put(self, endpoint: str, **kwargs) -> httpx.Response:
+        self._add_api_key(kwargs)
         return self._request("PUT", url=f"{self._service_url}/{endpoint}", **kwargs)
 
     def _delete(self, endpoint: str, **kwargs) -> httpx.Response:
+        self._add_api_key(kwargs)
         return self._request("DELETE", url=f"{self._service_url}/{endpoint}", **kwargs)
 
     def _close(self):
@@ -259,14 +271,14 @@ class IndexifyClient:
     ) -> str:
         ser_input = cloudpickle.dumps(kwargs)
         params = {"block_until_finish": block_until_done}
+        kwargs = {"headers": {"Content-Type": "application/cbor"}, "data": ser_input, "params":params}
+        self._add_api_key(kwargs)
         with httpx.Client() as client:
             with connect_sse(
                 client,
                 "POST",
                 f"{self.service_url}/namespaces/{self.namespace}/compute_graphs/{graph}/invoke_object",
-                headers={"Content-Type": "application/cbor"},
-                data=ser_input,
-                params=params,
+                **kwargs,
             ) as event_source:
                 if not event_source.response.is_success:
                     resp = event_source.response.read().decode("utf-8")

--- a/python-sdk/indexify/http_client.py
+++ b/python-sdk/indexify/http_client.py
@@ -14,8 +14,7 @@ from indexify.error import ApiException, GraphStillProcessing
 from indexify.functions_sdk.data_objects import IndexifyData
 from indexify.functions_sdk.graph import ComputeGraphMetadata, Graph
 from indexify.functions_sdk.indexify_functions import IndexifyFunction
-from indexify.settings import DEFAULT_SERVICE_URL, DEFAULT_SERVICE_URL_HTTPS
-
+from indexify.settings import DEFAULT_SERVICE_URL
 
 class InvocationEventPayload(BaseModel):
     invocation_id: str
@@ -104,7 +103,7 @@ class IndexifyClient:
         cert_path: str,
         key_path: str,
         ca_bundle_path: Optional[str] = None,
-        service_url: str = DEFAULT_SERVICE_URL_HTTPS,
+        service_url: str = DEFAULT_SERVICE_URL,
         *args,
         **kwargs,
     ) -> "IndexifyClient":

--- a/python-sdk/indexify/settings.py
+++ b/python-sdk/indexify/settings.py
@@ -1,2 +1,1 @@
-DEFAULT_SERVICE_URL = "http://localhost:8900"
-DEFAULT_SERVICE_URL_HTTPS = "https://localhost:8900"
+DEFAULT_SERVICE_URL = "https://api.tensorlake.ai"


### PR DESCRIPTION
## Context

Defaulting the Indexify client to talk to https://api.tensorlake.ai 
This requires getting an API Token from Tensorlake's cloud api, and setting it in the environment.

## What

1. Reading the api token from environment or from the constructor and setting it in the header.
2. Open Source users have to manually set INDEXIFY_SERVICE to their deployed endpoint

## Testing
1. Setting the URL to a deployed endpoint and passing in an api token. 

## Contribution Checklist

- [x] If the python-sdk was changed, please run `make fmt` in `python-sdk/`.
- [x] If the server was changed, please run `make fmt` in `server/`.
- [x] Make sure all PR Checks are passing.
