### PR TITLE
(feat): Enabled mTLS in ExtractorAgent, Fixes #989

### DIFF
--- a/python-sdk/indexify/common_util.py
+++ b/python-sdk/indexify/common_util.py
@@ -1,14 +1,20 @@
-from typing import Optional
+from typing import Optional, Union
 
 import httpx
 import yaml
+from httpx import AsyncClient, Client
 
-def get_httpx_client(config_path: Optional[str] = None) -> httpx.Client:
+
+def get_httpx_client(
+    config_path: Optional[str] = None,
+    make_async: Optional[bool] = False
+) -> AsyncClient | Client:
     """
     Creates and returns an httpx.Client instance, optionally configured with TLS settings from a YAML config file.
 
     The function creates a basic httpx.Client by default. If a config path is provided and the config specifies
     'use_tls' as True, it creates a TLS-enabled client with HTTP/2 support using the provided certificate settings.
+    To get https.AsyncClient, provide make_async as True.
 
     Args:
         config_path (Optional[str]): Path to a YAML configuration file. If provided, the file should contain TLS
@@ -21,6 +27,7 @@ def get_httpx_client(config_path: Optional[str] = None) -> httpx.Client:
                     "ca_bundle_path": str  # Optional: Path to CA bundle for verification
                 }
             }
+        make_async (Optional[bool]): Whether to make an asynchronous httpx client instance.
 
     Returns:
         httpx.Client: An initialized httpx client instance, either with basic settings or TLS configuration
@@ -33,16 +40,49 @@ def get_httpx_client(config_path: Optional[str] = None) -> httpx.Client:
         # Client with TLS configuration from config file
         client = get_httpx_client("/path/to/config.yaml")
     """
-    client = httpx.Client()
     if config_path:
         with open(config_path, "r") as file:
             config = yaml.safe_load(file)
         if config.get("use_tls", False):
             print(f'Configuring client with TLS config: {config}')
             tls_config = config["tls_config"]
-            client = httpx.Client(
+            return get_sync_or_async_client(make_async, **tls_config)
+    return get_sync_or_async_client(make_async)
+
+def get_sync_or_async_client(
+    make_async: Optional[bool] = False,
+    cert_path: Optional[str] = None,
+    key_path: Optional[str] = None,
+    ca_bundle_path: Optional[str] = None,
+) -> AsyncClient | Client:
+    """
+       Creates and returns either a synchronous or asynchronous httpx client with optional TLS configuration.
+
+       Args:
+           make_async (Optional[bool]): If True, returns an AsyncClient; if False, returns a synchronous Client.
+               Defaults to False.
+           cert_path (Optional[str]): Path to the client certificate file. Required for TLS configuration
+               when key_path is also provided.
+           key_path (Optional[str]): Path to the client private key file. Required for TLS configuration
+               when cert_path is also provided.
+           ca_bundle_path (Optional[str]): Path to the CA bundle file for certificate verification.
+               If not provided, defaults to system CA certificates.
+   """
+    if make_async:
+        if cert_path and key_path:
+            return httpx.AsyncClient(
                 http2=True,
-                cert=(tls_config["cert_path"], tls_config["key_path"]),
-                verify=tls_config.get("ca_bundle_path", True),
+                cert=(cert_path, key_path),
+                verify=ca_bundle_path if ca_bundle_path else True,
             )
-    return client
+        else:
+            return httpx.AsyncClient()
+    else:
+        if cert_path and key_path:
+            return httpx.Client(
+                http2=True,
+                cert=(cert_path, key_path),
+                verify=ca_bundle_path if ca_bundle_path else True
+            )
+        else:
+            return httpx.Client()

--- a/python-sdk/indexify/common_util.py
+++ b/python-sdk/indexify/common_util.py
@@ -1,0 +1,48 @@
+from typing import Optional
+
+import httpx
+import yaml
+
+def get_httpx_client(config_path: Optional[str] = None) -> httpx.Client:
+    """
+    Creates and returns an httpx.Client instance, optionally configured with TLS settings from a YAML config file.
+
+    The function creates a basic httpx.Client by default. If a config path is provided and the config specifies
+    'use_tls' as True, it creates a TLS-enabled client with HTTP/2 support using the provided certificate settings.
+
+    Args:
+        config_path (Optional[str]): Path to a YAML configuration file. If provided, the file should contain TLS
+            configuration with the following structure:
+            {
+                "use_tls": bool,
+                "tls_config": {
+                    "cert_path": str,  # Path to client certificate
+                    "key_path": str,   # Path to client private key
+                    "ca_bundle_path": str  # Optional: Path to CA bundle for verification
+                }
+            }
+
+    Returns:
+        httpx.Client: An initialized httpx client instance, either with basic settings or TLS configuration
+                     if specified in the config file.
+
+    Example:
+        # Basic client without TLS
+        client = get_httpx_client()
+
+        # Client with TLS configuration from config file
+        client = get_httpx_client("/path/to/config.yaml")
+    """
+    client = httpx.Client()
+    if config_path:
+        with open(config_path, "r") as file:
+            config = yaml.safe_load(file)
+        if config.get("use_tls", False):
+            print(f'Configuring client with TLS config: {config}')
+            tls_config = config["tls_config"]
+            client = httpx.Client(
+                http2=True,
+                cert=(tls_config["cert_path"], tls_config["key_path"]),
+                verify=tls_config.get("ca_bundle_path", True),
+            )
+    return client

--- a/python-sdk/indexify/executor/agent.py
+++ b/python-sdk/indexify/executor/agent.py
@@ -5,6 +5,7 @@ import traceback
 from concurrent.futures.process import BrokenProcessPool
 from importlib.metadata import version
 from typing import Dict, List, Optional
+from pathlib import Path
 
 import httpx
 import yaml
@@ -58,7 +59,7 @@ class ExtractorAgent:
         self,
         executor_id: str,
         num_workers,
-        code_path: str,
+        code_path: Path,
         server_addr: str = "localhost:8900",
         config_path: Optional[str] = None,
         name_alias: Optional[str] = None,
@@ -114,7 +115,8 @@ class ExtractorAgent:
         self._function_worker = FunctionWorker(
             workers=num_workers,
             indexify_client=IndexifyClient(
-                service_url=f"{self._protocol}://{server_addr}"
+                service_url=f"{self._protocol}://{server_addr}",
+                config_path=config_path,
             ),
         )
         self._has_registered = False

--- a/python-sdk/indexify/executor/agent.py
+++ b/python-sdk/indexify/executor/agent.py
@@ -67,7 +67,7 @@ class ExtractorAgent:
     ):
         self.name_alias = name_alias
         self.image_version = image_version
-
+        self._config_path = config_path
         self._probe = RuntimeProbes()
 
         runtime_probe: ProbeInfo = self._probe.probe()
@@ -199,7 +199,7 @@ class ExtractorAgent:
                 if self._require_image_bootstrap:
                     try:
                         image_info = await _get_image_info_for_compute_graph(
-                            task, self._protocol, self._server_addr
+                            task, self._protocol, self._server_addr, self._config_path
                         )
                         image_dependency_installer.executor_image_builder(
                             image_info, self.name_alias, self.image_version
@@ -455,14 +455,15 @@ class ExtractorAgent:
 
 
 async def _get_image_info_for_compute_graph(
-    task: Task, protocol, server_addr
+    task: Task, protocol, server_addr, config_path: str
 ) -> ImageInformation:
     namespace = task.namespace
     graph_name: str = task.compute_graph
     compute_fn_name: str = task.compute_fn
 
     http_client = IndexifyClient(
-        service_url=f"{protocol}://{server_addr}", namespace=namespace
+        service_url=f"{protocol}://{server_addr}", namespace=namespace,
+        config_path=config_path
     )
     compute_graph: ComputeGraphMetadata = http_client.graph(graph_name)
 

--- a/python-sdk/indexify/executor/downloader.py
+++ b/python-sdk/indexify/executor/downloader.py
@@ -11,6 +11,7 @@ from indexify.functions_sdk.data_objects import IndexifyData
 from indexify.functions_sdk.object_serializer import MsgPackSerializer
 
 from .api_objects import Task
+from ..common_util import get_httpx_client
 
 custom_theme = Theme(
     {
@@ -29,9 +30,10 @@ class DownloadedInputs(BaseModel):
 
 
 class Downloader:
-    def __init__(self, code_path: str, base_url: str):
+    def __init__(self, code_path: str, base_url: str, config_path: Optional[str] = None):
         self.code_path = code_path
         self.base_url = base_url
+        self._client = get_httpx_client(config_path)
 
     async def download_graph(self, namespace: str, name: str, version: int) -> str:
         path = os.path.join(self.code_path, namespace, f"{name}.{version}")
@@ -46,7 +48,7 @@ class Downloader:
             )
         )
 
-        response = httpx.get(
+        response = self._client.get(
             f"{self.base_url}/internal/namespaces/{namespace}/compute_graphs/{name}/code"
         )
         try:
@@ -85,7 +87,7 @@ class Downloader:
             )
         )
 
-        response = httpx.get(url)
+        response = self._client.get(url)
         try:
             response.raise_for_status()
         except httpx.HTTPStatusError as e:

--- a/python-sdk/indexify/executor/task_reporter.py
+++ b/python-sdk/indexify/executor/task_reporter.py
@@ -5,6 +5,7 @@ import httpx
 import nanoid
 from rich import print
 
+from indexify.common_util import get_httpx_client
 from indexify.executor.api_objects import RouterOutput as ApiRouterOutput
 from indexify.executor.api_objects import Task, TaskResult
 from indexify.executor.task_store import CompletedTask
@@ -22,9 +23,10 @@ FORCE_MULTIPART = ForceMultipartDict()
 
 
 class TaskReporter:
-    def __init__(self, base_url: str, executor_id: str):
+    def __init__(self, base_url: str, executor_id: str, config_path: Optional[str] = None):
         self._base_url = base_url
         self._executor_id = executor_id
+        self._client = get_httpx_client(config_path)
 
     def report_task_outcome(self, completed_task: CompletedTask):
         fn_outputs = []
@@ -84,7 +86,7 @@ class TaskReporter:
         else:
             kwargs["files"] = FORCE_MULTIPART
         try:
-            response = httpx.post(
+            response = self._client.post(
                 url=f"{self._base_url}/internal/ingest_files",
                 **kwargs,
             )

--- a/python-sdk/indexify/http_client.py
+++ b/python-sdk/indexify/http_client.py
@@ -5,7 +5,6 @@ from typing import Any, Dict, List, Optional
 import cloudpickle
 import httpx
 import msgpack
-import yaml
 from httpx_sse import connect_sse
 from pydantic import BaseModel, Json
 from rich import print
@@ -55,6 +54,7 @@ class IndexifyClient:
             service_url = os.environ["INDEXIFY_URL"]
 
         self.service_url = service_url
+        self._config_path = config_path
         self._client = get_httpx_client(config_path)
 
         self.namespace: str = namespace
@@ -262,7 +262,7 @@ class IndexifyClient:
         params = {"block_until_finish": block_until_done}
         kwargs = {"headers": {"Content-Type": "application/cbor"}, "data": ser_input, "params":params}
         self._add_api_key(kwargs)
-        with httpx.Client() as client:
+        with get_httpx_client(self._config_path) as client:
             with connect_sse(
                 client,
                 "POST",

--- a/python-sdk/indexify/http_client.py
+++ b/python-sdk/indexify/http_client.py
@@ -58,8 +58,8 @@ class IndexifyClient:
         if config_path:
             with open(config_path, "r") as file:
                 config = yaml.safe_load(file)
-
             if config.get("use_tls", False):
+                print(f'Configuring client with TLS config: {config}')
                 tls_config = config["tls_config"]
                 self._client = httpx.Client(
                     http2=True,
@@ -143,7 +143,7 @@ class IndexifyClient:
             verify=verify_option,
         )
         return client
-    
+
     def _add_api_key(self, kwargs):
         if self._api_key:
             kwargs["headers"] = {"Authorization": f"Bearer {self._api_key}"}

--- a/python-sdk/indexify/http_client.py
+++ b/python-sdk/indexify/http_client.py
@@ -10,6 +10,7 @@ from httpx_sse import connect_sse
 from pydantic import BaseModel, Json
 from rich import print
 
+from indexify.common_util import get_httpx_client
 from indexify.error import ApiException, GraphStillProcessing
 from indexify.functions_sdk.data_objects import IndexifyData
 from indexify.functions_sdk.graph import ComputeGraphMetadata, Graph
@@ -54,18 +55,7 @@ class IndexifyClient:
             service_url = os.environ["INDEXIFY_URL"]
 
         self.service_url = service_url
-        self._client = httpx.Client()
-        if config_path:
-            with open(config_path, "r") as file:
-                config = yaml.safe_load(file)
-            if config.get("use_tls", False):
-                print(f'Configuring client with TLS config: {config}')
-                tls_config = config["tls_config"]
-                self._client = httpx.Client(
-                    http2=True,
-                    cert=(tls_config["cert_path"], tls_config["key_path"]),
-                    verify=tls_config.get("ca_bundle_path", True),
-                )
+        self._client = get_httpx_client(config_path)
 
         self.namespace: str = namespace
         self.compute_graphs: List[Graph] = []

--- a/python-sdk/indexify/http_client.py
+++ b/python-sdk/indexify/http_client.py
@@ -130,7 +130,7 @@ class IndexifyClient:
             key_path=key_path,
             ca_bundle_path=ca_bundle_path
         )
-        
+
         indexify_client = IndexifyClient(service_url, *args, **kwargs)
         indexify_client._client = client
         return indexify_client

--- a/python-sdk/tests/test_constants.py
+++ b/python-sdk/tests/test_constants.py
@@ -1,0 +1,27 @@
+from indexify.executor.api_objects import Task
+
+tls_config = {
+    "use_tls": True,
+    "tls_config": {
+        "ca_bundle_path": "/path/to/ca_bundle.pem",
+        "cert_path": "/path/to/cert.pem",
+        "key_path": "/path/to/key.pem"
+    }
+}
+
+cert_path = tls_config["tls_config"]["cert_path"]
+key_path = tls_config["tls_config"]["key_path"]
+ca_bundle_path = tls_config["tls_config"]["ca_bundle_path"]
+service_url = "localhost:8900"
+config_path = "test/config/path"
+code_path = "test/code_path"
+task = Task(
+    id = "test_id",
+    namespace = "default",
+    compute_graph = "test_compute_graph",
+    compute_fn = "test_compute_fn",
+    invocation_id = "test_invocation_id",
+    input_key = "test|input|key",
+    requester_output_id = "test_output_id",
+    graph_version = 1,
+)

--- a/python-sdk/tests/test_downloader_behaviour.py
+++ b/python-sdk/tests/test_downloader_behaviour.py
@@ -1,0 +1,62 @@
+import unittest
+from unittest.mock import patch, mock_open
+
+from indexify.executor.downloader import Downloader
+from test_constants import *
+
+class TestDownloaderBehaviour(unittest.TestCase):
+
+    @patch("httpx.Client")
+    @patch(
+        'builtins.open',
+        new_callable=mock_open,
+        read_data='''
+                    use_tls: true
+                    tls_config:
+                        ca_bundle_path: /path/to/ca_bundle.pem
+                        cert_path: /path/to/cert.pem
+                        key_path: /path/to/key.pem
+                    '''
+    )
+    def test_download_input_initialised_with_mTLS(
+        self,
+        mock_file,
+        mock_client
+    ):
+        downloader = Downloader(
+            code_path=code_path,
+            base_url=service_url,
+            config_path=config_path,
+        )
+
+        # Verify that the correct file was loaded from the config_path
+        mock_file.assert_called()
+
+        # Verify TLS config in httpsx Client
+        mock_client.assert_called_with(
+            http2=True,
+            cert=(cert_path, key_path),
+            verify=ca_bundle_path,
+        )
+
+    @patch("httpx.Client")
+    @patch(
+        'builtins.open',
+        new_callable=mock_open,
+        read_data='''use_tls: false'''
+    )
+    def test_download_input_initialised_without_mTLS(
+        self,
+        mock_file,
+        mock_client
+    ):
+        downloader = Downloader(
+            code_path=code_path,
+            base_url=service_url,
+            config_path=config_path,
+        )
+        mock_file.assert_called()
+        mock_client.assert_called_with()
+
+if __name__ == '__main__':
+    unittest.main()

--- a/python-sdk/tests/test_extractor_agent_behaviour.py
+++ b/python-sdk/tests/test_extractor_agent_behaviour.py
@@ -1,0 +1,87 @@
+import ssl
+import unittest
+from pathlib import Path
+from unittest.mock import patch, mock_open
+from indexify.executor.agent import ExtractorAgent
+
+class TestExtractorAgent(unittest.TestCase):
+
+    @patch(
+        'builtins.open',
+        new_callable=mock_open,
+        read_data='''
+                use_tls: true
+                tls_config:
+                    ca_bundle_path: /path/to/ca_bundle.pem
+                    cert_path: /path/to/cert.pem
+                    key_path: /path/to/key.pem
+                '''
+    )
+    @patch('yaml.safe_load')
+    @patch('ssl.create_default_context')
+    # @patch('httpx.Client')
+    def test_tls_configuration(
+        self,
+        mock_file,
+        mock_yaml_load,
+        mock_create_default_context,
+        # mock_client
+    ):
+        # Mock the YAML file content with TLS enabled
+        tls_config = {
+            'use_tls': True,
+            'tls_config': {
+                'ca_bundle_path': '/path/to/ca_bundle.pem',
+                'cert_path': '/path/to/cert.pem',
+                'key_path': '/path/to/key.pem'
+            }
+        }
+        mock_yaml_load.return_value = tls_config
+
+        # Create an instance of ExtractorAgent with the mock config
+        agent = ExtractorAgent(
+            executor_id="unit-test",
+            num_workers=1,
+            code_path=Path("test"),
+            server_addr="localhost:8900",
+            config_path="test"
+        )
+
+        # Verify that the SSL context was created correctly
+        mock_create_default_context.assert_called_with(ssl.Purpose.SERVER_AUTH,
+            cafile='/path/to/ca_bundle.pem')
+        agent._ssl_context.load_cert_chain.assert_called_with(
+            certfile='/path/to/cert.pem', keyfile='/path/to/key.pem')
+        # mock_client.assert_called_with(
+        #     http2=True,
+        #     cert=('/path/to/cert.pem', '/path/to/key.pem'),
+        #     verify='/path/to/ca_bundle.pem'
+        # )
+
+        # Verify TLS config
+        self.assertTrue(agent._use_tls)
+        self.assertEqual(agent._config, tls_config)
+        self.assertEqual(agent._server_addr, "localhost:8900")
+        self.assertEqual(agent._protocol, "wss")
+        self.assertEqual(agent._tls_config, tls_config["tls_config"])
+
+    def test_no_tls_configuration(self):
+        # Create an instance of ExtractorAgent without TLS
+        agent = ExtractorAgent(
+            executor_id="unit-test",
+            num_workers=1,
+            code_path=Path("test"),
+            server_addr="localhost:8900",
+        )
+
+        # Verify that TLS is disabled
+        self.assertFalse(agent._use_tls)
+
+        # Verify that the SSL context is None
+        self.assertIsNone(agent._ssl_context)
+
+        # Verify the protocol is set to "http"
+        self.assertEqual(agent._protocol, 'http')
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Context
This change enables the agent to use mTLS by picking up the certificate and private key from `config_path`. This PR addresses issue #989

## What
Made minor changes in `ExtractorAgent` class in `agent.py` to pickup the mTLS config from `config_path` and pass it to `IndexifyClient`.

## Testing
Added 2 UTs - 
1) Initialisation of `ExtractorAgent` with mTLS config.
2) Default behaviour.

## Contribution Checklist

- [ DONE ] If the python-sdk was changed, please run `make fmt` in `python-sdk/`.
- [ NOT APPLICABLE ] If the server was changed, please run `make fmt` in `server/`.
- [ DONE  ] Make sure all PR Checks are passing.

