### PR TITLE
Fix Router Related Bugs

### DIFF
--- a/examples/basic_embedding/workflow.py
+++ b/examples/basic_embedding/workflow.py
@@ -1,0 +1,46 @@
+from indexify import RemoteGraph, Graph, Image
+from indexify.functions_sdk.indexify_functions import (
+    IndexifyFunction,
+)
+from pydantic import BaseModel
+from typing import List
+from sentence_transformers import SentenceTransformer
+
+
+tf_image = (
+    Image()
+    .base_image("pytorch/pytorch:2.4.1-cuda11.8-cudnn9-runtime")
+    .name("tensorlake/common-torch-deps-indexify-executor")
+    .run("pip install transformers")
+    .run("pip install sentence_transformers")
+    .run("pip install langchain")
+)
+
+class Embedding(BaseModel):
+    embedding: List[List[float]]
+
+class Sentences(BaseModel):
+    sentences: List[str]
+
+class EmbeddingFunction(IndexifyFunction):
+    name = "sentence_embedder"
+    image = tf_image 
+
+    def __init__(self):
+        super().__init__()
+        self.model = SentenceTransformer("all-MiniLM-L6-v2")
+
+    def run(self, sentences: Sentences) -> Embedding:
+        #embeddings = self.model.encode(sentences.sentences)
+        #embeddings = [embedding.tolist() for embedding in embeddings]
+        return Embedding(embedding=[[1.0, 2.0], [3.0, 4.0]])
+
+
+if __name__ == "__main__":
+    import sys
+    g = Graph(name="basic_embedding", start_node=EmbeddingFunction)
+    g = RemoteGraph.deploy(g, additional_modules=[sys.modules[__name__]])
+    sentences = Sentences(sentences=["hello world", "how are you"])
+    invocation_id = g.run(block_until_done=True, img=sentences)
+    output = g.output(invocation_id, "sentence_embedder")
+    print(output)

--- a/examples/container_images/transformers.py
+++ b/examples/container_images/transformers.py
@@ -1,0 +1,11 @@
+from indexify import Image
+
+
+tf_image = (
+    Image()
+    .base_image("pytorch/pytorch:2.4.1-cuda11.8-cudnn9-runtime")
+    .name("tensorlake/common-torch-deps-indexify-executor")
+    .run("pip install transformers")
+    .run("pip install sentence_transformers")
+    .run("pip install langchain")
+)

--- a/python-sdk/indexify/functions_sdk/indexify_functions.py
+++ b/python-sdk/indexify/functions_sdk/indexify_functions.py
@@ -48,37 +48,6 @@ class GraphInvocationContext(BaseModel):
         )
 
 
-def format_filtered_traceback(exc_info=None):
-    """
-    Format a traceback excluding indexify_functions.py lines.
-    Can be used in exception handlers to replace traceback.format_exc()
-    """
-    if exc_info is None:
-        exc_info = sys.exc_info()
-
-    # Get the full traceback as a string
-    full_traceback = traceback.format_exception(*exc_info)
-
-    # Filter out lines containing indexify_functions.py
-    filtered_lines = []
-    skip_next = False
-
-    for line in full_traceback:
-        if "indexify_functions.py" in line:
-            skip_next = True
-            continue
-        if skip_next:
-            if line.strip().startswith("File "):
-                skip_next = False
-            else:
-                continue
-        filtered_lines.append(line)
-
-    # Clean up any double blank lines that might have been created
-    cleaned = re.sub(r"\n\s*\n\s*\n", "\n\n", "".join(filtered_lines))
-    return cleaned
-
-
 def is_pydantic_model_from_annotation(type_annotation):
     # If it's a string representation
     if isinstance(type_annotation, str):
@@ -266,7 +235,7 @@ class IndexifyFunctionWrapper:
         try:
             extracted_data = self.indexify_function.run(*args, **kwargs)
         except Exception as e:
-            return [], format_filtered_traceback()
+            return [], traceback.format_exc()
         if not isinstance(extracted_data, list) and extracted_data is not None:
             return [extracted_data.name], None
         edges = []
@@ -289,7 +258,7 @@ class IndexifyFunctionWrapper:
         try:
             extracted_data = self.indexify_function.run(*args, **kwargs)
         except Exception as e:
-            return [], format_filtered_traceback()
+            return [], traceback.format_exc()
         if extracted_data is None:
             return [], None
 

--- a/python-sdk/tests/test_broken_graphs.py
+++ b/python-sdk/tests/test_broken_graphs.py
@@ -52,12 +52,18 @@ def create_broken_graph():
 
 class TestBrokenGraphs(unittest.TestCase):
     def test_broken_graph(self):
-        g = RemoteGraph.deploy(create_broken_graph())
+        g = create_broken_graph()
+        g = RemoteGraph.deploy(g)
 
-        invocation_id = g.run(
+        self.assertRaises(g.run(
             block_until_done=True,
             url="https://www.youtube.com/watch?v=gjHv4pM8WEQ",
-        )
+        ))
+
+        self.assertRaises(g.run(
+            block_until_done=True,
+            maybe="https://www.youtube.com/watch?v=gjHv4pM8WEQ",
+        ))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Context

* We were filtering out exceptions from the framework and only returning the application exceptions. In some cases, we were filtering out exceptions which would be from the framework not being able to invoke the functions. Showing the exceptions to make it easy to debug bugs. We will have to be smart about this, and show users the exceptions in their code and remove framework frames from traceback. If user functions are not even being invoked, we should show the framework bugs. 
* Passing in graph context to router functions in local execution


## What

* Fix the local graph runner for routers
* Removed the exception filtering code until we have a better solution. We have some tests which we can use for testing the filtering logic when we bring it back.

## Testing

* Unit Tests 
* 
## Contribution Checklist

- [x] If the python-sdk was changed, please run `make fmt` in `python-sdk/`.
- [x] If the server was changed, please run `make fmt` in `server/`.
- [x] Make sure all PR Checks are passing.
