### PR TITLE
Add unittest toggle for remote and local tests

### DIFF
--- a/.github/workflows/acceptance_tests.yaml
+++ b/.github/workflows/acceptance_tests.yaml
@@ -111,10 +111,15 @@ jobs:
                 sleep 5
             fi
           done
-      - name: Run Acceptance Tests
+      - name: Run Acceptance Tests (Remote)
         run: |
           cd python-sdk
           export INDEXIFY_URL=http://localhost:8900
           poetry run python tests/test_graph_behaviours.py
           poetry run python tests/test_graph_update.py
           poetry run python tests/test_graph_validation.py
+      - name: Run Acceptance Tests (Local)
+        run: |
+          cd python-sdk
+          export TEST_LOCAL_RUN=True
+          poetry run python tests/test_graph_behaviours.py

--- a/python-sdk/tests/test_graph_validation.py
+++ b/python-sdk/tests/test_graph_validation.py
@@ -134,7 +134,7 @@ class TestValidations(unittest.TestCase):
             return 1
 
         @indexify_function()
-        def end () -> int:
+        def end() -> int:
             return 1
 
         @indexify_router()


### PR DESCRIPTION
## Context

`test_graph_behaviours.py` has several tests for the core indexify functions. We should be able to run these tests either locally or as a Remote deployment (ie. starting a server and executor). Right now it's hard-coded for Remote testing.

## What
Add an env toggle before running the unit test and use it to either setup a remote or local graph.

## Testing

Verified toggle works.

## Contribution Checklist

- [ ] If the python-sdk was changed, please run `make fmt` in `python-sdk/`.
- [ ] If the server was changed, please run `make fmt` in `server/`.
- [ ] Make sure all PR Checks are passing.
<!-- You can run the tests manually:
In `python-sdk/`, run the run `pip install -e .`, start the server and executor, `python test_graph_behaviours.py`.

