### PR TITLE
Fix graph local exec

### DIFF
--- a/python-sdk/indexify/executor/agent.py
+++ b/python-sdk/indexify/executor/agent.py
@@ -418,7 +418,7 @@ class ExtractorAgent:
                         headers={"Content-Type": "application/json"},
                     ) as event_source:
                         if not event_source.response.is_success:
-                            resp = await event_source.response.aread().decode('utf-8')
+                            resp = await event_source.response.aread().decode("utf-8")
                             console.print(f"failed to register: {str(resp)}")
                             await asyncio.sleep(5)
                             continue

--- a/python-sdk/indexify/executor/function_worker.py
+++ b/python-sdk/indexify/executor/function_worker.py
@@ -17,6 +17,8 @@ from indexify.functions_sdk.indexify_functions import (
     GraphInvocationContext,
     IndexifyFunctionWrapper,
     RouterCallResult,
+    IndexifyRouter,
+    IndexifyFunction,
 )
 
 function_wrapper_map: Dict[str, IndexifyFunctionWrapper] = {}
@@ -169,7 +171,7 @@ def _run_function(
             fn = function_wrapper_map[key]
             if (
                 str(type(fn.indexify_function))
-                == "<class 'indexify.functions_sdk.indexify_functions.IndexifyRo'>"
+                == "<class 'indexify.functions_sdk.indexify_functions.IndexifyRouter'>"
             ):
                 router_call_result: RouterCallResult = fn.invoke_router(fn_name, input)
                 router_output = RouterOutput(edges=router_call_result.edges)

--- a/python-sdk/indexify/functions_sdk/data_objects.py
+++ b/python-sdk/indexify/functions_sdk/data_objects.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Union, Literal
+from typing import Any, Dict, List, Literal, Optional, Union
 
 from pydantic import BaseModel, Json
 

--- a/python-sdk/indexify/functions_sdk/object_serializer.py
+++ b/python-sdk/indexify/functions_sdk/object_serializer.py
@@ -1,7 +1,7 @@
 from typing import Any, List
 
-import jsonpickle
 import cloudpickle
+import jsonpickle
 import msgpack
 from pydantic import BaseModel
 
@@ -16,6 +16,7 @@ def get_serializer(serializer_type: str) -> Any:
     elif serializer_type == "json":
         return JsonSerializer()
     raise ValueError(f"Unknown serializer type: {serializer_type}")
+
 
 class JsonSerializer:
     @staticmethod

--- a/python-sdk/indexify/http_client.py
+++ b/python-sdk/indexify/http_client.py
@@ -16,6 +16,7 @@ from indexify.functions_sdk.graph import ComputeGraphMetadata, Graph
 from indexify.functions_sdk.indexify_functions import IndexifyFunction
 from indexify.settings import DEFAULT_SERVICE_URL
 
+
 class InvocationEventPayload(BaseModel):
     invocation_id: str
     fn_name: str
@@ -76,7 +77,9 @@ class IndexifyClient:
         self._fns: Dict[str, IndexifyFunction] = {}
         self._api_key = api_key
         if not self._api_key:
-            print("API key not provided. Trying to fetch from environment TENSORLAKE_API_KEY variable")
+            print(
+                "API key not provided. Trying to fetch from environment TENSORLAKE_API_KEY variable"
+            )
             self._api_key = os.getenv("TENSORLAKE_API_KEY")
 
     def _request(self, method: str, **kwargs) -> httpx.Response:
@@ -143,7 +146,7 @@ class IndexifyClient:
             verify=verify_option,
         )
         return client
-    
+
     def _add_api_key(self, kwargs):
         if self._api_key:
             kwargs["headers"] = {"Authorization": f"Bearer {self._api_key}"}
@@ -213,16 +216,16 @@ class IndexifyClient:
         self, compute_graph: str, invocation_id: str, key: str, value: Json
     ) -> None:
         response = self._post(
-                f"internal/namespaces/{self.namespace}/compute_graphs/{compute_graph}/invocations/{invocation_id}/ctx",
-                json={"key": key, "value": value},
-            )
+            f"internal/namespaces/{self.namespace}/compute_graphs/{compute_graph}/invocations/{invocation_id}/ctx",
+            json={"key": key, "value": value},
+        )
         response.raise_for_status()
 
     def get_state_key(self, compute_graph: str, invocation_id: str, key: str) -> Json:
         response = self._get(
-                f"internal/namespaces/{self.namespace}/compute_graphs/{compute_graph}/invocations/{invocation_id}/ctx",
-                json={"key": key},
-            )
+            f"internal/namespaces/{self.namespace}/compute_graphs/{compute_graph}/invocations/{invocation_id}/ctx",
+            json={"key": key},
+        )
         response.raise_for_status()
         return response.json().get("value")
 
@@ -270,7 +273,11 @@ class IndexifyClient:
     ) -> str:
         ser_input = cloudpickle.dumps(kwargs)
         params = {"block_until_finish": block_until_done}
-        kwargs = {"headers": {"Content-Type": "application/cbor"}, "data": ser_input, "params":params}
+        kwargs = {
+            "headers": {"Content-Type": "application/cbor"},
+            "data": ser_input,
+            "params": params,
+        }
         self._add_api_key(kwargs)
         with httpx.Client() as client:
             with connect_sse(

--- a/python-sdk/tests/test_broken_graphs.py
+++ b/python-sdk/tests/test_broken_graphs.py
@@ -55,15 +55,19 @@ class TestBrokenGraphs(unittest.TestCase):
         g = create_broken_graph()
         g = RemoteGraph.deploy(g)
 
-        self.assertRaises(g.run(
-            block_until_done=True,
-            url="https://www.youtube.com/watch?v=gjHv4pM8WEQ",
-        ))
+        self.assertRaises(
+            g.run(
+                block_until_done=True,
+                url="https://www.youtube.com/watch?v=gjHv4pM8WEQ",
+            )
+        )
 
-        self.assertRaises(g.run(
-            block_until_done=True,
-            maybe="https://www.youtube.com/watch?v=gjHv4pM8WEQ",
-        ))
+        self.assertRaises(
+            g.run(
+                block_until_done=True,
+                maybe="https://www.youtube.com/watch?v=gjHv4pM8WEQ",
+            )
+        )
 
 
 if __name__ == "__main__":

--- a/python-sdk/tests/test_function_worker.py
+++ b/python-sdk/tests/test_function_worker.py
@@ -12,6 +12,7 @@ from indexify.functions_sdk.indexify_functions import (
     IndexifyFunctionWrapper,
     indexify_function,
 )
+import sys
 
 
 @indexify_function()
@@ -74,7 +75,7 @@ class TestFunctionWorker(unittest.IsolatedAsyncioTestCase):
 
     async def test_function_worker_happy_path(self):
         with tempfile.NamedTemporaryFile(delete=True) as temp_file:
-            code_bytes = cloudpickle.dumps(self.g.serialize())
+            code_bytes = cloudpickle.dumps(self.g.serialize(additional_modules=[sys.modules[__name__]]))
 
             temp_file.write(code_bytes)
             temp_file.flush()

--- a/python-sdk/tests/test_graph_validation.py
+++ b/python-sdk/tests/test_graph_validation.py
@@ -134,7 +134,7 @@ class TestValidations(unittest.TestCase):
             return 1
 
         @indexify_function()
-        def end () -> int:
+        def end() -> int:
             return 1
 
         @indexify_router()


### PR DESCRIPTION
## Context

Allows Router Functions to be the start node of a graph 

```python

@indexify_function()
def add_two(x: Sum) -> int:
    return x.val + 2


@indexify_function()
def add_three(x: Sum) -> int:
    return x.val + 3


@indexify_router()
def route_if_even(x: Sum) -> List[Union[add_two, add_three]]:
    print(f"routing input {x}")
    if x.val % 2 == 0:
        return add_three
    else:
        return add_two



graph = Graph(name="test_router", description="test", start_node=route_if_even)
graph.route(route_if_even, [add_two, add_three])
graph = RemoteGraph.deploy(graph)
invocation_id = graph.run(block_until_done=True, x=Sum(val=2))
output = graph.output(invocation_id, "add_three")
self.assertEqual(output, [5])
```
## What

The server didn't care whether the first function was regular function or router. Relaxed some constraints on the SDK to allow router functions as start node.

## Testing

* Unit Test

## Contribution Checklist

- [x] If the python-sdk was changed, please run `make fmt` in `python-sdk/`.
- [x] If the server was changed, please run `make fmt` in `server/`.
- [x] Make sure all PR Checks are passing.

