### PR TITLE
Add tests for simple graph, with multiple inputs

### DIFF
--- a/python-sdk/tests/test_graph_behaviours.py
+++ b/python-sdk/tests/test_graph_behaviours.py
@@ -1,3 +1,4 @@
+import sys
 import unittest
 from pathlib import Path
 from typing import List, Union
@@ -26,6 +27,12 @@ class MyObject(BaseModel):
 @indexify_function()
 def simple_function(x: MyObject) -> MyObject:
     return MyObject(x=x.x + "b")
+
+
+@indexify_function()
+def simple_function_multiple_inputs(x: MyObject, y: int) -> MyObject:
+    suf = ''.join(["b" for _ in range(y)])
+    return MyObject(x=x.x + suf)
 
 
 @indexify_function(encoder="json")
@@ -207,6 +214,18 @@ class TestGraphBehaviors(unittest.TestCase):
         invocation_id = graph.run(block_until_done=True, x=MyObject(x="a"))
         output = graph.output(invocation_id, "simple_function")
         self.assertEqual(output, [MyObject(x="ab")])
+
+    # @parameterized.expand([(False), (True)])
+    def test_simple_function_multiple_inputs(self, is_remote=True):
+        print(sys.version_info.major, sys.version_info.minor)
+
+        graph = Graph(
+            name="test_simple_function2", description="test", start_node=simple_function_multiple_inputs
+        )
+        graph = remote_or_local_graph(graph, is_remote)
+        invocation_id = graph.run(block_until_done=True, x=MyObject(x="a"), y=10)
+        output = graph.output(invocation_id, "simple_function_multiple_inputs")
+        self.assertEqual(output, [MyObject(x="abbbbbbbbbb")])
 
     @parameterized.expand([(False), (True)])
     def test_simple_function_with_json_encoding(self, is_remote):

--- a/python-sdk/tests/test_graph_behaviours.py
+++ b/python-sdk/tests/test_graph_behaviours.py
@@ -40,6 +40,12 @@ def simple_function_with_json_encoder(x: MyObject) -> MyObject:
     return MyObject(x=x.x + "b")
 
 
+@indexify_function(encoder="json")
+def simple_function_multiple_inputs_json(x: MyObject, y: int) -> MyObject:
+    suf = ''.join(["b" for _ in range(y)])
+    return MyObject(x=x.x + suf)
+
+
 @indexify_function(encoder="invalid")
 def simple_function_with_invalid_encoder(x: MyObject) -> MyObject:
     return MyObject(x=x.x + "b")
@@ -215,16 +221,24 @@ class TestGraphBehaviors(unittest.TestCase):
         output = graph.output(invocation_id, "simple_function")
         self.assertEqual(output, [MyObject(x="ab")])
 
-    # @parameterized.expand([(False), (True)])
-    def test_simple_function_multiple_inputs(self, is_remote=True):
-        print(sys.version_info.major, sys.version_info.minor)
-
+    @parameterized.expand([(False), (True)])
+    def test_simple_function_multiple_inputs(self, is_remote):
         graph = Graph(
             name="test_simple_function2", description="test", start_node=simple_function_multiple_inputs
         )
         graph = remote_or_local_graph(graph, is_remote)
         invocation_id = graph.run(block_until_done=True, x=MyObject(x="a"), y=10)
         output = graph.output(invocation_id, "simple_function_multiple_inputs")
+        self.assertEqual(output, [MyObject(x="abbbbbbbbbb")])
+
+    @parameterized.expand([(False), (True)])
+    def test_simple_function_multiple_inputs_json(self, is_remote=False):
+        graph = Graph(
+            name="test_simple_function2_json", description="test", start_node=simple_function_multiple_inputs_json
+        )
+        graph = remote_or_local_graph(graph, is_remote)
+        invocation_id = graph.run(block_until_done=True, x=MyObject(x="a"), y=10)
+        output = graph.output(invocation_id, "simple_function_multiple_inputs_json")
         self.assertEqual(output, [MyObject(x="abbbbbbbbbb")])
 
     @parameterized.expand([(False), (True)])


### PR DESCRIPTION
## Context

Add a couple of tests for a simple graph function where the function takes in multiple inputs. This should work given how we setup the args but we didn't have a test for it. Also add test, for sanity, with json encoding.

## What

Add tests for graph behaviours. This will run as a workflow action.

## Testing
N/A

## Contribution Checklist

- [ ] If the python-sdk was changed, please run `make fmt` in `python-sdk/`.
- [ ] If the server was changed, please run `make fmt` in `server/`.
- [x] Make sure all PR Checks are passing.
<!-- You can run the tests manually:
In `python-sdk/`, run the run `pip install -e .`, start the server and executor, `python test_graph_behaviours.py`.

