### PR TITLE
feature(sdk): support graph deletion

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -30,6 +30,14 @@ Consider providing screenshots, logs, code or other visual aids to help the revi
 - [ ] If the python-sdk was changed, please run `make fmt` in `python-sdk/`.
 - [ ] If the server was changed, please run `make fmt` in `server/`.
 - [ ] Make sure all PR Checks are passing.
-<!-- You can run the tests manually:
-In `python-sdk/`, run the run `pip install -e .`, start the server and executor, `python test_graph_behaviours.py`.
+<!--
+You can run the tests manually:
 
+Notes:
+
+- Tests can be run manually: in `python-sdk/`, run the run `pip install -e .`,
+  start the server and executor, and run `python test_graph_behaviours.py`.
+- To test if changes to the server are backward compatible with the latest
+  release, label the PR with `ci_compat_test`. This might report failures
+  unrelated to your change if previous incompatible changes were pushed without
+  being released yet -->

--- a/.github/workflows/acceptance_tests.yaml
+++ b/.github/workflows/acceptance_tests.yaml
@@ -5,36 +5,20 @@ on:
     branches:
       - 'main'
   pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
     branches:
       - 'main'
+    paths:
+      - 'server/**'
+      - 'python-sdk/**'
+      - '.github/workflows/acceptance_tests.yaml'
 
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  changes:
-    name: Get Changes
-    runs-on: ubuntu-latest
-    outputs:
-      ui: ${{ steps.filter.outputs.ui }}
-      indexify: ${{ steps.filter.outputs.indexify }}
-    steps:
-      - uses: actions/checkout@v3
-      - uses: dorny/paths-filter@v2
-        id: filter
-        with:
-          filters: |
-            ui:
-              - 'server/ui/**'
-            indexify:
-              - 'server/**'
-              - 'python-sdk/**'
-              - '.github/**'
-
   build:
     name: Build
-    needs: changes
-    if: ${{ needs.changes.outputs.indexify == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -57,8 +41,7 @@ jobs:
 
   acceptance_tests:
     name: Run Acceptance Tests
-    needs: [changes, build]
-    if: ${{ needs.changes.outputs.indexify == 'true' }}
+    needs: build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -146,9 +129,9 @@ jobs:
           poetry run python tests/test_graph_validation.py
 
   last_release_acceptance_tests:
-    name: Run Acceptance Tests of Last Release
-    needs: [changes, build]
-    if: ${{ needs.changes.outputs.indexify == 'true' }}
+    name: 'Last Release Acceptance Tests (trigger with label: ci_compat_test)'
+    if: contains(github.event.pull_request.labels.*.name, 'ci_compat_test')
+    needs: build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -3,10 +3,10 @@ name: Tests
 on:
   push:
     branches:
-      - "main"
+      - 'main'
   pull_request:
     branches:
-      - "main"
+      - 'main'
 
 env:
   CARGO_TERM_COLOR: always
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      
+
       - name: Setup Node.js
         if: ${{ needs.changes.outputs.ui == 'true' }}
         uses: actions/setup-node@v3
@@ -66,6 +66,20 @@ jobs:
           cd server/
           cargo +nightly fmt -- --check
 
+      - name: Install poetry
+        if: ${{ needs.changes.outputs.other == 'true' }}
+        run: pipx install poetry
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.11
+          cache: 'poetry'
+      - name: Python Format Check
+        if: ${{ needs.changes.outputs.other == 'true' }}
+        run: |
+          cd python-sdk/
+          make check
+
   test:
     name: Run Tests
     needs: changes
@@ -74,7 +88,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Update APT package list
-        run: sudo apt-get update || true  # skip errors as temp workaround for https://github.com/tensorlakeai/indexify/actions/runs/8814655533/job/24194983960#step:3:33
+        run: sudo apt-get update || true # skip errors as temp workaround for https://github.com/tensorlakeai/indexify/actions/runs/8814655533/job/24194983960#step:3:33
       - name: Install protoc
         run: sudo apt install -y protobuf-compiler npm
       - name: Set up Python 3.9

--- a/python-sdk/Makefile
+++ b/python-sdk/Makefile
@@ -5,8 +5,12 @@ build:
 	@poetry build
 
 fmt:
-	black .
-	isort . --profile black
+	@poetry run black .
+	@poetry run isort . --profile black
+
+check:
+	@poetry run black --check .
+	@poetry run isort . --check-only --profile black
 
 lint:
 	@poetry run pylint ./indexify

--- a/python-sdk/indexify/common_util.py
+++ b/python-sdk/indexify/common_util.py
@@ -6,8 +6,7 @@ from httpx import AsyncClient, Client
 
 
 def get_httpx_client(
-    config_path: Optional[str] = None,
-    make_async: Optional[bool] = False
+    config_path: Optional[str] = None, make_async: Optional[bool] = False
 ) -> AsyncClient | Client:
     """
     Creates and returns an httpx.Client instance, optionally configured with TLS settings from a YAML config file.
@@ -44,10 +43,11 @@ def get_httpx_client(
         with open(config_path, "r") as file:
             config = yaml.safe_load(file)
         if config.get("use_tls", False):
-            print(f'Configuring client with TLS config: {config}')
+            print(f"Configuring client with TLS config: {config}")
             tls_config = config["tls_config"]
             return get_sync_or_async_client(make_async, **tls_config)
     return get_sync_or_async_client(make_async)
+
 
 def get_sync_or_async_client(
     make_async: Optional[bool] = False,
@@ -56,18 +56,18 @@ def get_sync_or_async_client(
     ca_bundle_path: Optional[str] = None,
 ) -> AsyncClient | Client:
     """
-       Creates and returns either a synchronous or asynchronous httpx client with optional TLS configuration.
+    Creates and returns either a synchronous or asynchronous httpx client with optional TLS configuration.
 
-       Args:
-           make_async (Optional[bool]): If True, returns an AsyncClient; if False, returns a synchronous Client.
-               Defaults to False.
-           cert_path (Optional[str]): Path to the client certificate file. Required for TLS configuration
-               when key_path is also provided.
-           key_path (Optional[str]): Path to the client private key file. Required for TLS configuration
-               when cert_path is also provided.
-           ca_bundle_path (Optional[str]): Path to the CA bundle file for certificate verification.
-               If not provided, defaults to system CA certificates.
-   """
+    Args:
+        make_async (Optional[bool]): If True, returns an AsyncClient; if False, returns a synchronous Client.
+            Defaults to False.
+        cert_path (Optional[str]): Path to the client certificate file. Required for TLS configuration
+            when key_path is also provided.
+        key_path (Optional[str]): Path to the client private key file. Required for TLS configuration
+            when cert_path is also provided.
+        ca_bundle_path (Optional[str]): Path to the CA bundle file for certificate verification.
+            If not provided, defaults to system CA certificates.
+    """
     if make_async:
         if cert_path and key_path:
             return httpx.AsyncClient(
@@ -82,7 +82,7 @@ def get_sync_or_async_client(
             return httpx.Client(
                 http2=True,
                 cert=(cert_path, key_path),
-                verify=ca_bundle_path if ca_bundle_path else True
+                verify=ca_bundle_path if ca_bundle_path else True,
             )
         else:
             return httpx.Client()

--- a/python-sdk/indexify/executor/agent.py
+++ b/python-sdk/indexify/executor/agent.py
@@ -3,8 +3,8 @@ import json
 import traceback
 from concurrent.futures.process import BrokenProcessPool
 from importlib.metadata import version
-from typing import Dict, List, Optional
 from pathlib import Path
+from typing import Dict, List, Optional
 
 from httpx_sse import aconnect_sse
 from pydantic import BaseModel
@@ -13,13 +13,13 @@ from rich.panel import Panel
 from rich.text import Text
 from rich.theme import Theme
 
+from indexify.common_util import get_httpx_client
 from indexify.functions_sdk.data_objects import (
     FunctionWorkerOutput,
     IndexifyData,
 )
 from indexify.functions_sdk.graph_definition import ComputeGraphMetadata
 from indexify.http_client import IndexifyClient
-from indexify.common_util import get_httpx_client
 
 from ..functions_sdk.image import ImageInformation
 from . import image_dependency_installer
@@ -82,9 +82,7 @@ class ExtractorAgent:
 
         self.num_workers = num_workers
         if config_path:
-            console.print(
-                "Running the extractor with TLS enabled", style="cyan bold"
-            )
+            console.print("Running the extractor with TLS enabled", style="cyan bold")
             self._protocol = "https"
         else:
             self._protocol = "http"
@@ -107,7 +105,7 @@ class ExtractorAgent:
         self._task_reporter = TaskReporter(
             base_url=self._base_url,
             executor_id=self._executor_id,
-            config_path=self._config_path
+            config_path=self._config_path,
         )
 
     async def task_completion_reporter(self):
@@ -349,7 +347,7 @@ class ExtractorAgent:
         self._should_run = True
         while self._should_run:
             url = f"{self._protocol}://{self._server_addr}/internal/executors/{self._executor_id}/tasks"
-            print(f'calling url: {url}')
+            print(f"calling url: {url}")
 
             def to_sentence_case(snake_str):
                 words = snake_str.split("_")
@@ -442,8 +440,9 @@ async def _get_image_info_for_compute_graph(
     compute_fn_name: str = task.compute_fn
 
     http_client = IndexifyClient(
-        service_url=f"{protocol}://{server_addr}", namespace=namespace,
-        config_path=config_path
+        service_url=f"{protocol}://{server_addr}",
+        namespace=namespace,
+        config_path=config_path,
     )
     compute_graph: ComputeGraphMetadata = http_client.graph(graph_name)
 

--- a/python-sdk/indexify/executor/downloader.py
+++ b/python-sdk/indexify/executor/downloader.py
@@ -10,8 +10,8 @@ from rich.theme import Theme
 from indexify.functions_sdk.data_objects import IndexifyData
 from indexify.functions_sdk.object_serializer import MsgPackSerializer
 
-from .api_objects import Task
 from ..common_util import get_httpx_client
+from .api_objects import Task
 
 custom_theme = Theme(
     {
@@ -30,7 +30,9 @@ class DownloadedInputs(BaseModel):
 
 
 class Downloader:
-    def __init__(self, code_path: str, base_url: str, config_path: Optional[str] = None):
+    def __init__(
+        self, code_path: str, base_url: str, config_path: Optional[str] = None
+    ):
         self.code_path = code_path
         self.base_url = base_url
         self._client = get_httpx_client(config_path)

--- a/python-sdk/indexify/executor/function_worker.py
+++ b/python-sdk/indexify/executor/function_worker.py
@@ -15,10 +15,10 @@ from indexify.functions_sdk.data_objects import (
 from indexify.functions_sdk.indexify_functions import (
     FunctionCallResult,
     GraphInvocationContext,
-    IndexifyFunctionWrapper,
-    RouterCallResult,
-    IndexifyRouter,
     IndexifyFunction,
+    IndexifyFunctionWrapper,
+    IndexifyRouter,
+    RouterCallResult,
 )
 
 function_wrapper_map: Dict[str, IndexifyFunctionWrapper] = {}

--- a/python-sdk/indexify/executor/task_reporter.py
+++ b/python-sdk/indexify/executor/task_reporter.py
@@ -23,7 +23,9 @@ FORCE_MULTIPART = ForceMultipartDict()
 
 
 class TaskReporter:
-    def __init__(self, base_url: str, executor_id: str, config_path: Optional[str] = None):
+    def __init__(
+        self, base_url: str, executor_id: str, config_path: Optional[str] = None
+    ):
         self._base_url = base_url
         self._executor_id = executor_id
         self._client = get_httpx_client(config_path)

--- a/python-sdk/indexify/http_client.py
+++ b/python-sdk/indexify/http_client.py
@@ -175,6 +175,20 @@ class IndexifyClient:
         for fn_name, fn in graph.nodes.items():
             self._fns[f"{graph.name}/{fn_name}"] = fn
 
+    def delete_compute_graph(
+        self,
+        graph_name: str,
+    ) -> None:
+        """
+        Deletes a graph and all of its invocations from the namespace.
+        :param graph_name The name of the graph to delete.
+        WARNING: This operation is irreversible.
+        """
+        response = self._delete(
+            f"namespaces/{self.namespace}/compute_graphs/{graph_name}",
+        )
+        response.raise_for_status()
+
     def graphs(self) -> List[str]:
         response = self._get(f"graphs")
         return response.json()["graphs"]

--- a/python-sdk/tests/test_constants.py
+++ b/python-sdk/tests/test_constants.py
@@ -5,8 +5,8 @@ tls_config = {
     "tls_config": {
         "ca_bundle_path": "/path/to/ca_bundle.pem",
         "cert_path": "/path/to/cert.pem",
-        "key_path": "/path/to/key.pem"
-    }
+        "key_path": "/path/to/key.pem",
+    },
 }
 
 cert_path = tls_config["tls_config"]["cert_path"]
@@ -16,12 +16,12 @@ service_url = "localhost:8900"
 config_path = "test/config/path"
 code_path = "test/code_path"
 task = Task(
-    id = "test_id",
-    namespace = "default",
-    compute_graph = "test_compute_graph",
-    compute_fn = "test_compute_fn",
-    invocation_id = "test_invocation_id",
-    input_key = "test|input|key",
-    requester_output_id = "test_output_id",
-    graph_version = 1,
+    id="test_id",
+    namespace="default",
+    compute_graph="test_compute_graph",
+    compute_fn="test_compute_fn",
+    invocation_id="test_invocation_id",
+    input_key="test|input|key",
+    requester_output_id="test_output_id",
+    graph_version=1,
 )

--- a/python-sdk/tests/test_downloader_behaviour.py
+++ b/python-sdk/tests/test_downloader_behaviour.py
@@ -1,28 +1,25 @@
 import unittest
-from unittest.mock import patch, mock_open
+from unittest.mock import mock_open, patch
 
-from indexify.executor.downloader import Downloader
 from test_constants import *
 
-class TestDownloaderBehaviour(unittest.TestCase):
+from indexify.executor.downloader import Downloader
 
+
+class TestDownloaderBehaviour(unittest.TestCase):
     @patch("httpx.Client")
     @patch(
-        'builtins.open',
+        "builtins.open",
         new_callable=mock_open,
-        read_data='''
+        read_data="""
                     use_tls: true
                     tls_config:
                         ca_bundle_path: /path/to/ca_bundle.pem
                         cert_path: /path/to/cert.pem
                         key_path: /path/to/key.pem
-                    '''
+                    """,
     )
-    def test_download_input_initialised_with_mTLS(
-        self,
-        mock_file,
-        mock_client
-    ):
+    def test_download_input_initialised_with_mTLS(self, mock_file, mock_client):
         downloader = Downloader(
             code_path=code_path,
             base_url=service_url,
@@ -40,16 +37,8 @@ class TestDownloaderBehaviour(unittest.TestCase):
         )
 
     @patch("httpx.Client")
-    @patch(
-        'builtins.open',
-        new_callable=mock_open,
-        read_data='''use_tls: false'''
-    )
-    def test_download_input_initialised_without_mTLS(
-        self,
-        mock_file,
-        mock_client
-    ):
+    @patch("builtins.open", new_callable=mock_open, read_data="""use_tls: false""")
+    def test_download_input_initialised_without_mTLS(self, mock_file, mock_client):
         downloader = Downloader(
             code_path=code_path,
             base_url=service_url,
@@ -58,5 +47,6 @@ class TestDownloaderBehaviour(unittest.TestCase):
         mock_file.assert_called()
         mock_client.assert_called_with()
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()

--- a/python-sdk/tests/test_extractor_agent_behaviour.py
+++ b/python-sdk/tests/test_extractor_agent_behaviour.py
@@ -1,37 +1,41 @@
 import ssl
 import unittest
 from pathlib import Path
-from unittest.mock import patch, mock_open
+from unittest.mock import mock_open, patch
+
+from test_constants import (
+    ca_bundle_path,
+    cert_path,
+    config_path,
+    key_path,
+    service_url,
+    tls_config,
+)
 
 from indexify.executor.agent import ExtractorAgent
-from test_constants import tls_config, service_url, config_path, cert_path, key_path, ca_bundle_path
+
 
 class TestExtractorAgent(unittest.TestCase):
-
     @patch(
-        'builtins.open',
+        "builtins.open",
         new_callable=mock_open,
-        read_data='''
+        read_data="""
                 use_tls: true
                 tls_config:
                     ca_bundle_path: /path/to/ca_bundle.pem
                     cert_path: /path/to/cert.pem
                     key_path: /path/to/key.pem
-                '''
+                """,
     )
-    @patch('httpx.Client')
-    def test_tls_configuration(
-        self,
-        mock_client,
-        mock_file
-    ):
+    @patch("httpx.Client")
+    def test_tls_configuration(self, mock_client, mock_file):
         # Create an instance of ExtractorAgent with the mock config
         agent = ExtractorAgent(
             executor_id="unit-test",
             num_workers=1,
             code_path=Path("test"),
             server_addr=service_url,
-            config_path=config_path
+            config_path=config_path,
         )
 
         # Verify that the correct file was loaded from the config_path
@@ -58,7 +62,8 @@ class TestExtractorAgent(unittest.TestCase):
         )
 
         # Verify the protocol is set to "http"
-        self.assertEqual(agent._protocol, 'http')
+        self.assertEqual(agent._protocol, "http")
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()

--- a/python-sdk/tests/test_function_worker.py
+++ b/python-sdk/tests/test_function_worker.py
@@ -1,3 +1,4 @@
+import sys
 import tempfile
 import unittest
 from typing import List, Mapping, Union
@@ -12,7 +13,6 @@ from indexify.functions_sdk.indexify_functions import (
     IndexifyFunctionWrapper,
     indexify_function,
 )
-import sys
 
 
 @indexify_function()
@@ -75,7 +75,9 @@ class TestFunctionWorker(unittest.IsolatedAsyncioTestCase):
 
     async def test_function_worker_happy_path(self):
         with tempfile.NamedTemporaryFile(delete=True) as temp_file:
-            code_bytes = cloudpickle.dumps(self.g.serialize(additional_modules=[sys.modules[__name__]]))
+            code_bytes = cloudpickle.dumps(
+                self.g.serialize(additional_modules=[sys.modules[__name__]])
+            )
 
             temp_file.write(code_bytes)
             temp_file.flush()

--- a/python-sdk/tests/test_graph_behaviours.py
+++ b/python-sdk/tests/test_graph_behaviours.py
@@ -2,9 +2,8 @@ import sys
 import unittest
 from pathlib import Path
 from typing import List, Union
+
 from parameterized import parameterized
-
-
 from pydantic import BaseModel
 
 from indexify import (
@@ -31,7 +30,7 @@ def simple_function(x: MyObject) -> MyObject:
 
 @indexify_function()
 def simple_function_multiple_inputs(x: MyObject, y: int) -> MyObject:
-    suf = ''.join(["b" for _ in range(y)])
+    suf = "".join(["b" for _ in range(y)])
     return MyObject(x=x.x + suf)
 
 
@@ -42,7 +41,7 @@ def simple_function_with_json_encoder(x: MyObject) -> MyObject:
 
 @indexify_function(encoder="json")
 def simple_function_multiple_inputs_json(x: MyObject, y: int) -> MyObject:
-    suf = ''.join(["b" for _ in range(y)])
+    suf = "".join(["b" for _ in range(y)])
     return MyObject(x=x.x + suf)
 
 
@@ -224,7 +223,9 @@ class TestGraphBehaviors(unittest.TestCase):
     @parameterized.expand([(False), (True)])
     def test_simple_function_multiple_inputs(self, is_remote):
         graph = Graph(
-            name="test_simple_function2", description="test", start_node=simple_function_multiple_inputs
+            name="test_simple_function2",
+            description="test",
+            start_node=simple_function_multiple_inputs,
         )
         graph = remote_or_local_graph(graph, is_remote)
         invocation_id = graph.run(block_until_done=True, x=MyObject(x="a"), y=10)
@@ -234,7 +235,9 @@ class TestGraphBehaviors(unittest.TestCase):
     @parameterized.expand([(False), (True)])
     def test_simple_function_multiple_inputs_json(self, is_remote=False):
         graph = Graph(
-            name="test_simple_function2_json", description="test", start_node=simple_function_multiple_inputs_json
+            name="test_simple_function2_json",
+            description="test",
+            start_node=simple_function_multiple_inputs_json,
         )
         graph = remote_or_local_graph(graph, is_remote)
         invocation_id = graph.run(block_until_done=True, x=MyObject(x="a"), y=10)


### PR DESCRIPTION
## Context

<!--
In a few sentences or less, please explain the context behind this change to help answer why this change is needed.

If this is a bug fix, make sure to include "fixes #xxxx", or
"closes #xxxx".

Screenshots, logs, code or other visual aids are greatly appreciated.
 -->

There is currently no way to delete a compute graph using the SDK.

## What

<!--
In a few sentences, please summarize the change to help reviewers.

Consider providing screenshots, logs, code or other visual aids to help the reviewer understand the approach taken.
-->

A new `delete_compute_graph` function is added to the `IndexifyClient`.

## Testing

<!--
Please include steps used to verify the change.

Consider providing screenshots, logs, code or other visual aids to help the reviewer in their testing.
-->

## Contribution Checklist

- [x] If the python-sdk was changed, please run `make fmt` in `python-sdk/`.
- [x] If the server was changed, please run `make fmt` in `server/`.
- [x] Make sure all PR Checks are passing.
<!-- You can run the tests manually:
In `python-sdk/`, run the run `pip install -e .`, start the server and executor, `python test_graph_behaviours.py`.

