### PR TITLE
fix(server,sdk)!: rename rerun to replay_invocations for clarity

### DIFF
--- a/python-sdk/indexify/http_client.py
+++ b/python-sdk/indexify/http_client.py
@@ -126,9 +126,7 @@ class IndexifyClient:
             raise ValueError("Both cert and key must be provided for mTLS")
 
         client = get_sync_or_async_client(
-            cert_path=cert_path,
-            key_path=key_path,
-            ca_bundle_path=ca_bundle_path
+            cert_path=cert_path, key_path=key_path, ca_bundle_path=ca_bundle_path
         )
 
         indexify_client = IndexifyClient(service_url, *args, **kwargs)
@@ -253,8 +251,8 @@ class IndexifyClient:
             print(f"failed to fetch logs: {e}")
             return None
 
-    def rerun_graph(self, graph: str):
-        self._post(f"namespaces/{self.namespace}/compute_graphs/{graph}/rerun")
+    def replay_invocations(self, graph: str):
+        self._post(f"namespaces/{self.namespace}/compute_graphs/{graph}/replay")
 
     def invoke_graph_with_object(
         self, graph: str, block_until_done: bool = False, **kwargs

--- a/python-sdk/indexify/remote_graph.py
+++ b/python-sdk/indexify/remote_graph.py
@@ -39,7 +39,6 @@ class RemoteGraph:
         :return: The invocation ID of the graph execution.
 
         Example:
-
             @indexify_function()
             def foo(x: int) -> int:
                 return x + 1
@@ -51,13 +50,14 @@ class RemoteGraph:
             self._name, block_until_done, **kwargs
         )
 
-    def rerun(self):
+    def replay_invocations(self):
         """
-        Rerun the graph with the given invocation ID.
+        Replay all the graph previous runs/invocations on the latest version of the graph.
 
-        :param invocation_id: The invocation ID of the graph execution.
+        This is useful to make all the previous invocations go through
+        an updated graph to take advantage of graph improvements.
         """
-        self._client.rerun_graph(self._name)
+        self._client.replay_invocations(self._name)
 
     @classmethod
     def deploy(

--- a/python-sdk/tests/test_graph_update.py
+++ b/python-sdk/tests/test_graph_update.py
@@ -32,7 +32,7 @@ class TestGraphUpdate(unittest.TestCase):
 
         g = Graph(name="updategraph1", start_node=update2)
         g = RemoteGraph.deploy(g)
-        g.rerun()
+        g.replay_invocations()
         time.sleep(1)
         output = g.output(invocation_id, fn_name="update2")
         self.assertEqual(output[0], Object(x="ac"))

--- a/server/src/routes.rs
+++ b/server/src/routes.rs
@@ -61,7 +61,7 @@ use download::{
     download_invocation_payload,
 };
 use internal_ingest::ingest_files_from_executor;
-use invoke::{invoke_with_file, invoke_with_object, rerun_compute_graph};
+use invoke::{invoke_with_file, invoke_with_object, replay_compute_graph};
 use logs::download_task_logs;
 
 use crate::{
@@ -289,8 +289,8 @@ pub fn namespace_routes(route_state: RouteState) -> Router {
             post(invoke_with_object).with_state(route_state.clone()),
         )
         .route(
-            "/compute_graphs/:compute_graph/rerun",
-            post(rerun_compute_graph).with_state(route_state.clone()),
+            "/compute_graphs/:compute_graph/replay",
+            post(replay_compute_graph).with_state(route_state.clone()),
         )
         .route(
             "/compute_graphs/:compute_graph/invocations/:invocation_id",

--- a/server/src/routes/invoke.rs
+++ b/server/src/routes/invoke.rs
@@ -14,8 +14,8 @@ use state_store::{
     invocation_events::{InvocationFinishedEvent, InvocationStateChangeEvent},
     requests::{
         InvokeComputeGraphRequest,
+        ReplayComputeGraphRequest,
         RequestPayload,
-        RerunComputeGraphRequest,
         StateMachineUpdateRequest,
     },
 };
@@ -234,10 +234,10 @@ pub async fn invoke_with_object(
     )
 }
 
-/// Rerun compute graph with all existing payloads
+/// Replay compute graph with all previous invocation payloads
 #[utoipa::path(
     post,
-    path = "/namespaces/{namespace}/compute_graphs/{compute_graph}/rerun",
+    path = "/namespaces/{namespace}/compute_graphs/{compute_graph}/replay",
     request_body(content_type = "application/json", content = inline(serde_json::Value)),
     tag = "ingestion",
     responses(
@@ -246,11 +246,11 @@ pub async fn invoke_with_object(
         (status = INTERNAL_SERVER_ERROR, description = "Internal Server Error")
     ),
 )]
-pub async fn rerun_compute_graph(
+pub async fn replay_compute_graph(
     Path((namespace, compute_graph)): Path<(String, String)>,
     State(state): State<RouteState>,
 ) -> Result<(), IndexifyAPIError> {
-    let request = RequestPayload::RerunComputeGraph(RerunComputeGraphRequest {
+    let request = RequestPayload::ReplayComputeGraph(ReplayComputeGraphRequest {
         namespace: namespace.clone(),
         compute_graph_name: compute_graph.clone(),
     });
@@ -262,7 +262,7 @@ pub async fn rerun_compute_graph(
         })
         .await
         .map_err(|e| {
-            IndexifyAPIError::internal_error(anyhow!("failed to create graph rerun task: {}", e))
+            IndexifyAPIError::internal_error(anyhow!("failed to create graph replay task: {}", e))
         })?;
     Ok(())
 }

--- a/server/src/system_tasks.rs
+++ b/server/src/system_tasks.rs
@@ -64,8 +64,8 @@ impl SystemTasksExecutor {
                 tracing::info!("Executing invocation {:?}", invocation);
                 self.state
                     .write(state_store::requests::StateMachineUpdateRequest {
-                        payload: state_store::requests::RequestPayload::RerunInvocation(
-                            state_store::requests::RerunInvocationRequest {
+                        payload: state_store::requests::RequestPayload::ReplayInvocation(
+                            state_store::requests::ReplayInvocationRequest {
                                 namespace: task.namespace.clone(),
                                 compute_graph_name: task.compute_graph_name.clone(),
                                 graph_version: task.graph_version.clone(),
@@ -145,8 +145,8 @@ mod tests {
         CreateComputeGraphRequest,
         FinalizeTaskRequest,
         InvokeComputeGraphRequest,
+        ReplayComputeGraphRequest,
         RequestPayload,
-        RerunComputeGraphRequest,
         StateMachineUpdateRequest,
     };
     use tracing_subscriber::{layer::SubscriberExt, Layer};
@@ -202,7 +202,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_graph_rerun() -> Result<()> {
+    async fn test_graph_replay() -> Result<()> {
         let env_filter = tracing_subscriber::EnvFilter::try_from_default_env()
             .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info"));
         let _ = tracing::subscriber::set_global_default(
@@ -332,7 +332,7 @@ mod tests {
                 .invocation_ctx(&graph.namespace, &graph.name, &invocation_payload.id)?;
         assert_eq!(graph_ctx.unwrap().outstanding_tasks, 0);
 
-        let request = RequestPayload::RerunComputeGraph(RerunComputeGraphRequest {
+        let request = RequestPayload::ReplayComputeGraph(ReplayComputeGraphRequest {
             namespace: graph.namespace.clone(),
             compute_graph_name: graph.name.clone(),
         });
@@ -382,7 +382,7 @@ mod tests {
 
         let graph = graphs[0].clone();
 
-        let request = RequestPayload::RerunComputeGraph(RerunComputeGraphRequest {
+        let request = RequestPayload::ReplayComputeGraph(ReplayComputeGraphRequest {
             namespace: graph.namespace.clone(),
             compute_graph_name: graph.name.clone(),
         });
@@ -550,7 +550,7 @@ mod tests {
     // tasks in progress should stays at or below MAX_PENDING_TASKS
     // all tasks should complete eventually
     #[tokio::test]
-    async fn test_graph_flow_control_rerun() -> Result<()> {
+    async fn test_graph_flow_control_replay() -> Result<()> {
         let env_filter = tracing_subscriber::EnvFilter::try_from_default_env()
             .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info"));
         let _ = tracing::subscriber::set_global_default(
@@ -637,7 +637,7 @@ mod tests {
 
         let graph = graphs[0].clone();
 
-        let request = RequestPayload::RerunComputeGraph(RerunComputeGraphRequest {
+        let request = RequestPayload::ReplayComputeGraph(ReplayComputeGraphRequest {
             namespace: graph.namespace.clone(),
             compute_graph_name: graph.name.clone(),
         });

--- a/server/state_store/src/lib.rs
+++ b/server/state_store/src/lib.rs
@@ -178,15 +178,15 @@ impl IndexifyState {
                 )?;
                 state_changes
             }
-            requests::RequestPayload::RerunComputeGraph(rerun_compute_graph_request) => {
+            requests::RequestPayload::ReplayComputeGraph(replay_compute_graph_request) => {
                 tracing::info!(
-                    "rerun compute graph: {:?}",
-                    rerun_compute_graph_request.compute_graph_name
+                    "replay compute graph: {:?}",
+                    replay_compute_graph_request.compute_graph_name
                 );
-                state_machine::rerun_compute_graph(
+                state_machine::replay_compute_graph(
                     self.db.clone(),
                     &txn,
-                    rerun_compute_graph_request.clone(),
+                    replay_compute_graph_request.clone(),
                 )?;
                 let _ = self.system_tasks_tx.send(());
                 vec![]
@@ -207,11 +207,11 @@ impl IndexifyState {
                 )?;
                 vec![]
             }
-            requests::RequestPayload::RerunInvocation(rerun_invocation_request) => {
-                let mut state_changes = state_machine::rerun_invocation(
+            requests::RequestPayload::ReplayInvocation(replay_invocation_request) => {
+                let mut state_changes = state_machine::replay_invocation(
                     self.db.clone(),
                     &txn,
-                    rerun_invocation_request.clone(),
+                    replay_invocation_request.clone(),
                 )?;
                 for state_change in &mut state_changes {
                     let last_change_id = self

--- a/server/state_store/src/requests.rs
+++ b/server/state_store/src/requests.rs
@@ -19,8 +19,8 @@ pub struct StateMachineUpdateRequest {
 
 pub enum RequestPayload {
     InvokeComputeGraph(InvokeComputeGraphRequest),
-    RerunComputeGraph(RerunComputeGraphRequest),
-    RerunInvocation(RerunInvocationRequest),
+    ReplayComputeGraph(ReplayComputeGraphRequest),
+    ReplayInvocation(ReplayInvocationRequest),
     FinalizeTask(FinalizeTaskRequest),
     CreateNameSpace(NamespaceRequest),
     CreateComputeGraph(CreateComputeGraphRequest),
@@ -48,7 +48,7 @@ pub struct RemoveSystemTaskRequest {
 }
 
 #[derive(Debug, Clone)]
-pub struct RerunInvocationRequest {
+pub struct ReplayInvocationRequest {
     pub namespace: String,
     pub compute_graph_name: String,
     pub graph_version: GraphVersion,
@@ -75,7 +75,7 @@ pub struct InvokeComputeGraphRequest {
 }
 
 #[derive(Debug, Clone)]
-pub struct RerunComputeGraphRequest {
+pub struct ReplayComputeGraphRequest {
     pub namespace: String,
     pub compute_graph_name: String,
 }

--- a/server/state_store/src/state_machine.rs
+++ b/server/state_store/src/state_machine.rs
@@ -43,8 +43,8 @@ use crate::requests::{
     ReductionTasks,
     RegisterExecutorRequest,
     RemoveSystemTaskRequest,
-    RerunComputeGraphRequest,
-    RerunInvocationRequest,
+    ReplayComputeGraphRequest,
+    ReplayInvocationRequest,
     UpdateSystemTaskRequest,
 };
 
@@ -147,10 +147,10 @@ pub fn update_system_task(
     Ok(())
 }
 
-pub fn rerun_compute_graph(
+pub fn replay_compute_graph(
     db: Arc<TransactionDB>,
     txn: &Transaction<TransactionDB>,
-    req: RerunComputeGraphRequest,
+    req: ReplayComputeGraphRequest,
 ) -> Result<()> {
     let key = format!("{}|{}", req.namespace, req.compute_graph_name);
     let graph = txn
@@ -188,10 +188,10 @@ pub fn rerun_compute_graph(
     Ok(())
 }
 
-pub fn rerun_invocation(
+pub fn replay_invocation(
     db: Arc<TransactionDB>,
     txn: &Transaction<TransactionDB>,
-    req: RerunInvocationRequest,
+    req: ReplayInvocationRequest,
 ) -> Result<Vec<StateChange>> {
     let graph_ctx_key =
         GraphInvocationCtx::key_from(&req.namespace, &req.compute_graph_name, &req.invocation_id);
@@ -205,7 +205,7 @@ pub fn rerun_invocation(
     let graph_ctx: GraphInvocationCtx = JsonEncoder::decode(&graph_ctx)?;
     if graph_ctx.graph_version >= req.graph_version {
         tracing::info!(
-            "skipping rerun of invocation: {}, already latest version of invocation context",
+            "skipping replay of invocation: {}, already latest version of invocation context",
             req.invocation_id
         );
         return Ok(Vec::new());
@@ -225,7 +225,7 @@ pub fn rerun_invocation(
         let value: NodeOutput = JsonEncoder::decode(&value)?;
         if value.graph_version >= req.graph_version {
             tracing::info!(
-                "skipping rerun of invocation: {}, already latest version of outputs",
+                "skipping replay of invocation: {}, already latest version of outputs",
                 req.invocation_id
             );
             return Ok(Vec::new());
@@ -242,7 +242,7 @@ pub fn rerun_invocation(
         .ok_or(anyhow::anyhow!("Compute graph not found"))?;
     let graph = JsonEncoder::decode::<ComputeGraph>(&graph)?;
     if graph.version > req.graph_version {
-        // Graph was updated after rerun task was created
+        // Graph was updated after replay task was created
         return Ok(Vec::new());
     }
 


### PR DESCRIPTION
## Context

<!--
In a few sentences or less, please explain the context behind this change to help answer why this change is needed.

If this is a bug fix, make sure to include "fixes #xxxx", or
"closes #xxxx".

Screenshots, logs, code or other visual aids are greatly appreciated.
 -->

The current term `rerun` is confusing especially when compared with the `run` method.

Example 1:
```
invocation_id = g.run(block_until_done=True, x=Object(x="a"))
```

Example 2:
```
g.rerun()
```

The code difference between Example 1 and 2 is minimal but the impact on the graph's data is immense. Example 2 will go through all previous `runs`/`invocations` and will execute them again but on the latest version of the graph.

## What

<!--
In a few sentences, please summarize the change to help reviewers.

Consider providing screenshots, logs, code or other visual aids to help the reviewer understand the approach taken.
-->

We are renaming `rerun` to `replay_invocation` in the SDK and in the server to remove any possible confusion.

## Testing

<!--
Please include steps used to verify the change.

Consider providing screenshots, logs, code or other visual aids to help the reviewer in their testing.
-->

The test_graph_update.py tests replay.

## Contribution Checklist

- [x] If the python-sdk was changed, please run `make fmt` in `python-sdk/`.
- [x] If the server was changed, please run `make fmt` in `server/`.
- [x] Make sure all PR Checks are passing.
<!-- You can run the tests manually:
In `python-sdk/`, run the run `pip install -e .`, start the server and executor, `python test_graph_behaviours.py`.

