### PR TITLE
chore(server): create and use ComputeGraph::key_from

### DIFF
--- a/server/data_model/src/lib.rs
+++ b/server/data_model/src/lib.rs
@@ -334,7 +334,11 @@ pub struct ComputeGraph {
 
 impl ComputeGraph {
     pub fn key(&self) -> String {
-        format!("{}|{}", self.namespace, self.name)
+        ComputeGraph::key_from(&self.namespace, &self.name)
+    }
+
+    pub fn key_from(namespace: &str, name: &str) -> String {
+        format!("{}|{}", namespace, name)
     }
 }
 

--- a/server/state_store/src/scanner.rs
+++ b/server/state_store/src/scanner.rs
@@ -467,7 +467,7 @@ impl StateReader {
     }
 
     pub fn get_compute_graph(&self, namespace: &str, name: &str) -> Result<Option<ComputeGraph>> {
-        let key = format!("{}|{}", namespace, name);
+        let key = ComputeGraph::key_from(namespace, name);
         let compute_graph = self.get_from_cf(&IndexifyObjectsColumns::ComputeGraphs, key)?;
         Ok(compute_graph)
     }

--- a/server/state_store/src/state_machine.rs
+++ b/server/state_store/src/state_machine.rs
@@ -152,7 +152,7 @@ pub fn rerun_compute_graph(
     txn: &Transaction<TransactionDB>,
     req: RerunComputeGraphRequest,
 ) -> Result<()> {
-    let key = format!("{}|{}", req.namespace, req.compute_graph_name);
+    let key = ComputeGraph::key_from(&req.namespace, &req.compute_graph_name);
     let graph = txn
         .get_for_update_cf(
             &IndexifyObjectsColumns::ComputeGraphs.cf_db(&db),
@@ -232,7 +232,8 @@ pub fn rerun_invocation(
         }
     }
 
-    let compute_graph_key = format!("{}|{}", req.namespace, req.compute_graph_name);
+    let compute_graph_key =
+        ComputeGraph::key_from(req.namespace.as_str(), req.compute_graph_name.as_str());
     let graph = txn
         .get_for_update_cf(
             &IndexifyObjectsColumns::ComputeGraphs.cf_db(&db),
@@ -315,7 +316,8 @@ pub fn create_graph_input(
     txn: &Transaction<TransactionDB>,
     req: &InvokeComputeGraphRequest,
 ) -> Result<()> {
-    let compute_graph_key = format!("{}|{}", req.namespace, req.compute_graph_name);
+    let compute_graph_key =
+        ComputeGraph::key_from(req.namespace.as_str(), req.compute_graph_name.as_str());
     let cg = txn
         .get_for_update_cf(
             &IndexifyObjectsColumns::ComputeGraphs.cf_db(&db),
@@ -436,7 +438,7 @@ pub fn delete_compute_graph(
 ) -> Result<()> {
     txn.delete_cf(
         &IndexifyObjectsColumns::ComputeGraphs.cf_db(&db),
-        format!("{}|{}", namespace, name),
+        ComputeGraph::key_from(namespace, name),
     )?;
     let prefix = format!("{}|{}|", namespace, name);
     delete_cf_prefix(


### PR DESCRIPTION
## Context

<!--
In a few sentences or less, please explain the context behind this change to help answer why this change is needed.

If this is a bug fix, make sure to include "fixes #xxxx", or
"closes #xxxx".

Screenshots, logs, code or other visual aids are greatly appreciated.
 -->

Compute graph key creation was not abstracted in the data_model.

## What

<!--
In a few sentences, please summarize the change to help reviewers.

Consider providing screenshots, logs, code or other visual aids to help the reviewer understand the approach taken.
-->

This PR ensures that all compute graph key is created from the compute graph data model.

## Testing

<!--
Please include steps used to verify the change.

Consider providing screenshots, logs, code or other visual aids to help the reviewer in their testing.
-->

N/A

## Contribution Checklist

- [x] If the python-sdk was changed, please run `make fmt` in `python-sdk/`.
- [x] If the server was changed, please run `make fmt` in `server/`.
- [x] Make sure all PR Checks are passing.
<!-- You can run the tests manually:
In `python-sdk/`, run the run `pip install -e .`, start the server and executor, `python test_graph_behaviours.py`.

