### PR TITLE
feat: add default page to server

### DIFF
--- a/server/src/index.html
+++ b/server/src/index.html
@@ -1,0 +1,107 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Indexify Server</title>
+    <style>
+        body {
+            margin: 0;
+            padding: 0;
+            min-height: 100vh;
+            display: flex;
+            flex-direction: column;
+            font-family: system-ui, -apple-system, sans-serif;
+            background: linear-gradient(135deg, #f5f7fa 0%, #c3cfe2 100%);
+        }
+        
+        .container {
+            flex: 1;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            padding: 2rem;
+            text-align: center;
+        }
+        
+        h1 {
+            font-size: 2.5rem;
+            color: #2d3748;
+            margin-bottom: 1rem;
+        }
+        
+        .description {
+            color: #4a5568;
+            margin-bottom: 2rem;
+            max-width: 600px;
+            line-height: 1.6;
+        }
+        
+        .buttons {
+            display: flex;
+            gap: 1rem;
+            flex-wrap: wrap;
+            justify-content: center;
+        }
+        
+        .button {
+            display: inline-flex;
+            align-items: center;
+            padding: 0.75rem 1.5rem;
+            font-size: 1rem;
+            font-weight: 500;
+            text-decoration: none;
+            color: white;
+            background-color: #4299e1;
+            border-radius: 0.375rem;
+            transition: background-color 0.2s;
+        }
+        
+        .button:hover {
+            background-color: #3182ce;
+        }
+        
+        .button svg {
+            margin-right: 0.5rem;
+            width: 1.25rem;
+            height: 1.25rem;
+        }
+        
+        footer {
+            text-align: center;
+            padding: 1rem;
+            color: #4a5568;
+            font-size: 0.875rem;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>Welcome to Indexify Server</h1>
+        <p class="description">
+            Indexify is a realtime serving engine for Data-Intensive Generative AI Applications. Choose from the options below to get started.
+        </p>
+        <div class="buttons">
+            <a href="https://docs.tensorlake.ai" target="_blank" class="button">
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+                </svg>
+                Docs
+            </a>
+            <a href="/ui" class="button">
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
+                </svg>
+                Launch UI
+            </a>
+            <a href="/docs/swagger/#/" class="button">
+                <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+                </svg>
+                Swagger API
+            </a>
+        </div>
+    </div>
+</body>
+</html>

--- a/server/src/routes.rs
+++ b/server/src/routes.rs
@@ -15,7 +15,7 @@ use axum::{
     },
     http::{Method, Response},
     middleware::{self, Next},
-    response::{sse::Event, IntoResponse},
+    response::{sse::Event, Html, IntoResponse},
     routing::{delete, get, post},
     Json,
     Router,
@@ -218,8 +218,8 @@ pub fn create_routes(route_state: RouteState) -> Router {
         .layer(DefaultBodyLimit::disable())
 }
 
-async fn index() -> &'static str {
-    "Indexify Server"
+async fn index() -> impl IntoResponse {
+    Html(include_str!("./index.html"))
 }
 
 #[axum::debug_handler]


### PR DESCRIPTION
## Description:

- Addresses one of the comment form our community members for having a better page than just showing "Indexify Server"

## What:

- Adds a default/static page to the server when users run `indexify-server` and open `localhost:8900`

## Screenshot

<img width="1511" alt="image" src="https://github.com/user-attachments/assets/d78cd1fb-da9c-4207-929a-1218bf38aa3c">


## Contribution Checklist

- ~~[ ] If the python-sdk was changed, please run `make fmt` in `python-sdk/`~~.
- [x] If the server was changed, please run `make fmt` in `server/`.
- [x] Make sure all PR Checks are passing.
<!-- You can run the tests manually:
In `python-sdk/`, run the run `pip install -e .`, start the server and executor, `python test_graph_behaviours.py`.

