### PR TITLE
feat(server): stop updating immutable fields of a compute grapgh

### DIFF
--- a/python-sdk/tests/test_graph_update.py
+++ b/python-sdk/tests/test_graph_update.py
@@ -24,13 +24,17 @@ def update2(x: Object) -> Object:
 
 class TestGraphUpdate(unittest.TestCase):
     def test_graph_update(self):
-        g = Graph(name="updategraph1", start_node=update)
+        g = Graph(
+            name="updategraph1", description="test graph update", start_node=update
+        )
         g = RemoteGraph.deploy(g)
         invocation_id = g.run(block_until_done=True, x=Object(x="a"))
         output = g.output(invocation_id, fn_name="update")
         self.assertEqual(output[0], Object(x="ab"))
 
-        g = Graph(name="updategraph1", start_node=update2)
+        g = Graph(
+            name="updategraph1", description="test graph update (2)", start_node=update2
+        )
         g = RemoteGraph.deploy(g)
         g.replay_invocations()
         time.sleep(1)

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -2,7 +2,7 @@
 
 set -ex
 
-(cd server && cargo test -- --test-threads 1)
+(cd server && cargo test --workspace -- --test-threads 1)
 
 echo "Ok, that is enough"
 

--- a/server/data_model/src/test_objects.rs
+++ b/server/data_model/src/test_objects.rs
@@ -47,7 +47,7 @@ pub mod tests {
             .unwrap()
     }
 
-    fn test_compute_fn(name: &str, image_hash: Option<String>) -> ComputeFn {
+    pub fn test_compute_fn(name: &str, image_hash: Option<String>) -> ComputeFn {
         match image_hash {
             Some(image_hash) => {
                 let mut image_information = ImageInformation::default();


### PR DESCRIPTION
## Context

<!--
In a few sentences or less, please explain the context behind this change to help answer why this change is needed.

If this is a bug fix, make sure to include "fixes #xxxx", or
"closes #xxxx".

Screenshots, logs, code or other visual aids are greatly appreciated.
 -->

Currently, we override all the compute graph fields with the JSON payload of the API. This may override immutable fields like the version, the namespace or the created_at fields when those are not mean to be update-able.

Additionally, this prepares the code to introduce a future `replay_running` field on the compute graph which would be another non update-able field.

## What

<!--
In a few sentences, please summarize the change to help reviewers.

Consider providing screenshots, logs, code or other visual aids to help the reviewer understand the approach taken.
-->

Move compute graph update login into a update method on the `ComputeGraph` data-model. Move update business logic in that update method (like image and graph versioning).

## Testing

<!--
Please include steps used to verify the change.

Consider providing screenshots, logs, code or other visual aids to help the reviewer in their testing.
-->

## Contribution Checklist

- [x] If the python-sdk was changed, please run `make fmt` in `python-sdk/`.
- [x] If the server was changed, please run `make fmt` in `server/`.
- [x] Make sure all PR Checks are passing.
<!--
You can run the tests manually:

Notes:

- Tests can be run manually: in `python-sdk/`, run the run `pip install -e .`,
  start the server and executor, and run `python test_graph_behaviours.py`.
- To test if changes to the server are backward compatible with the latest
  release, label the PR with `ci_compat_test`. This might report failures
  unrelated to your change if previous incompatible changes were pushed without
  being released yet -->
