### PR TITLE
feat(server): structured logging

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -2990,6 +2990,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2999,12 +3009,15 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -83,7 +83,7 @@ axum ={workspace=true}
 tokio = {workspace=true}
 axum-server={workspace=true}
 futures = "0.3.30"
-tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
+tracing-subscriber = { version = "0.3.18", features = ["env-filter", "json" ] }
 utoipa = { workspace = true }
 utoipa-swagger-ui = { workspace = true }
 sha2={workspace=true}

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -3,7 +3,14 @@ use std::path::PathBuf;
 use clap::Parser;
 use service::Service;
 use tracing::error;
-use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, Layer};
+use tracing_subscriber::{
+    fmt::{
+        self,
+        format::{Format, JsonFields},
+    },
+    layer::SubscriberExt,
+    util::SubscriberInitExt,
+};
 
 mod config;
 mod executors;
@@ -18,23 +25,52 @@ mod system_tasks;
 #[derive(Parser)]
 #[command(version, about, long_about = None)]
 struct Cli {
-    #[arg(short, long, value_name = "config file")]
+    #[arg(short, long, help = "Development mode")]
+    dev: bool,
+    #[arg(short, long, value_name = "config file", help = "Path to config file")]
     config: Option<PathBuf>,
+}
+
+fn setup_tracing(structured_logging: bool) {
+    // RUST_LOG used to control logging level.
+    let env_filter_layer =
+        tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| {
+            tracing_subscriber::EnvFilter::default()
+                .add_directive(tracing_subscriber::filter::LevelFilter::INFO.into())
+        });
+
+    if structured_logging {
+        let log_layer = fmt::layer()
+            .event_format(
+                Format::default()
+                    .json()
+                    .with_span_list(false)
+                    .flatten_event(true),
+            )
+            .fmt_fields(JsonFields::default());
+        tracing_subscriber::registry()
+            .with(env_filter_layer)
+            .with(log_layer)
+            .init();
+        return;
+    }
+
+    tracing_subscriber::registry()
+        .with(env_filter_layer)
+        .with(tracing_subscriber::fmt::layer().compact())
+        .init();
 }
 
 #[tokio::main]
 async fn main() {
-    let env_filter = tracing_subscriber::EnvFilter::try_from_default_env()
-        .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info"));
-    tracing_subscriber::registry()
-        .with(tracing_subscriber::fmt::layer().with_filter(env_filter))
-        .init();
-
     let cli = Cli::parse();
     let config = match cli.config {
         Some(path) => config::ServerConfig::from_path(path.to_str().unwrap()).unwrap(),
         None => config::ServerConfig::default(),
     };
+
+    setup_tracing(!cli.dev);
+
     let service = Service::new(config);
     if let Err(err) = service.start().await {
         error!("Error starting service: {:?}", err);

--- a/server/src/routes.rs
+++ b/server/src/routes.rs
@@ -202,17 +202,16 @@ pub fn create_routes(route_state: RouteState) -> Router {
         .layer(
             TraceLayer::new_for_http()
                 .make_span_with(|req: &Request| {
-                    let method = req.method();
-                    let uri = req.uri();
+                    let method = req.method().as_str();
+                    let uri = req.uri().to_string();
 
                     let matched_path = req
                         .extensions()
                         .get::<MatchedPath>()
-                        .map(|matched_path| matched_path.as_str());
+                        .map(MatchedPath::as_str);
 
-                    tracing::debug_span!("request", %method, %uri, matched_path)
+                    tracing::info_span!("request", method, uri, matched_path)
                 })
-                .on_failure(()),
         )
         .layer(cors)
         .layer(DefaultBodyLimit::disable())


### PR DESCRIPTION
## Context

<!--
In a few sentences or less, please explain the context behind this change to help answer why this change is needed.

If this is a bug fix, make sure to include "fixes #xxxx", or
"closes #xxxx".

Screenshots, logs, code or other visual aids are greatly appreciated.
 -->

To help operationalize indexify-server, it needs to output structured logs.

## What

indexify-server now defaults to structured logging unless it is started with the new `--dev` flag.

```
> ./indexify-server -h

Usage: indexify-server [OPTIONS]

Options:
  -d, --dev                   Development mode
  -c, --config <config file>  Path to config file
  -h, --help                  Print help
  -V, --version               Print version
```

```
> RUST_LOG=debug ./indexify-server  --dev
```
<img width="1267" alt="image" src="https://github.com/user-attachments/assets/46440b6d-1355-4386-b7ed-24fcfadb23dd">

```
> RUST_LOG=debug ./indexify-server

{"timestamp":"2024-11-14T21:06:22.883233Z","level":"INFO","message":"starting system tasks executor","target":"indexify_server::service"}
{"timestamp":"2024-11-14T21:06:22.883277Z","level":"INFO","message":"server api listening on 0.0.0.0:8900","target":"indexify_server::service"}
{"timestamp":"2024-11-14T21:06:22.883217Z","level":"INFO","message":"starting scheduler","target":"indexify_server::service"}
{"timestamp":"2024-11-14T21:06:22.883218Z","level":"INFO","message":"starting garbage collector","target":"indexify_server::service"}
{"timestamp":"2024-11-14T21:06:26.758675Z","level":"DEBUG","message":"started processing request","target":"tower_http::trace::on_request","span":{"matched_path":"/internal/executors/:id/tasks","method":"POST","uri":"/internal/executors/CBphXAEycy0ktN_g2rFjE/tasks","name":"request"}}
{"timestamp":"2024-11-14T21:06:26.759261Z","level":"DEBUG","message":"finished processing request","latency":"0 ms","status":200,"target":"tower_http::trace::on_response","span":{"matched_path":"/internal/executors/:id/tasks","method":"POST","uri":"/internal/executors/CBphXAEycy0ktN_g2rFjE/tasks","name":"request"}}
```


<!--
In a few sentences, please summarize the change to help reviewers.

Consider providing screenshots, logs, code or other visual aids to help the reviewer understand the approach taken.
-->

## Testing

<!--
Please include steps used to verify the change.

Consider providing screenshots, logs, code or other visual aids to help the reviewer in their testing.
-->

## Contribution Checklist

- [x] If the python-sdk was changed, please run `make fmt` in `python-sdk/`.
- [x] If the server was changed, please run `make fmt` in `server/`.
- [x] Make sure all PR Checks are passing.
<!--
You can run the tests manually:

Notes:

- Tests can be run manually: in `python-sdk/`, run the run `pip install -e .`,
  start the server and executor, and run `python test_graph_behaviours.py`.
- To test if changes to the server are backward compatible with the latest
  release, label the PR with `ci_compat_test`. This might report failures
  unrelated to your change if previous incompatible changes were pushed without
  being released yet -->
