### PR TITLE
Metrics

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -98,9 +98,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.92"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74f37166d7d48a0284b99dd824694c26119c700b53bf0d1540cdb147dbdaaf13"
+checksum = "4c95c10ba0b00a02636238b814946408b1322d5ac4760326e6fb8ec956d85775"
 
 [[package]]
 name = "arbitrary"
@@ -533,9 +533,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.20"
+version = "4.5.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97f376d85a664d5837dbae44bf546e6477a679ff6610010f17276f686d867e8"
+checksum = "fb3b4b9e5a7c7514dfa52869339ee98b3156b0bfb4e8a77c4ff4babb64b1604f"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -543,9 +543,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.20"
+version = "4.5.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19bc80abd44e4bed93ca373a0704ccbd1b710dc5749406201bb018272808dc54"
+checksum = "b17a95aa67cc7b5ebd32aa5370189aa0d79069ef1c64ce893bd30fb24bff20ec"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1259,6 +1259,124 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid_transform"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
+dependencies = [
+ "displaydoc",
+ "icu_locid",
+ "icu_locid_transform_data",
+ "icu_provider",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid_transform_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdc8ff3388f852bede6b579ad4e978ab004f139284d7b28715f773507b946f6e"
+
+[[package]]
+name = "icu_normalizer"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "utf16_iter",
+ "utf8_iter",
+ "write16",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8cafbf7aa791e9b22bec55a167906f9e1215fd475cd22adfcf660e03e989516"
+
+[[package]]
+name = "icu_properties"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_locid_transform",
+ "icu_properties_data",
+ "icu_provider",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67a8effbc3dd3e4ba1afa8ad918d5684b8868b3b26500753effea8d2eed19569"
+
+[[package]]
+name = "icu_provider"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
+dependencies = [
+ "displaydoc",
+ "icu_locid",
+ "icu_provider_macros",
+ "stable_deref_trait",
+ "tinystr",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_provider_macros"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1266,12 +1384,23 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
-version = "0.5.0"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
+checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
 dependencies = [
- "unicode-bidi",
- "unicode-normalization",
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
 ]
 
 [[package]]
@@ -1423,9 +1552,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.158"
+version = "0.2.162"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
+checksum = "18d287de67fe55fd7e1581fe933d965a5a9477b38e949cfa9f8574ef01506398"
 
 [[package]]
 name = "libloading"
@@ -1468,6 +1597,12 @@ name = "linux-raw-sys"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+
+[[package]]
+name = "litemap"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "643cb0b8d4fcc284004d5fd0d67ccf61dfffadb7f75e1e71bc420f4688a3a704"
 
 [[package]]
 name = "lock_api"
@@ -2390,9 +2525,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.37"
+version = "0.38.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acb788b847c24f28525660c4d7758620a7210875711f79e7f663cc152726811"
+checksum = "99e4ea3e1cdc4b559b8e5650f9c8e5998e3e5c1343b4eaf034565f32318d63c0"
 dependencies = [
  "bitflags 2.6.0",
  "errno",
@@ -2538,18 +2673,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.214"
+version = "1.0.215"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f55c3193aca71c12ad7890f1785d2b73e1b9f63a0bbc353c08ef26fe03fc56b5"
+checksum = "6513c1ad0b11a9376da888e3e0baa0077f1aed55c17f50e7b2397136129fb88f"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.214"
+version = "1.0.215"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de523f781f095e28fa605cdce0f8307e451cc0fd14e2eb4cd2e98a355b147766"
+checksum = "ad1e866f866923f252f05c889987993144fb74e722403468a4ebd70c3cd756c0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2752,6 +2887,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
 name = "state_store"
 version = "0.1.0"
 dependencies = [
@@ -2836,6 +2977,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "synstructure"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "sysinfo"
 version = "0.31.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2870,9 +3022,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.13.0"
+version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0f2c9fc62d0beef6951ccffd757e241266a2c833136efbe35af6cd2567dca5b"
+checksum = "28cce251fcbc87fac86a866eeb0d6c2d536fc16d06f184bb61aeae11aa4cee0c"
 dependencies = [
  "cfg-if",
  "fastrand",
@@ -2945,6 +3097,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2961,9 +3123,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.41.0"
+version = "1.41.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "145f3413504347a2be84393cc8a7d2fb4d863b375909ea59f2158261aa258bbb"
+checksum = "22cfb5bee7a6a52939ca9224d6ac897bb669134078daa8735560897f69de4d33"
 dependencies = [
  "backtrace",
  "bytes",
@@ -3241,25 +3403,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-bidi"
-version = "0.3.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
-
-[[package]]
-name = "unicode-normalization"
-version = "0.1.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
-dependencies = [
- "tinyvec",
-]
 
 [[package]]
 name = "unsafe-libyaml"
@@ -3275,9 +3422,9 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.5.2"
+version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22784dbdf76fdde8af1aeda5622b546b422b6fc585325248a2bf9f5e41e94d6c"
+checksum = "8d157f1b96d14500ffdc1f10ba712e780825526c03d9a49b4d0324b0d9113ada"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -3289,6 +3436,18 @@ name = "urlencoding"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
+name = "utf16_iter"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
@@ -3741,10 +3900,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "write16"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
+
+[[package]]
+name = "writeable"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+
+[[package]]
 name = "yansi"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
+
+[[package]]
+name = "yoke"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c5b1314b079b0930c31e3af543d8ee1757b1951ae1e1565ec704403a7240ca5"
+dependencies = [
+ "serde",
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28cc31741b18cb6f1d5ff12f5b7523e3d6eb0852bbbad19d73905511d9849b95"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
 
 [[package]]
 name = "zerocopy"
@@ -3768,10 +3963,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerofrom"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91ec111ce797d0e0784a1116d0ddcdbea84322cd79e5d5ad173daeba4f93ab55"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ea7b4a3637ea8669cedf0f1fd5c286a17f3de97b8dd5a70a6c167a1730e63a5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
 name = "zeroize"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+
+[[package]]
+name = "zerovec"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zip"

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -263,6 +263,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum-otel-metrics"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11b5bd67776dca9326650fc2e2ddd15ddaca16a3c8e80a9a874ba111afab82bd"
+dependencies = [
+ "axum",
+ "futures-util",
+ "http",
+ "http-body",
+ "opentelemetry 0.22.0",
+ "opentelemetry-prometheus 0.15.0",
+ "opentelemetry-semantic-conventions",
+ "opentelemetry_sdk 0.22.1",
+ "pin-project-lite",
+ "prometheus",
+ "tower 0.4.13",
+]
+
+[[package]]
 name = "axum-server"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1262,6 +1281,7 @@ dependencies = [
  "anyhow",
  "async-stream",
  "axum",
+ "axum-otel-metrics",
  "axum-server",
  "blob_store",
  "bytes",
@@ -1276,6 +1296,10 @@ dependencies = [
  "indexify_utils",
  "nanoid",
  "object_store",
+ "opentelemetry 0.24.0",
+ "opentelemetry-prometheus 0.17.0",
+ "opentelemetry_sdk 0.24.1",
+ "prometheus",
  "rand",
  "serde",
  "serde_json",
@@ -1723,6 +1747,117 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
+name = "opentelemetry"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900d57987be3f2aeb70d385fff9b27fb74c5723cc9a52d904d4f9c807a0667bf"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "once_cell",
+ "pin-project-lite",
+ "thiserror",
+ "urlencoding",
+]
+
+[[package]]
+name = "opentelemetry"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c365a63eec4f55b7efeceb724f1336f26a9cf3427b70e59e2cd2a5b947fba96"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "once_cell",
+ "pin-project-lite",
+ "thiserror",
+]
+
+[[package]]
+name = "opentelemetry-prometheus"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30bbcf6341cab7e2193e5843f0ac36c446a5b3fccb28747afaeda17996dcd02e"
+dependencies = [
+ "once_cell",
+ "opentelemetry 0.22.0",
+ "opentelemetry_sdk 0.22.1",
+ "prometheus",
+ "protobuf",
+]
+
+[[package]]
+name = "opentelemetry-prometheus"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc4191ce34aa274621861a7a9d68dbcf618d5b6c66b10081631b61fd81fbc015"
+dependencies = [
+ "once_cell",
+ "opentelemetry 0.24.0",
+ "opentelemetry_sdk 0.24.1",
+ "prometheus",
+ "protobuf",
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9ab5bd6c42fb9349dcf28af2ba9a0667f697f9bdcca045d39f2cec5543e2910"
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e90c7113be649e31e9a0f8b5ee24ed7a16923b322c3c5ab6367469c049d6b7e"
+dependencies = [
+ "async-trait",
+ "crossbeam-channel",
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "glob",
+ "once_cell",
+ "opentelemetry 0.22.0",
+ "ordered-float",
+ "percent-encoding",
+ "rand",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "692eac490ec80f24a17828d49b40b60f5aeaccdfe6a503f939713afd22bc28df"
+dependencies = [
+ "async-trait",
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "glob",
+ "once_cell",
+ "opentelemetry 0.24.0",
+ "percent-encoding",
+ "rand",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "ordered-float"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83e7ccb95e240b7c9506a3d544f10d935e142cc90b0a1d56954fb44d89ad6b97"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1860,6 +1995,27 @@ dependencies = [
  "version_check",
  "yansi",
 ]
+
+[[package]]
+name = "prometheus"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d33c28a30771f7f96db69893f78b857f7450d7e0237e9c8fc6427a81bae7ed1"
+dependencies = [
+ "cfg-if",
+ "fnv",
+ "lazy_static",
+ "memchr",
+ "parking_lot",
+ "protobuf",
+ "thiserror",
+]
+
+[[package]]
+name = "protobuf"
+version = "2.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
 
 [[package]]
 name = "quanta"
@@ -3111,6 +3267,12 @@ dependencies = [
  "idna",
  "percent-encoding",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf8parse"

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -1532,6 +1532,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
+name = "metrics"
+version = "0.1.0"
+dependencies = [
+ "axum-otel-metrics",
+ "once_cell",
+ "opentelemetry 0.24.0",
+ "opentelemetry-prometheus 0.17.0",
+ "opentelemetry_sdk 0.24.1",
+ "pin-project-lite",
+ "prometheus",
+ "serde",
+ "state_store",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1736,9 +1751,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "openssl-probe"
@@ -1943,9 +1958,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
+checksum = "915a1e146535de9163f3987b8944ed8cf49a18bb0056bcebcdcece385cece4ff"
 
 [[package]]
 name = "pin-utils"
@@ -3282,9 +3297,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "utoipa"
-version = "5.1.3"
+version = "5.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d9ba0ade4e2f024cd1842dfbaf9dbc540639fc082299acf7649d71bd14eaca3"
+checksum = "514a48569e4e21c86d0b84b5612b5e73c0b2cf09db63260134ba426d4e8ea714"
 dependencies = [
  "indexmap",
  "serde",
@@ -3294,9 +3309,9 @@ dependencies = [
 
 [[package]]
 name = "utoipa-gen"
-version = "5.1.3"
+version = "5.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cf390d6503c9c9eac988447c38ba934a707b0b768b14511a493b4fc0e8ecb00"
+checksum = "5629efe65599d0ccd5d493688cbf6e03aa7c1da07fe59ff97cf5977ed0637f66"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -1294,6 +1294,7 @@ dependencies = [
  "hyper",
  "indexify_ui",
  "indexify_utils",
+ "metrics",
  "nanoid",
  "object_store",
  "opentelemetry 0.24.0",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -28,6 +28,7 @@ rocksdb = { git = "https://github.com/rust-rocksdb/rust-rocksdb", rev = "87b6b2d
 data_model = { path = "data_model" }
 indexify_utils = { path = "utils" }
 indexify_ui = {path = "indexify_ui"}
+metrics = {path = "metrics"}
 hyper = "1.5.0"
 state_store = { path = "state_store" }
 strum = { version = "0.26.3", features = ["derive"] }
@@ -108,6 +109,7 @@ opentelemetry-prometheus = {workspace=true}
 opentelemetry_sdk = { workspace=true }
 prometheus = {workspace=true}
 axum-otel-metrics = { workspace=true }
+metrics = {workspace=true}
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -20,8 +20,8 @@ members = [
 ]
 
 [workspace.dependencies]
-serde = { version = "1.0.214", features = ["derive"] }
-anyhow = "1.0.92"
+serde = { version = "1.0.215", features = ["derive"] }
+anyhow = "1.0.93"
 serde_json = "1.0.132"
 # https://github.com/rust-rocksdb/rust-rocksdb/issues/881
 rocksdb = { git = "https://github.com/rust-rocksdb/rust-rocksdb", rev = "87b6b2df89c1fafcfb53129f8c3304d636a94f2e", features=["multi-threaded-cf"]}
@@ -34,13 +34,13 @@ state_store = { path = "state_store" }
 strum = { version = "0.26.3", features = ["derive"] }
 tracing = "0.1.40"
 rand = "0.8.5"
-tokio = { version = "1.41.0", features = ["full"] }
+tokio = { version = "1.41.1", features = ["full"] }
 once_cell = "1.20.2"
 serde_yml = "0.0.12"
 figment = {version="0.10.19",features=["yaml"]}
 axum = {version = "0.7.7", features = ["multipart", "macros", "tokio"]}
 axum-server = "0.7.1"
-tempfile = "3.13.0"
+tempfile = "3.14.0"
 utoipa = { version = "5.2.0", features = ["axum_extras"] }
 utoipa-swagger-ui = { version = "8.0.3", features = ["axum"] }
 object_store = {version= "0.11.1", features = ["aws"]}
@@ -65,7 +65,7 @@ tower-http = { version = "0.6.1", default-features = false, features = [
 pin-project = "1.1.7"
 ciborium = "0.2.2"
 uuid = { version = "1.11.0", features = ["v4"] }
-url = "2.5.2"
+url = "2.5.3"
 opentelemetry = { version="0.24.0", features = ["metrics"] }
 opentelemetry_sdk = { version = "0.24.0", features = ["metrics"] }
 opentelemetry-prometheus = {version = "0.17.0"}
@@ -82,7 +82,7 @@ serde={workspace = true}
 serde_json={workspace = true}
 anyhow = {workspace=true}
 figment = {workspace=true}
-clap = { version = "4.5.20", features = ["derive"] }
+clap = { version = "4.5.21", features = ["derive"] }
 tracing ={workspace=true}
 axum ={workspace=true}
 tokio = {workspace=true}

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "blob_store",
     "data_model",
     "indexify_ui",
+    "metrics",
     "state_store",
     "task_scheduler",
     "utils",
@@ -39,7 +40,7 @@ figment = {version="0.10.19",features=["yaml"]}
 axum = {version = "0.7.7", features = ["multipart", "macros", "tokio"]}
 axum-server = "0.7.1"
 tempfile = "3.13.0"
-utoipa = { version = "5.1.3", features = ["axum_extras"] }
+utoipa = { version = "5.2.0", features = ["axum_extras"] }
 utoipa-swagger-ui = { version = "8.0.3", features = ["axum"] }
 object_store = {version= "0.11.1", features = ["aws"]}
 futures = "0.3.31"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -62,10 +62,13 @@ tower-http = { version = "0.6.1", default-features = false, features = [
 ] }
 pin-project = "1.1.7"
 ciborium = "0.2.2"
-opentelemetry_sdk = "0.26.0"
-opentelemetry = "0.26.0"
 uuid = { version = "1.11.0", features = ["v4"] }
 url = "2.5.2"
+opentelemetry = { version="0.24.0", features = ["metrics"] }
+opentelemetry_sdk = { version = "0.24.0", features = ["metrics"] }
+opentelemetry-prometheus = {version = "0.17.0"}
+prometheus = {version = "0.13.4"}
+axum-otel-metrics = { version = "0.8.1"}
 
 [dependencies]
 async-stream = {workspace = true}
@@ -99,6 +102,11 @@ hex = "0.4.3"
 indexify_ui = {workspace=true}
 hyper = {workspace=true}
 url = {workspace=true}
+opentelemetry = {workspace=true}
+opentelemetry-prometheus = {workspace=true}
+opentelemetry_sdk = { workspace=true }
+prometheus = {workspace=true}
+axum-otel-metrics = { workspace=true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/server/metrics/Cargo.toml
+++ b/server/metrics/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "metrics"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+opentelemetry = {workspace=true}
+opentelemetry-prometheus = {workspace=true}
+opentelemetry_sdk = { workspace=true }
+prometheus = {workspace=true}
+axum-otel-metrics = { workspace=true }
+pin-project-lite = {workspace=true}
+serde={workspace = true}
+once_cell = {workspace=true}
+state_store = {workspace=true}

--- a/server/metrics/src/lib.rs
+++ b/server/metrics/src/lib.rs
@@ -126,21 +126,21 @@ pub mod api_io_stats {
 
     impl Metrics {
         pub fn new() -> Metrics {
-            let meter = opentelemetry::global::meter("indexify-server");
+            let meter = opentelemetry::global::meter("service-api");
             let invocations = meter
-                .u64_counter("indexify.server.invocations")
+                .u64_counter("invocations")
                 .with_description("number of invocations")
                 .init();
             let invocation_bytes = meter
-                .u64_counter("indexify.server.invocation_bytes")
+                .u64_counter("invocation_bytes")
                 .with_description("number of bytes ingested during invocations")
                 .init();
             let fn_outputs = meter
-                .u64_counter("indexify.server.fn_outputs")
+                .u64_counter("fn_outputs")
                 .with_description("number of fn outputs")
                 .init();
             let fn_output_bytes = meter
-                .u64_counter("indexify.server.fn_output_bytes")
+                .u64_counter("fn_output_bytes")
                 .with_description("number of bytes ingested for fn outputs")
                 .init();
             Metrics {

--- a/server/metrics/src/lib.rs
+++ b/server/metrics/src/lib.rs
@@ -1,0 +1,370 @@
+use std::{
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+    time::{Duration, Instant},
+};
+
+use pin_project_lite::pin_project;
+
+pin_project! {
+    #[must_use = "futures do nothing unless you `.await` or poll them"]
+    pub struct TimedFuture<F, C>
+    where
+        F: Future,
+        C: FnOnce(Duration),
+    {
+        #[pin]
+        inner: F,
+        start: Instant,
+        callback: Option<C>, // This is an Option because the future might be polled even after completion
+    }
+}
+
+impl<F, C> TimedFuture<F, C>
+where
+    F: Future,
+    C: FnOnce(Duration),
+{
+    pub fn new(inner: F, callback: C) -> Self {
+        Self {
+            inner,
+            callback: Some(callback),
+            start: Instant::now(),
+        }
+    }
+}
+
+impl<F, C> Future for TimedFuture<F, C>
+where
+    F: Future,
+    C: FnOnce(Duration),
+{
+    type Output = F::Output;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+        let poll_result = this.inner.poll(cx);
+
+        if poll_result.is_ready() {
+            let elapsed = this.start.elapsed();
+            if let Some(callback) = this.callback.take() {
+                callback(elapsed);
+            }
+        }
+
+        poll_result
+    }
+}
+
+pub fn create_timed_future<F, C>(future: F, callback: C) -> TimedFuture<F, C>
+where
+    F: Future,
+    C: FnOnce(Duration),
+{
+    TimedFuture::new(future, callback)
+}
+
+pub struct CounterGuard<'a, F>
+where
+    F: Fn(&str, i64),
+{
+    node_addr: &'a str,
+    func: F,
+}
+
+impl<'a, F> CounterGuard<'a, F>
+where
+    F: Fn(&str, i64),
+{
+    pub fn new(node_addr: &'a str, func: F) -> Self {
+        func(node_addr, 1);
+        Self { node_addr, func }
+    }
+}
+
+impl<'a, F> Drop for CounterGuard<'a, F>
+where
+    F: Fn(&str, i64),
+{
+    fn drop(&mut self) {
+        (self.func)(self.node_addr, -1);
+    }
+}
+
+use opentelemetry_sdk::metrics::SdkMeterProvider;
+
+pub fn init_provider() -> prometheus::Registry {
+    let registry = prometheus::Registry::new();
+    let exporter = opentelemetry_prometheus::exporter()
+        .with_registry(registry.clone())
+        .build();
+    let mut provider = SdkMeterProvider::builder();
+    if let Ok(exporter) = exporter {
+        provider = provider.with_reader(exporter);
+    };
+    opentelemetry::global::set_meter_provider(provider.build());
+    registry
+}
+
+pub mod api_io_stats {
+    use opentelemetry::metrics::Counter;
+
+    #[derive(Debug)]
+    pub struct Metrics {
+        pub invocations: Counter<u64>,
+        pub invocation_bytes: Counter<u64>,
+        pub fn_outputs: Counter<u64>,
+        pub fn_output_bytes: Counter<u64>,
+    }
+
+    impl Default for Metrics {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
+
+    impl Metrics {
+        pub fn new() -> Metrics {
+            let meter = opentelemetry::global::meter("indexify-server");
+            let invocations = meter
+                .u64_counter("indexify.server.invocations")
+                .with_description("number of invocations")
+                .init();
+            let invocation_bytes = meter
+                .u64_counter("indexify.server.invocation_bytes")
+                .with_description("number of bytes ingested during invocations")
+                .init();
+            let fn_outputs = meter
+                .u64_counter("indexify.server.fn_outputs")
+                .with_description("number of fn outputs")
+                .init();
+            let fn_output_bytes = meter
+                .u64_counter("indexify.server.fn_output_bytes")
+                .with_description("number of bytes ingested for fn outputs")
+                .init();
+            Metrics {
+                invocations,
+                invocation_bytes,
+                fn_outputs,
+                fn_output_bytes,
+            }
+        }
+    }
+}
+
+use opentelemetry::{
+    metrics::{Counter, Histogram},
+    KeyValue,
+};
+
+pub trait TimerUpdate {
+    fn add(&self, duration: Duration, labels: &[KeyValue]);
+}
+
+impl TimerUpdate for Counter<f64> {
+    fn add(&self, duration: Duration, labels: &[KeyValue]) {
+        self.add(duration.as_secs_f64(), labels);
+    }
+}
+
+impl TimerUpdate for Histogram<f64> {
+    fn add(&self, duration: Duration, labels: &[KeyValue]) {
+        self.record(duration.as_secs_f64(), labels);
+    }
+}
+
+pub struct Timer<'a, T: TimerUpdate + Sync> {
+    start: Instant,
+    metric: &'a T,
+}
+
+impl<'a, T: TimerUpdate + Sync> Timer<'a, T> {
+    pub fn start(metric: &'a T) -> Self {
+        Self {
+            start: Instant::now(),
+            metric,
+        }
+    }
+}
+
+impl<'a, T: TimerUpdate + Sync> Drop for Timer<'a, T> {
+    fn drop(&mut self) {
+        self.metric.add(self.start.elapsed(), &[]);
+    }
+}
+
+pub mod scheduler_stats {
+    use std::sync::{Arc, Mutex};
+
+    use opentelemetry::{
+        metrics::{Histogram, ObservableCounter, ObservableGauge},
+        KeyValue,
+    };
+
+    use state_store::IndexifyState;
+
+    #[derive(Debug)]
+    pub struct Metrics {
+        pub tasks_completed: ObservableCounter<u64>,
+        pub tasks_errored: ObservableCounter<u64>,
+        pub tasks_in_progress: ObservableGauge<u64>,
+        pub executors_online: ObservableGauge<u64>,
+        pub scheduler_invocations: Histogram<f64>,
+        pub tasks_per_executor: ObservableGauge<u64>,
+        pub state_machine_apply: Histogram<f64>,
+    }
+
+    impl Metrics {
+        pub fn new(indexify_state: Arc<IndexifyState>) -> Metrics {
+            let meter = opentelemetry::global::meter("indexify-coordinator");
+
+            let prev_value = Arc::new(Mutex::new(0));
+            let tasks_completed = meter
+                .u64_observable_counter("indexify.coordinator.tasks_completed")
+                .with_callback({
+                    let app = indexify_state.clone();
+                    let prev_value = prev_value.clone();
+                    move |observer| {
+                        let mut prev_value = prev_value.lock().unwrap();
+                        let value = app
+                            .data
+                            .indexify_state
+                            .metrics
+                            .lock()
+                            .unwrap()
+                            .tasks_completed;
+                        observer.observe(value - *prev_value, &[]);
+                        *prev_value = value;
+                    }
+                })
+                .with_description("Number of tasks completed")
+                .init();
+
+            let prev_value = Arc::new(Mutex::new(0));
+            let tasks_errored = meter
+                .u64_observable_counter("indexify.coordinator.tasks_errored")
+                .with_callback({
+                    let app = indexify_state.clone();
+                    let prev_value = prev_value.clone();
+                    move |observer| {
+                        let mut prev_value = prev_value.lock().unwrap();
+                        let value = app
+                            .data
+                            .indexify_state
+                            .metrics
+                            .lock()
+                            .unwrap()
+                            .tasks_completed_with_errors;
+                        observer.observe(value - *prev_value, &[]);
+                        *prev_value = value;
+                    }
+                })
+                .with_description("Number of tasks completed with error")
+                .init();
+
+            let tasks_in_progress = meter
+                .u64_observable_gauge("indexify.coordinator.tasks_in_progress")
+                .with_callback({
+                    let app = indexify_state.clone();
+                    move |observer| {
+                        app.data
+                            .indexify_state
+                            .unfinished_tasks_by_extractor
+                            .observe_task_counts(observer);
+                    }
+                })
+                .with_description("Number of tasks in progress")
+                .init();
+            let executors_online = meter
+                .u64_observable_gauge("indexify.coordinator.executors_online")
+                .with_callback({
+                    let app = indexify_state.clone();
+                    move |observer| {
+                        let value = app.data.indexify_state.executor_count();
+                        observer.observe(value as u64, &[]);
+                    }
+                })
+                .with_description("Number of executors online")
+                .init();
+
+            let scheduler_invocations = meter
+                .f64_histogram("indexify.coordinator.scheduler_invocations")
+                .with_description("Scheduler invocation latencies in seconds")
+                .init();
+
+            let tasks_per_executor = meter
+                .u64_observable_gauge("indexify.coordinator.tasks_per_executor")
+                .with_callback({
+                    let app = indexify_state.clone();
+                    move |observer| {
+                        let counts = app
+                            .data
+                            .indexify_state
+                            .unfinished_tasks_by_executor
+                            .read()
+                            .unwrap();
+                        for (executor_id, tasks) in counts.iter() {
+                            observer.observe(
+                                tasks.tasks.len() as u64,
+                                &[KeyValue::new("executor_id", executor_id.to_string())],
+                            );
+                        }
+                    }
+                })
+                .with_description("Number of tasks per executor")
+                .init();
+            
+            let state_machine_apply = meter
+                .f64_histogram("indexify.state_machine_apply")
+                .with_description("State machine apply changes latencies in seconds")
+                .init();
+            Metrics {
+                tasks_completed,
+                tasks_errored,
+                tasks_in_progress,
+                executors_online,
+                scheduler_invocations,
+                tasks_per_executor,
+                state_machine_apply,
+            }
+        }
+    }
+}
+
+pub mod kv_storage {
+    use opentelemetry::metrics::Histogram;
+
+    #[derive(Debug)]
+    pub struct Metrics {
+        pub reads: Histogram<f64>,
+        pub writes: Histogram<f64>,
+    }
+
+    impl Default for Metrics {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
+
+    impl Metrics {
+        pub fn new() -> Metrics {
+            let meter = opentelemetry::global::meter("kv-storage");
+
+            let reads = meter
+                .f64_histogram("indexify.kv_storage.reads")
+                .with_description("K/V store read latencies in seconds")
+                .init();
+
+            let writes = meter
+                .f64_histogram("indexify.metadata_added")
+                .with_description("k/v store add latencies in seconds")
+                .init();
+
+            Metrics {
+                reads,
+                writes,
+            }
+        }
+    }
+}

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -68,11 +68,14 @@ async fn main() {
         Some(path) => config::ServerConfig::from_path(path.to_str().unwrap()).unwrap(),
         None => config::ServerConfig::default(),
     };
-
     setup_tracing(!cli.dev);
 
-    let service = Service::new(config);
-    if let Err(err) = service.start().await {
+    let service = Service::new(config).await;
+    if let Err(err) = service {
+        error!("Error creating service: {:?}", err);
+        return;
+    }
+    if let Err(err) = service.unwrap().start().await {
         error!("Error starting service: {:?}", err);
     }
 }

--- a/server/src/routes.rs
+++ b/server/src/routes.rs
@@ -435,7 +435,7 @@ async fn create_compute_graph(
                     .blob_storage
                     .put(&file_name, stream)
                     .await
-                    .map_err(|e| IndexifyAPIError::internal_error(e))?;
+                    .map_err(IndexifyAPIError::internal_error)?;
                 put_result = Some(result);
             } else if name == "compute_graph" {
                 let text = field
@@ -882,7 +882,7 @@ async fn get_ctx_state_key(
         .get_ctx_state_key(&namespace, &compute_graph, &invocation_id, &request.key)
         .await
         .map_err(IndexifyAPIError::internal_error)?;
-    let value = value.map(|v| serde_json::from_slice(&v.to_vec()).unwrap());
+    let value = value.map(|v| serde_json::from_slice(&v).unwrap());
     Ok(Json(CtxStateGetResponse { value }))
 }
 

--- a/server/src/routes.rs
+++ b/server/src/routes.rs
@@ -27,6 +27,7 @@ use futures::StreamExt;
 use hyper::StatusCode;
 use indexify_ui::Assets as UiAssets;
 use indexify_utils::GuardStreamExt;
+use metrics::api_io_stats;
 use nanoid::nanoid;
 use prometheus::Encoder;
 use state_store::{
@@ -150,6 +151,7 @@ pub struct RouteState {
     pub kvs: Arc<KVS>,
     pub executor_manager: Arc<ExecutorManager>,
     pub registry: Arc<prometheus::Registry>,
+    pub metrics: Arc<api_io_stats::Metrics>,
 }
 
 pub fn create_routes(route_state: RouteState) -> Router {

--- a/server/src/routes.rs
+++ b/server/src/routes.rs
@@ -158,7 +158,9 @@ pub fn create_routes(route_state: RouteState) -> Router {
         .allow_origin(Any)
         .allow_headers(Any);
 
-    let axum_metrics = HttpMetricsLayerBuilder::new().build();
+    let axum_metrics = HttpMetricsLayerBuilder::new()
+        .with_path("/metrics/http".to_string())
+        .build();
     Router::new()
         .merge(SwaggerUi::new("/docs/swagger").url("/docs/openapi.json", ApiDoc::openapi()))
         .merge(axum_metrics.routes())

--- a/server/src/routes/download.rs
+++ b/server/src/routes/download.rs
@@ -26,7 +26,7 @@ pub async fn download_invocation_payload(
         .blob_storage
         .get(&output.payload.path)
         .await
-        .map_err(|e| IndexifyAPIError::internal_error(e))?;
+        .map_err(IndexifyAPIError::internal_error)?;
     Response::builder()
         .header("Content-Type", "application/octet-stream")
         .header("Content-Length", output.payload.size.to_string())
@@ -84,7 +84,7 @@ pub async fn download_fn_output_payload(
         .blob_storage
         .get(&payload.path)
         .await
-        .map_err(|e| IndexifyAPIError::internal_error(e))?;
+        .map_err(IndexifyAPIError::internal_error)?;
     Response::builder()
         .header("Content-Type", "application/octet-stream")
         .header("Content-Length", payload.size.to_string())
@@ -119,7 +119,7 @@ pub async fn download_fn_output_by_key(
         .blob_storage
         .get(&payload.path)
         .await
-        .map_err(|e| IndexifyAPIError::internal_error(e))?;
+        .map_err(IndexifyAPIError::internal_error)?;
     Response::builder()
         .header("Content-Type", "application/octet-stream")
         .header("Content-Length", payload.size.to_string())

--- a/server/src/routes/internal_ingest.rs
+++ b/server/src/routes/internal_ingest.rs
@@ -101,7 +101,7 @@ pub async fn ingest_files_from_executor(
 
     // Write data object to blob store.
     let mut node_output_sequence: usize = 0;
-    let diagnostics_keys = vec!["stdout", "stderr"];
+    let diagnostics_keys = ["stdout", "stderr"];
     while let Some(mut field) = files.next_field().await.unwrap() {
         if let Some(name) = field.name() {
             let name_ref = name.to_string();
@@ -253,7 +253,7 @@ async fn write_to_disk<'a>(
         .to_string();
     info!("writing to blob store, file name = {:?}", file_name);
     let stream = field.map(|res| res.map_err(|err| anyhow::anyhow!(err)));
-    blob_storage.put(&file_name, stream).await.map_err(|e| {
+    blob_storage.put(file_name, stream).await.map_err(|e| {
         error!("failed to write to blob store: {}", e);
         IndexifyAPIError::internal_error(anyhow!("failed to write to blob store: {}", e))
     })

--- a/server/src/routes/internal_ingest.rs
+++ b/server/src/routes/internal_ingest.rs
@@ -157,6 +157,15 @@ pub async fn ingest_files_from_executor(
         }
     }
 
+    state
+        .metrics
+        .fn_outputs
+        .add(output_objects.len() as u64, &[]);
+    state.metrics.fn_output_bytes.add(
+        output_objects.iter().map(|e| e.size_bytes).sum::<u64>(),
+        &[],
+    );
+
     // Save metadata in rocksdb for the objects in the blob store.
     let task_result =
         task_result.ok_or(IndexifyAPIError::bad_request("task_result is required"))?;

--- a/server/src/routes/invoke.rs
+++ b/server/src/routes/invoke.rs
@@ -157,6 +157,7 @@ pub async fn invoke_with_object(
     State(state): State<RouteState>,
     body: Body,
 ) -> Result<impl IntoResponse, IndexifyAPIError> {
+    state.metrics.invocations.add(1, &[]);
     let should_block = params.block_until_finish.unwrap_or(false);
     let payload_key = Uuid::new_v4().to_string();
     let payload_stream = body
@@ -175,6 +176,7 @@ pub async fn invoke_with_object(
         size: put_result.size_bytes,
         sha256_hash: put_result.sha256_hash,
     };
+    state.metrics.invocation_bytes.add(data_payload.size, &[]);
     let invocation_payload = InvocationPayloadBuilder::default()
         .namespace(namespace.clone())
         .compute_graph_name(compute_graph.clone())

--- a/server/src/routes/logs.rs
+++ b/server/src/routes/logs.rs
@@ -59,7 +59,7 @@ pub async fn download_task_logs(
         .blob_storage
         .get(&payload.path)
         .await
-        .map_err(|e| IndexifyAPIError::internal_error(e))?;
+        .map_err(IndexifyAPIError::internal_error)?;
     Response::builder()
         .header("Content-Type", "application/octet-stream")
         .header("Content-Length", payload.size.to_string())

--- a/server/src/scheduler.rs
+++ b/server/src/scheduler.rs
@@ -162,7 +162,10 @@ mod tests {
     async fn test_invoke_compute_graph_event_creates_tasks() -> Result<()> {
         let state_store = TestStateStore::new().await?;
         let indexify_state = state_store.indexify_state.clone();
-        let scheduler = Scheduler::new(indexify_state.clone());
+        let scheduler = Scheduler::new(
+            indexify_state.clone(),
+            Arc::new(scheduler_stats::Metrics::new(indexify_state.clone())),
+        );
         let invocation_id = state_store.with_simple_graph().await;
         scheduler.run_scheduler().await?;
         let tasks = indexify_state
@@ -184,7 +187,10 @@ mod tests {
     async fn create_tasks_when_after_fn_finishes() -> Result<()> {
         let state_store = TestStateStore::new().await?;
         let indexify_state = state_store.indexify_state.clone();
-        let scheduler = Scheduler::new(indexify_state.clone());
+        let scheduler = Scheduler::new(
+            indexify_state.clone(),
+            Arc::new(scheduler_stats::Metrics::new(indexify_state.clone())),
+        );
         let invocation_id = state_store.with_simple_graph().await;
         scheduler.run_scheduler().await?;
         let tasks = indexify_state
@@ -220,7 +226,10 @@ mod tests {
     async fn handle_failed_tasks() -> Result<()> {
         let state_store = TestStateStore::new().await?;
         let indexify_state = state_store.indexify_state.clone();
-        let scheduler = Scheduler::new(indexify_state.clone());
+        let scheduler = Scheduler::new(
+            indexify_state.clone(),
+            Arc::new(scheduler_stats::Metrics::new(indexify_state.clone())),
+        );
         let invocation_id = state_store.with_simple_graph().await;
         scheduler.run_scheduler().await?;
         let tasks = indexify_state
@@ -279,7 +288,10 @@ mod tests {
     async fn test_task_remove() -> Result<()> {
         let state_store = TestStateStore::new().await?;
         let indexify_state = state_store.indexify_state.clone();
-        let scheduler = Scheduler::new(indexify_state.clone());
+        let scheduler = Scheduler::new(
+            indexify_state.clone(),
+            Arc::new(scheduler_stats::Metrics::new(indexify_state.clone())),
+        );
         let ex = Arc::new(ExecutorManager::new(indexify_state.clone()).await);
         let invocation_id = state_store.with_simple_graph().await;
         ex.register_executor(mock_executor()).await?;
@@ -321,7 +333,10 @@ mod tests {
     async fn test_task_unassign() -> Result<()> {
         let state_store = TestStateStore::new().await?;
         let indexify_state = state_store.indexify_state.clone();
-        let scheduler = Scheduler::new(indexify_state.clone());
+        let scheduler = Scheduler::new(
+            indexify_state.clone(),
+            Arc::new(scheduler_stats::Metrics::new(indexify_state.clone())),
+        );
         let ex = Arc::new(ExecutorManager::new(indexify_state.clone()).await);
         let invocation_id = state_store.with_simple_graph().await;
         ex.register_executor(mock_executor()).await?;
@@ -360,7 +375,10 @@ mod tests {
     async fn test_add_executor() -> Result<()> {
         let state_store = TestStateStore::new().await?;
         let indexify_state = state_store.indexify_state.clone();
-        let scheduler = Scheduler::new(indexify_state.clone());
+        let scheduler = Scheduler::new(
+            indexify_state.clone(),
+            Arc::new(scheduler_stats::Metrics::new(indexify_state.clone())),
+        );
         let invocation_id = state_store.with_simple_graph().await;
         let ex = Arc::new(ExecutorManager::new(indexify_state.clone()).await);
 
@@ -419,7 +437,10 @@ mod tests {
     async fn test_create_tasks_for_router_tasks() {
         let state_store = TestStateStore::new().await.unwrap();
         let indexify_state = state_store.indexify_state.clone();
-        let scheduler = Scheduler::new(indexify_state.clone());
+        let scheduler = Scheduler::new(
+            indexify_state.clone(),
+            Arc::new(scheduler_stats::Metrics::new(indexify_state.clone())),
+        );
         let invocation_id = state_store.with_router_graph().await;
         scheduler.run_scheduler().await.unwrap();
         let tasks = indexify_state

--- a/server/src/scheduler.rs
+++ b/server/src/scheduler.rs
@@ -48,7 +48,7 @@ impl Scheduler {
         let mut processed_reduction_tasks = vec![];
         let mut diagnostic_msgs = vec![];
         for state_change in &state_changes {
-            processed_state_changes.push(state_change.id.clone());
+            processed_state_changes.push(state_change.id);
             let result = match &state_change.change_type {
                 ChangeType::InvokeComputeGraph(invoke_compute_graph_event) => Some(
                     handle_invoke_compute_graph(
@@ -61,7 +61,7 @@ impl Scheduler {
                     let task = self
                         .indexify_state
                         .reader()
-                        .get_task_from_finished_event(&task_finished_event)?
+                        .get_task_from_finished_event(task_finished_event)?
                         .ok_or(anyhow!("task not found {}", task_finished_event.task_id))?;
                     let compute_graph = self
                         .indexify_state
@@ -315,7 +315,7 @@ mod tests {
 
         let task = tasks.first().unwrap();
         state_store
-            .finalize_task(&task, 1, TaskOutcome::Success, false)
+            .finalize_task(task, 1, TaskOutcome::Success, false)
             .await?;
 
         let executor_tasks = indexify_state

--- a/server/src/service.rs
+++ b/server/src/service.rs
@@ -28,7 +28,7 @@ pub struct Service {
     pub config: ServerConfig,
     pub indexify_state: Arc<IndexifyState>,
     metrics_registry: Arc<Registry>,
-    _sched_metrics: Arc<SchedulerMetrics>,
+    sched_metrics: Arc<SchedulerMetrics>,
 }
 
 impl Service {
@@ -40,7 +40,7 @@ impl Service {
             config,
             indexify_state,
             metrics_registry,
-            _sched_metrics: sched_metrics,
+            sched_metrics,
         })
     }
 
@@ -64,7 +64,7 @@ impl Service {
         let app = create_routes(route_state);
         let handle = Handle::new();
         let handle_sh = handle.clone();
-        let scheduler = Scheduler::new(self.indexify_state.clone());
+        let scheduler = Scheduler::new(self.indexify_state.clone(), self.sched_metrics.clone());
 
         let mut gc = Gc::new(
             self.indexify_state.clone(),

--- a/server/src/service.rs
+++ b/server/src/service.rs
@@ -60,6 +60,7 @@ impl Service {
             blob_storage: blob_storage.clone(),
             executor_manager,
             registry: self.metrics_registry.clone(),
+            metrics: Arc::new(metrics::api_io_stats::Metrics::new()),
         };
         let app = create_routes(route_state);
         let handle = Handle::new();

--- a/server/src/system_tasks.rs
+++ b/server/src/system_tasks.rs
@@ -140,6 +140,7 @@ mod tests {
         TaskId,
         TaskOutcome,
     };
+    use metrics::scheduler_stats;
     use rand::Rng;
     use state_store::requests::{
         CreateComputeGraphRequest,
@@ -215,7 +216,10 @@ mod tests {
             .await
             .unwrap();
         let shutdown_rx = tokio::sync::watch::channel(()).1;
-        let scheduler = Scheduler::new(state.clone());
+        let scheduler = Scheduler::new(
+            state.clone(),
+            Arc::new(scheduler_stats::Metrics::new(state.clone())),
+        );
         let mut executor = SystemTasksExecutor::new(state.clone(), shutdown_rx);
 
         let graph = mock_graph_a(None);
@@ -563,7 +567,10 @@ mod tests {
             .await
             .unwrap();
         let shutdown_rx = tokio::sync::watch::channel(()).1;
-        let scheduler = Scheduler::new(state.clone());
+        let scheduler = Scheduler::new(
+            state.clone(),
+            Arc::new(scheduler_stats::Metrics::new(state.clone())),
+        );
         let mut executor = SystemTasksExecutor::new(state.clone(), shutdown_rx);
 
         let graph = mock_graph_a(None);

--- a/server/src/system_tasks.rs
+++ b/server/src/system_tasks.rs
@@ -68,7 +68,7 @@ impl SystemTasksExecutor {
                             state_store::requests::ReplayInvocationRequest {
                                 namespace: task.namespace.clone(),
                                 compute_graph_name: task.compute_graph_name.clone(),
-                                graph_version: task.graph_version.clone(),
+                                graph_version: task.graph_version,
                                 invocation_id: invocation.id.clone(),
                             },
                         ),
@@ -615,7 +615,7 @@ mod tests {
                 .0;
             let incomplete_tasks = tasks.iter().filter(|t| t.outcome == TaskOutcome::Unknown);
             let state_changes = state.reader().get_unprocessed_state_changes()?;
-            if state_changes.len() == 0 && incomplete_tasks.count() == 0 {
+            if state_changes.is_empty() && incomplete_tasks.count() == 0 {
                 break;
             }
         }
@@ -685,7 +685,7 @@ mod tests {
             let system_tasks = state.reader().get_system_tasks(None).unwrap().0;
 
             let state_changes = state.reader().get_unprocessed_state_changes()?;
-            if state_changes.len() == 0 && num_incomplete_tasks == 0 && system_tasks.len() == 0 {
+            if state_changes.is_empty() && num_incomplete_tasks == 0 && system_tasks.is_empty() {
                 break;
             }
         }

--- a/server/state_store/src/lib.rs
+++ b/server/state_store/src/lib.rs
@@ -38,12 +38,12 @@ use tokio::sync::{
 
 pub mod invocation_events;
 pub mod kv;
+pub mod metrics;
 pub mod requests;
 pub mod scanner;
 pub mod serializer;
 pub mod state_machine;
 pub mod test_state_store;
-pub mod metrics;
 
 #[derive(Debug)]
 pub struct ExecutorState {
@@ -106,7 +106,7 @@ pub struct IndexifyState {
     pub gc_rx: tokio::sync::watch::Receiver<()>,
     pub system_tasks_tx: tokio::sync::watch::Sender<()>,
     pub system_tasks_rx: tokio::sync::watch::Receiver<()>,
-    pub metrics: Arc<StateStoreMetrics>
+    pub metrics: Arc<StateStoreMetrics>,
 }
 
 impl IndexifyState {
@@ -270,7 +270,12 @@ impl IndexifyState {
             requests::RequestPayload::SchedulerUpdate(request) => {
                 let new_state_changes = self.change_events_for_scheduler_update(&request);
                 for req in &request.task_requests {
-                    match state_machine::create_tasks(self.db.clone(), &txn, req)? {
+                    match state_machine::create_tasks(
+                        self.db.clone(),
+                        &txn,
+                        req,
+                        self.metrics.clone().clone(),
+                    )? {
                         Some(completion) => {
                             if let Err(err) = self.task_event_tx.send(
                                 InvocationStateChangeEvent::InvocationFinished(
@@ -304,6 +309,7 @@ impl IndexifyState {
                         &txn,
                         &allocation.task,
                         &allocation.executor,
+                        self.metrics.clone(),
                     )?;
                     allocated_tasks_by_executor.push(allocation.executor.clone());
                 }
@@ -315,7 +321,12 @@ impl IndexifyState {
                     let entry = states.entry(request.executor.id.clone()).or_default();
                     entry.num_registered += 1;
                 }
-                state_machine::register_executor(self.db.clone(), &txn, &request)?;
+                state_machine::register_executor(
+                    self.db.clone(),
+                    &txn,
+                    &request,
+                    self.metrics.clone(),
+                )?;
                 self.register_executor(&request)
             }
             requests::RequestPayload::DeregisterExecutor(request) => {
@@ -336,7 +347,12 @@ impl IndexifyState {
                 };
                 if removed {
                     tracing::info!("de-registering executor: {}", request.executor_id);
-                    state_machine::deregister_executor(self.db.clone(), &txn, &request)?;
+                    state_machine::deregister_executor(
+                        self.db.clone(),
+                        &txn,
+                        &request,
+                        self.metrics.clone(),
+                    )?;
                 }
                 state_changes
             }

--- a/server/state_store/src/lib.rs
+++ b/server/state_store/src/lib.rs
@@ -231,6 +231,7 @@ impl IndexifyState {
                     self.db.clone(),
                     &txn,
                     finalize_task.clone(),
+                    self.metrics.clone(),
                 )? {
                     self.finalize_task(&finalize_task).await?
                 } else {

--- a/server/state_store/src/metrics.rs
+++ b/server/state_store/src/metrics.rs
@@ -69,7 +69,11 @@ impl StateStoreMetrics {
             .write()
             .unwrap()
             .entry(executor_id.to_string())
-            .and_modify(|e| *e -= 1)
+            .and_modify(|e| {
+                if *e > 0 {
+                    *e -= 1
+                }
+            })
             .or_insert(0);
         match outcome {
             TaskOutcome::Success => {

--- a/server/state_store/src/metrics.rs
+++ b/server/state_store/src/metrics.rs
@@ -1,0 +1,45 @@
+use std::collections::HashMap;
+use data_model::TaskOutcome;
+
+#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Default, Hash, PartialEq, Eq)]
+pub struct FnMetricsId {
+    pub namespace: String,
+    pub compute_graph: String,
+    pub compute_fn: String,
+    pub image_name: String,
+    pub image_version: String,
+}
+
+#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Default)]
+pub struct StateStoreMetrics {
+    pub tasks_completed: u64,
+    pub tasks_completed_with_errors: u64,
+    pub assigned_tasks: HashMap<FnMetricsId, u64>,
+    pub unassigned_tasks: HashMap<FnMetricsId, u64>,
+}
+
+impl StateStoreMetrics {
+    pub fn new() -> Self {
+        Self {
+            tasks_completed: 0,
+            tasks_completed_with_errors: 0,
+            assigned_tasks: HashMap::new(),
+            unassigned_tasks: HashMap::new(),
+        }
+    }
+    
+    pub fn update_task_completion(&mut self, outcome: TaskOutcome, fn_id: FnMetricsId) {
+        match outcome {
+            TaskOutcome::Success => self.tasks_completed += 1,
+            TaskOutcome::Failure => self.tasks_completed_with_errors += 1,
+            _ => (),
+        }
+        let count = self.assigned_tasks.entry(fn_id).or_insert(0);
+        *count -= 1;
+    }
+
+    pub fn task_assigned(&mut self, id: FnMetricsId) {
+        let count_assigned = self.assigned_tasks.entry(id).or_insert(0);
+        *count_assigned += 1;
+    }
+}

--- a/server/state_store/src/metrics.rs
+++ b/server/state_store/src/metrics.rs
@@ -64,7 +64,7 @@ impl StateStoreMetrics {
         }
     }
 
-    pub fn update_task_completion(&mut self, outcome: TaskOutcome, task: Task, executor_id: &str) {
+    pub fn update_task_completion(&self, outcome: TaskOutcome, task: Task, executor_id: &str) {
         self.tasks_by_executor
             .write()
             .unwrap()
@@ -85,7 +85,9 @@ impl StateStoreMetrics {
         }
         let id = FnMetricsId::from_task(&task);
         let mut count = self.assigned_tasks.write().unwrap();
-        *count.entry(id).or_insert(0) -= 1;
+        if *count.entry(id.clone()).or_insert(0) > 0 {
+            *count.entry(id).or_insert(0) -= 1;
+        }
     }
 
     pub fn task_unassigned(&self, tasks: Vec<Task>) {
@@ -108,7 +110,9 @@ impl StateStoreMetrics {
             let mut count_assigned = self.assigned_tasks.write().unwrap();
             *count_assigned.entry(id.clone()).or_insert(0) += 1;
             let mut count_unassigned = self.unassigned_tasks.write().unwrap();
-            *count_unassigned.entry(id).or_insert(0) -= 1;
+            if *count_unassigned.entry(id.clone()).or_insert(0) > 0 {
+                *count_unassigned.entry(id).or_insert(0) -= 1;
+            }
         }
     }
 
@@ -120,6 +124,8 @@ impl StateStoreMetrics {
     pub fn remove_executor(&self, executor_id: &str) {
         let mut executors_online = self.executors_online.write().unwrap();
         self.tasks_by_executor.write().unwrap().remove(executor_id);
-        *executors_online -= 1;
+        if *executors_online > 0 {
+            *executors_online -= 1;
+        }
     }
 }

--- a/server/state_store/src/metrics.rs
+++ b/server/state_store/src/metrics.rs
@@ -1,45 +1,125 @@
-use std::collections::HashMap;
-use data_model::TaskOutcome;
+use std::{
+    collections::HashMap,
+    fmt::Display,
+    sync::{Arc, RwLock},
+};
+
+use data_model::{Task, TaskOutcome};
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Default, Hash, PartialEq, Eq)]
 pub struct FnMetricsId {
     pub namespace: String,
     pub compute_graph: String,
     pub compute_fn: String,
-    pub image_name: String,
-    pub image_version: String,
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Default)]
+impl FnMetricsId {
+    pub fn from_task(task: &Task) -> Self {
+        Self {
+            namespace: task.namespace.clone(),
+            compute_graph: task.compute_graph_name.clone(),
+            compute_fn: task.compute_fn_name.clone(),
+        }
+    }
+}
+
+impl Display for FnMetricsId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}/{}/{}",
+            self.namespace, self.compute_graph, self.compute_fn
+        )
+    }
+}
+
+/*
+ * StateStoreMetrics is a struct that holds metrics for the state store.
+ * It keeps track of the number of tasks completed, the number of tasks
+ * completed with errors, the number of assigned tasks, and the number of
+ * unassigned tasks. Currently metrics are not persisted across restarts
+ * TODO: When the server starts up, we should scan the database for assigned
+ * and unassigned tasks. But for now, it's fine to just emit metrics which
+ * reflect the current state of the system since starting the server.
+ */
+#[derive(Clone, Debug, Default)]
 pub struct StateStoreMetrics {
-    pub tasks_completed: u64,
-    pub tasks_completed_with_errors: u64,
-    pub assigned_tasks: HashMap<FnMetricsId, u64>,
-    pub unassigned_tasks: HashMap<FnMetricsId, u64>,
+    pub tasks_completed: Arc<RwLock<u64>>,
+    pub tasks_completed_with_errors: Arc<RwLock<u64>>,
+    pub assigned_tasks: Arc<RwLock<HashMap<FnMetricsId, u64>>>,
+    pub unassigned_tasks: Arc<RwLock<HashMap<FnMetricsId, u64>>>,
+    pub executors_online: Arc<RwLock<u64>>,
+    pub tasks_by_executor: Arc<RwLock<HashMap<String, u64>>>,
 }
 
 impl StateStoreMetrics {
     pub fn new() -> Self {
         Self {
-            tasks_completed: 0,
-            tasks_completed_with_errors: 0,
-            assigned_tasks: HashMap::new(),
-            unassigned_tasks: HashMap::new(),
+            tasks_completed: Arc::new(RwLock::new(0)),
+            tasks_completed_with_errors: Arc::new(RwLock::new(0)),
+            assigned_tasks: Arc::new(RwLock::new(HashMap::new())),
+            unassigned_tasks: Arc::new(RwLock::new(HashMap::new())),
+            executors_online: Arc::new(RwLock::new(0)),
+            tasks_by_executor: Arc::new(RwLock::new(HashMap::new())),
         }
-    }
-    
-    pub fn update_task_completion(&mut self, outcome: TaskOutcome, fn_id: FnMetricsId) {
-        match outcome {
-            TaskOutcome::Success => self.tasks_completed += 1,
-            TaskOutcome::Failure => self.tasks_completed_with_errors += 1,
-            _ => (),
-        }
-        let count = self.assigned_tasks.entry(fn_id).or_insert(0);
-        *count -= 1;
     }
 
-    pub fn task_assigned(&mut self, id: FnMetricsId) {
-        let count_assigned = self.assigned_tasks.entry(id).or_insert(0);
-        *count_assigned += 1;
+    pub fn update_task_completion(&mut self, outcome: TaskOutcome, task: Task, executor_id: &str) {
+        self.tasks_by_executor
+            .write()
+            .unwrap()
+            .entry(executor_id.to_string())
+            .and_modify(|e| *e -= 1)
+            .or_insert(0);
+        match outcome {
+            TaskOutcome::Success => {
+                let mut tasks_completed = self.tasks_completed.write().unwrap();
+                *tasks_completed += 1;
+            }
+            TaskOutcome::Failure => {
+                let mut tasks_completed_with_errors =
+                    self.tasks_completed_with_errors.write().unwrap();
+                *tasks_completed_with_errors += 1;
+            }
+            _ => (),
+        }
+        let id = FnMetricsId::from_task(&task);
+        let mut count = self.assigned_tasks.write().unwrap();
+        *count.entry(id).or_insert(0) -= 1;
+    }
+
+    pub fn task_unassigned(&self, tasks: Vec<Task>) {
+        for task in tasks {
+            let id = FnMetricsId::from_task(&task);
+            let mut count = self.unassigned_tasks.write().unwrap();
+            *count.entry(id).or_insert(0) += 1;
+        }
+    }
+
+    pub fn task_assigned(&self, tasks: Vec<Task>, executor_id: &str) {
+        self.tasks_by_executor
+            .write()
+            .unwrap()
+            .entry(executor_id.to_string())
+            .and_modify(|e| *e += tasks.len() as u64)
+            .or_insert(tasks.len() as u64);
+        for task in tasks {
+            let id = FnMetricsId::from_task(&task);
+            let mut count_assigned = self.assigned_tasks.write().unwrap();
+            *count_assigned.entry(id.clone()).or_insert(0) += 1;
+            let mut count_unassigned = self.unassigned_tasks.write().unwrap();
+            *count_unassigned.entry(id).or_insert(0) -= 1;
+        }
+    }
+
+    pub fn add_executor(&self) {
+        let mut executors_online = self.executors_online.write().unwrap();
+        *executors_online += 1;
+    }
+
+    pub fn remove_executor(&self, executor_id: &str) {
+        let mut executors_online = self.executors_online.write().unwrap();
+        self.tasks_by_executor.write().unwrap().remove(executor_id);
+        *executors_online -= 1;
     }
 }

--- a/server/state_store/src/state_machine.rs
+++ b/server/state_store/src/state_machine.rs
@@ -33,19 +33,22 @@ use strum::AsRefStr;
 use tracing::error;
 
 use super::serializer::{JsonEncode, JsonEncoder};
-use crate::requests::{
-    CreateTasksRequest,
-    DeleteInvocationRequest,
-    DeregisterExecutorRequest,
-    FinalizeTaskRequest,
-    InvokeComputeGraphRequest,
-    NamespaceRequest,
-    ReductionTasks,
-    RegisterExecutorRequest,
-    RemoveSystemTaskRequest,
-    ReplayComputeGraphRequest,
-    ReplayInvocationRequest,
-    UpdateSystemTaskRequest,
+use crate::{
+    metrics::StateStoreMetrics,
+    requests::{
+        CreateTasksRequest,
+        DeleteInvocationRequest,
+        DeregisterExecutorRequest,
+        FinalizeTaskRequest,
+        InvokeComputeGraphRequest,
+        NamespaceRequest,
+        ReductionTasks,
+        RegisterExecutorRequest,
+        RemoveSystemTaskRequest,
+        ReplayComputeGraphRequest,
+        ReplayInvocationRequest,
+        UpdateSystemTaskRequest,
+    },
 };
 
 pub type ContentId = String;
@@ -316,8 +319,7 @@ pub fn create_graph_input(
     txn: &Transaction<TransactionDB>,
     req: &InvokeComputeGraphRequest,
 ) -> Result<()> {
-    let compute_graph_key =
-        ComputeGraph::key_from(req.namespace.as_str(), req.compute_graph_name.as_str());
+    let compute_graph_key = format!("{}|{}", req.namespace, req.compute_graph_name);
     let cg = txn
         .get_for_update_cf(
             &IndexifyObjectsColumns::ComputeGraphs.cf_db(&db),
@@ -384,13 +386,22 @@ pub(crate) fn create_or_update_compute_graph(
     )?;
 
     if let Some(existing_compute_graph) = existing_compute_graph {
-        let mut existing_compute_graph: ComputeGraph =
-            JsonEncoder::decode(&existing_compute_graph)?;
+        let existing_compute_graph: ComputeGraph = JsonEncoder::decode(&existing_compute_graph)?;
+        if compute_graph.code.sha256_hash != existing_compute_graph.code.sha256_hash ||
+            compute_graph.edges != existing_compute_graph.edges ||
+            compute_graph.nodes != existing_compute_graph.nodes ||
+            compute_graph.start_fn != existing_compute_graph.start_fn
+        {
+            compute_graph.version = existing_compute_graph.version.next();
+        }
 
-        // Merge the existing compute graph with the new one containing updated fields
-        // Not allowing changes to internal fields.
-        existing_compute_graph.update(compute_graph.clone());
-        compute_graph = existing_compute_graph;
+        for (node_name, node) in compute_graph.nodes.iter_mut() {
+            if let Some(existing_node) = existing_compute_graph.nodes.get(node_name) {
+                if node.image_hash() != existing_node.image_hash() {
+                    node.set_image_version(existing_node.clone().image_version_next());
+                }
+            }
+        }
     };
 
     let serialized_compute_graph = JsonEncoder::encode(&compute_graph)?;
@@ -429,7 +440,7 @@ pub fn delete_compute_graph(
 ) -> Result<()> {
     txn.delete_cf(
         &IndexifyObjectsColumns::ComputeGraphs.cf_db(&db),
-        ComputeGraph::key_from(namespace, name),
+        format!("{}|{}", namespace, name),
     )?;
     let prefix = format!("{}|{}|", namespace, name);
     delete_cf_prefix(
@@ -572,6 +583,7 @@ pub(crate) fn create_tasks(
     db: Arc<TransactionDB>,
     txn: &Transaction<TransactionDB>,
     req: &CreateTasksRequest,
+    sm_metrics: Arc<StateStoreMetrics>,
 ) -> Result<Option<InvocationCompletion>> {
     let ctx_key = format!(
         "{}|{}|{}",
@@ -614,6 +626,7 @@ pub(crate) fn create_tasks(
         ctx_key,
         serialized_analytics,
     )?;
+    sm_metrics.task_unassigned(req.tasks.clone());
     if graph_ctx.outstanding_tasks == 0 {
         Ok(Some(mark_invocation_finished(
             db,
@@ -632,6 +645,7 @@ pub fn allocate_tasks(
     txn: &Transaction<TransactionDB>,
     task: &Task,
     executor_id: &ExecutorId,
+    sm_metrics: Arc<StateStoreMetrics>,
 ) -> Result<()> {
     txn.put_cf(
         &IndexifyObjectsColumns::TaskAllocations.cf_db(&db),
@@ -642,6 +656,7 @@ pub fn allocate_tasks(
         &IndexifyObjectsColumns::UnallocatedTasks.cf_db(&db),
         task.key(),
     )?;
+    sm_metrics.task_assigned(vec![task.clone()], executor_id.get());
     Ok(())
 }
 
@@ -842,6 +857,7 @@ pub(crate) fn register_executor(
     db: Arc<TransactionDB>,
     txn: &Transaction<TransactionDB>,
     req: &RegisterExecutorRequest,
+    sm_metrics: Arc<StateStoreMetrics>,
 ) -> Result<()> {
     let serialized_executor_metadata = JsonEncoder::encode(&req.executor)?;
     txn.put_cf(
@@ -849,6 +865,7 @@ pub(crate) fn register_executor(
         req.executor.key(),
         serialized_executor_metadata,
     )?;
+    sm_metrics.add_executor();
     Ok(())
 }
 
@@ -856,6 +873,7 @@ pub(crate) fn deregister_executor(
     db: Arc<TransactionDB>,
     txn: &Transaction<TransactionDB>,
     req: &DeregisterExecutorRequest,
+    sm_metrics: Arc<StateStoreMetrics>,
 ) -> Result<()> {
     let mut read_options = ReadOptions::default();
     read_options.set_readahead_size(4_194_304);
@@ -880,5 +898,6 @@ pub(crate) fn deregister_executor(
         &IndexifyObjectsColumns::Executors.cf_db(&db),
         req.executor_id.to_string(),
     )?;
+    sm_metrics.remove_executor(req.executor_id.get());
     Ok(())
 }

--- a/server/state_store/src/state_machine.rs
+++ b/server/state_store/src/state_machine.rs
@@ -666,6 +666,7 @@ pub fn mark_task_completed(
     db: Arc<TransactionDB>,
     txn: &Transaction<TransactionDB>,
     req: FinalizeTaskRequest,
+    sm_metrics: Arc<StateStoreMetrics>,
 ) -> Result<bool> {
     let task_key = format!(
         "{}|{}|{}|{}|{}",
@@ -746,6 +747,7 @@ pub fn mark_task_completed(
         task.key(),
         task_bytes,
     )?;
+    sm_metrics.update_task_completion(req.task_outcome, task.clone(), req.executor_id.get());
     Ok(true)
 }
 


### PR DESCRIPTION
## Context

Metrics 

## What

Exposing HTTP and some service metrics via Prometheus endpoints 
`/metrics/http` -returns http metrics and `/metrics/service` returns service metrics.

## Testing

Ran the graph behavior tests and observed metrics

`curl http://localhost:8900/metrics/http`


`curl http://localhost:8900/metrics/service`
```
# HELP executors_online Number of executors online
# TYPE executors_online gauge
executors_online{otel_scope_name="state_machine_stats"} 1
# HELP target_info Target metadata
# TYPE target_info gauge
target_info{service_name="unknown_service",telemetry_sdk_language="rust",telemetry_sdk_name="opentelemetry",telemetry_sdk_version="0.24.1"} 1
# HELP tasks_completed_total Number of tasks completed
# TYPE tasks_completed_total counter
tasks_completed_total{otel_scope_name="state_machine_stats"} 54
# HELP tasks_errored_total Number of tasks completed with error
# TYPE tasks_errored_total counter
tasks_errored_total{otel_scope_name="state_machine_stats"} 1
# HELP tasks_in_progress Number of tasks in progress
# TYPE tasks_in_progress gauge
tasks_in_progress{task_type="default/simple_pipeline/generate_seq",otel_scope_name="state_machine_stats"} 0
tasks_in_progress{task_type="default/simple_pipeline/make_it_string",otel_scope_name="state_machine_stats"} 0
tasks_in_progress{task_type="default/simple_pipeline/square",otel_scope_name="state_machine_stats"} 0
tasks_in_progress{task_type="default/simple_pipeline/sum_of_squares",otel_scope_name="state_machine_stats"} 0
tasks_in_progress{task_type="default/test/generate_seq",otel_scope_name="state_machine_stats"} 0
tasks_in_progress{task_type="default/test/square",otel_scope_name="state_machine_stats"} 0
tasks_in_progress{task_type="default/test_context/SimpleFunctionCtxC",otel_scope_name="state_machine_stats"} 0
tasks_in_progress{task_type="default/test_context/simple_function_ctx",otel_scope_name="state_machine_stats"} 0
tasks_in_progress{task_type="default/test_context/simple_function_ctx_b",otel_scope_name="state_machine_stats"} 0
tasks_in_progress{task_type="default/test_handle_file/handle_file",otel_scope_name="state_machine_stats"} 0
tasks_in_progress{task_type="default/test_ignore_none/add_two",otel_scope_name="state_machine_stats"} 0
tasks_in_progress{task_type="default/test_ignore_none/gen_seq",otel_scope_name="state_machine_stats"} 0
tasks_in_progress{task_type="default/test_ignore_none/ignore_none",otel_scope_name="state_machine_stats"} 0
tasks_in_progress{task_type="default/test_map_reduce/generate_seq",otel_scope_name="state_machine_stats"} 0
tasks_in_progress{task_type="default/test_map_reduce/make_it_string",otel_scope_name="state_machine_stats"} 0
tasks_in_progress{task_type="default/test_map_reduce/square",otel_scope_name="state_machine_stats"} 0
tasks_in_progress{task_type="default/test_map_reduce/square_with_json_encoder",otel_scope_name="state_machine_stats"} 0
tasks_in_progress{task_type="default/test_map_reduce/sum_of_squares",otel_scope_name="state_machine_stats"} 0
tasks_in_progress{task_type="default/test_map_reduce/sum_of_squares_with_json_encoding",otel_scope_name="state_machine_stats"} 0
tasks_in_progress{task_type="default/test_router/add_three",otel_scope_name="state_machine_stats"} 0
tasks_in_progress{task_type="default/test_router/add_two",otel_scope_name="state_machine_stats"} 0
tasks_in_progress{task_type="default/test_router/generate_seq",otel_scope_name="state_machine_stats"} 0
tasks_in_progress{task_type="default/test_router/make_it_string_from_int",otel_scope_name="state_machine_stats"} 0
tasks_in_progress{task_type="default/test_router/route_if_even",otel_scope_name="state_machine_stats"} 0
tasks_in_progress{task_type="default/test_router/square",otel_scope_name="state_machine_stats"} 0
tasks_in_progress{task_type="default/test_router/sum_of_squares",otel_scope_name="state_machine_stats"} 0
tasks_in_progress{task_type="default/test_simple_function/simple_function",otel_scope_name="state_machine_stats"} 0
tasks_in_progress{task_type="default/test_simple_function2/simple_function_multiple_inputs",otel_scope_name="state_machine_stats"} 0
tasks_in_progress{task_type="default/test_simple_function2_json/simple_function_multiple_inputs_json",otel_scope_name="state_machine_stats"} 0
tasks_in_progress{task_type="default/test_simple_function_with_invalid_encoding/simple_function_with_invalid_encoder",otel_scope_name="state_machine_stats"} 0
tasks_in_progress{task_type="default/test_simple_function_with_json_encoding/simple_function_with_json_encoder",otel_scope_name="state_machine_stats"} 0
# HELP tasks_per_executor Number of tasks per executor
# TYPE tasks_per_executor gauge
tasks_per_executor{executor_id="spDPTMi0lKPxdcOljMs9X",otel_scope_name="state_machine_stats"} 0
```



## Contribution Checklist

- [x] If the python-sdk was changed, please run `make fmt` in `python-sdk/`.
- [x] If the server was changed, please run `make fmt` in `server/`.
- [x] Make sure all PR Checks are passing.
