### PR TITLE
feat(tracing): open-telemetry traces

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -264,18 +264,20 @@ dependencies = [
 
 [[package]]
 name = "axum-otel-metrics"
-version = "0.8.1"
+version = "0.9.0-alpha.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11b5bd67776dca9326650fc2e2ddd15ddaca16a3c8e80a9a874ba111afab82bd"
+checksum = "f60a607562cbef52413f4c2d66b6ac786b161920b183007dabbe3ba5c0b416c8"
 dependencies = [
  "axum",
  "futures-util",
  "http",
  "http-body",
- "opentelemetry 0.22.0",
- "opentelemetry-prometheus 0.15.0",
+ "opentelemetry",
+ "opentelemetry-http",
+ "opentelemetry-otlp",
+ "opentelemetry-prometheus",
  "opentelemetry-semantic-conventions",
- "opentelemetry_sdk 0.22.1",
+ "opentelemetry_sdk",
  "pin-project-lite",
  "prometheus",
  "tower 0.4.13",
@@ -298,6 +300,24 @@ dependencies = [
  "tokio",
  "tower 0.4.13",
  "tower-service",
+]
+
+[[package]]
+name = "axum-tracing-opentelemetry"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "561a0967337dfeaf3e28700d23e791712cd7d5e97ab335e0f4a0c3ac62e6ece0"
+dependencies = [
+ "axum",
+ "futures-core",
+ "futures-util",
+ "http",
+ "opentelemetry",
+ "pin-project-lite",
+ "tower 0.5.1",
+ "tracing",
+ "tracing-opentelemetry",
+ "tracing-opentelemetry-instrumentation-sdk",
 ]
 
 [[package]]
@@ -364,7 +384,7 @@ dependencies = [
  "futures",
  "metrics",
  "object_store",
- "opentelemetry 0.24.0",
+ "opentelemetry",
  "reqwest",
  "serde",
  "sha2",
@@ -1085,7 +1105,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap",
+ "indexmap 2.5.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1101,6 +1121,12 @@ dependencies = [
  "cfg-if",
  "crunchy",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -1219,10 +1245,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-util"
-version = "0.1.7"
+name = "hyper-timeout"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cde7055719c54e36e95e8719f95883f22072a48ede39db7fc17a4e1d5281e9b9"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df2dcfbe0677734ab2f3ffa7fa7bfd4706bfdc1ef393f2ee30184aed67e631b4"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1233,7 +1272,6 @@ dependencies = [
  "pin-project-lite",
  "socket2",
  "tokio",
- "tower 0.4.13",
  "tower-service",
  "tracing",
 ]
@@ -1415,6 +1453,7 @@ dependencies = [
  "axum",
  "axum-otel-metrics",
  "axum-server",
+ "axum-tracing-opentelemetry",
  "blob_store",
  "bytes",
  "ciborium",
@@ -1429,9 +1468,10 @@ dependencies = [
  "metrics",
  "nanoid",
  "object_store",
- "opentelemetry 0.24.0",
- "opentelemetry-prometheus 0.17.0",
- "opentelemetry_sdk 0.24.1",
+ "opentelemetry",
+ "opentelemetry-otlp",
+ "opentelemetry-prometheus",
+ "opentelemetry_sdk",
  "prometheus",
  "rand",
  "serde",
@@ -1443,6 +1483,7 @@ dependencies = [
  "tokio",
  "tower-http",
  "tracing",
+ "tracing-opentelemetry",
  "tracing-subscriber",
  "url",
  "utoipa",
@@ -1472,12 +1513,22 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "indexmap"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68b900aa2f7301e21c36462b170ee99994de34dff39a4a6a528e80e7376d07e5"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.14.5",
  "serde",
 ]
 
@@ -1677,9 +1728,9 @@ dependencies = [
  "axum-otel-metrics",
  "data_model",
  "once_cell",
- "opentelemetry 0.24.0",
- "opentelemetry-prometheus 0.17.0",
- "opentelemetry_sdk 0.24.1",
+ "opentelemetry",
+ "opentelemetry-prometheus",
+ "opentelemetry_sdk",
  "pin-project-lite",
  "prometheus",
  "serde",
@@ -1903,21 +1954,6 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "opentelemetry"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "900d57987be3f2aeb70d385fff9b27fb74c5723cc9a52d904d4f9c807a0667bf"
-dependencies = [
- "futures-core",
- "futures-sink",
- "js-sys",
- "once_cell",
- "pin-project-lite",
- "thiserror 1.0.63",
- "urlencoding",
-]
-
-[[package]]
-name = "opentelemetry"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c365a63eec4f55b7efeceb724f1336f26a9cf3427b70e59e2cd2a5b947fba96"
@@ -1931,16 +1967,36 @@ dependencies = [
 ]
 
 [[package]]
-name = "opentelemetry-prometheus"
-version = "0.15.0"
+name = "opentelemetry-http"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30bbcf6341cab7e2193e5843f0ac36c446a5b3fccb28747afaeda17996dcd02e"
+checksum = "ad31e9de44ee3538fb9d64fe3376c1362f406162434609e79aea2a41a0af78ab"
 dependencies = [
- "once_cell",
- "opentelemetry 0.22.0",
- "opentelemetry_sdk 0.22.1",
- "prometheus",
- "protobuf",
+ "async-trait",
+ "bytes",
+ "http",
+ "opentelemetry",
+ "reqwest",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b925a602ffb916fb7421276b86756027b37ee708f9dce2dbdcc51739f07e727"
+dependencies = [
+ "async-trait",
+ "futures-core",
+ "http",
+ "opentelemetry",
+ "opentelemetry-http",
+ "opentelemetry-proto",
+ "opentelemetry_sdk",
+ "prost",
+ "reqwest",
+ "thiserror 1.0.63",
+ "tokio",
+ "tonic",
 ]
 
 [[package]]
@@ -1950,39 +2006,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc4191ce34aa274621861a7a9d68dbcf618d5b6c66b10081631b61fd81fbc015"
 dependencies = [
  "once_cell",
- "opentelemetry 0.24.0",
- "opentelemetry_sdk 0.24.1",
+ "opentelemetry",
+ "opentelemetry_sdk",
  "prometheus",
  "protobuf",
 ]
 
 [[package]]
-name = "opentelemetry-semantic-conventions"
-version = "0.14.0"
+name = "opentelemetry-proto"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9ab5bd6c42fb9349dcf28af2ba9a0667f697f9bdcca045d39f2cec5543e2910"
+checksum = "30ee9f20bff9c984511a02f082dc8ede839e4a9bf15cc2487c8d6fea5ad850d9"
+dependencies = [
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prost",
+ "tonic",
+]
 
 [[package]]
-name = "opentelemetry_sdk"
-version = "0.22.1"
+name = "opentelemetry-semantic-conventions"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e90c7113be649e31e9a0f8b5ee24ed7a16923b322c3c5ab6367469c049d6b7e"
-dependencies = [
- "async-trait",
- "crossbeam-channel",
- "futures-channel",
- "futures-executor",
- "futures-util",
- "glob",
- "once_cell",
- "opentelemetry 0.22.0",
- "ordered-float",
- "percent-encoding",
- "rand",
- "thiserror 1.0.63",
- "tokio",
- "tokio-stream",
-]
+checksum = "1cefe0543875379e47eb5f1e68ff83f45cc41366a92dfd0d073d513bf68e9a05"
 
 [[package]]
 name = "opentelemetry_sdk"
@@ -1996,20 +2042,13 @@ dependencies = [
  "futures-util",
  "glob",
  "once_cell",
- "opentelemetry 0.24.0",
+ "opentelemetry",
  "percent-encoding",
  "rand",
  "serde_json",
  "thiserror 1.0.63",
-]
-
-[[package]]
-name = "ordered-float"
-version = "4.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83e7ccb95e240b7c9506a3d544f10d935e142cc90b0a1d56954fb44d89ad6b97"
-dependencies = [
- "num-traits",
+ "tokio",
+ "tokio-stream",
 ]
 
 [[package]]
@@ -2164,6 +2203,29 @@ dependencies = [
  "parking_lot",
  "protobuf",
  "thiserror 1.0.63",
+]
+
+[[package]]
+name = "prost"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b0487d90e047de87f984913713b85c601c05609aad5b0df4b4573fbf69aa13f"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9552f850d5f0964a4e4d0bf306459ac29323ddfbae05e35a7c0d35cb0803cc5"
+dependencies = [
+ "anyhow",
+ "itertools 0.13.0",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2393,6 +2455,7 @@ checksum = "a77c62af46e79de0a562e1a9849205ffcb7fc1238876e9bd743357570e04046f"
 dependencies = [
  "base64",
  "bytes",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "h2",
@@ -2744,7 +2807,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap",
+ "indexmap 2.5.0",
  "itoa",
  "ryu",
  "serde",
@@ -2909,7 +2972,7 @@ dependencies = [
  "indexify_utils",
  "metrics",
  "object_store",
- "opentelemetry 0.24.0",
+ "opentelemetry",
  "rocksdb",
  "serde",
  "serde_json",
@@ -3238,11 +3301,41 @@ version = "0.22.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "583c44c02ad26b0c3f3066fe629275e50627026c51ac2e595cca4c230ce1ce1d"
 dependencies = [
- "indexmap",
+ "indexmap 2.5.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
  "winnow",
+]
+
+[[package]]
+name = "tonic"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "axum",
+ "base64",
+ "bytes",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "prost",
+ "socket2",
+ "tokio",
+ "tokio-stream",
+ "tower 0.4.13",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -3253,9 +3346,13 @@ checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
 dependencies = [
  "futures-core",
  "futures-util",
+ "indexmap 1.9.3",
  "pin-project",
  "pin-project-lite",
+ "rand",
+ "slab",
  "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -3347,6 +3444,36 @@ dependencies = [
  "log",
  "once_cell",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-opentelemetry"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9784ed4da7d921bc8df6963f8c80a0e4ce34ba6ba76668acadd3edbd985ff3b"
+dependencies = [
+ "js-sys",
+ "once_cell",
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "smallvec",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber",
+ "web-time",
+]
+
+[[package]]
+name = "tracing-opentelemetry-instrumentation-sdk"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159fbb3bd93e20342e7e6ef45b96c5d122cd88043f37ad0e4b5bb052f0f4483"
+dependencies = [
+ "http",
+ "opentelemetry",
+ "tracing",
+ "tracing-opentelemetry",
 ]
 
 [[package]]
@@ -3458,12 +3585,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "urlencoding"
-version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
-
-[[package]]
 name = "utf16_iter"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3487,7 +3608,7 @@ version = "5.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "514a48569e4e21c86d0b84b5612b5e73c0b2cf09db63260134ba426d4e8ea714"
 dependencies = [
- "indexmap",
+ "indexmap 2.5.0",
  "serde",
  "serde_json",
  "utoipa-gen",
@@ -4048,7 +4169,7 @@ dependencies = [
  "crossbeam-utils",
  "displaydoc",
  "flate2",
- "indexmap",
+ "indexmap 2.5.0",
  "memchr",
  "thiserror 1.0.63",
  "zopfli",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -66,11 +66,13 @@ pin-project = "1.1.7"
 ciborium = "0.2.2"
 uuid = { version = "1.11.0", features = ["v4"] }
 url = "2.5.4"
-opentelemetry = { version="0.24.0", features = ["metrics"] }
-opentelemetry_sdk = { version = "0.24.0", features = ["metrics"] }
-opentelemetry-prometheus = {version = "0.17.0"}
+opentelemetry = { version="0.24", features = ["metrics", "trace"] }
+opentelemetry_sdk = { version = "0.24.1", features = ["rt-tokio", "metrics", "trace"] }
+opentelemetry-otlp = { version = "0.17", features = ["tokio", "metrics", "trace"] }
+opentelemetry-prometheus = { version = "0.17" }
 prometheus = {version = "0.13.4"}
-axum-otel-metrics = { version = "0.8.1"}
+axum-otel-metrics = { version = "0.9.0-alpha.2" }
+tracing-opentelemetry = "0.25"
 
 [dependencies]
 async-stream = {workspace = true}
@@ -106,14 +108,16 @@ hyper = {workspace=true}
 url = {workspace=true}
 opentelemetry = {workspace=true}
 opentelemetry-prometheus = {workspace=true}
-opentelemetry_sdk = { workspace=true }
+opentelemetry_sdk.workspace = true
 prometheus = {workspace=true}
 axum-otel-metrics = { workspace=true }
 metrics = {workspace=true}
+tracing-opentelemetry = {workspace=true}
+opentelemetry-otlp = {workspace=true}
+axum-tracing-opentelemetry = { version = "0.19.0", features = ["tracing_level_info"] }
 
 [dev-dependencies]
 tempfile = { workspace = true }
-
 
 [build-dependencies]
 # All features enabled

--- a/server/data_model/src/lib.rs
+++ b/server/data_model/src/lib.rs
@@ -1140,7 +1140,7 @@ mod tests {
     }
 
     // Check function pattern
-    fn check_compute_parent<F>(node: &str, expected_parents: Vec<&str>, configure_graph: F)
+    fn check_compute_parent<F>(node: &str, mut expected_parents: Vec<&str>, configure_graph: F)
     where
         F: FnOnce(&mut ComputeGraph),
     {
@@ -1172,12 +1172,11 @@ mod tests {
         let mut graph = create_test_graph();
         configure_graph(&mut graph);
 
-        assert_eq!(
-            graph.get_compute_parent_nodes(node).sort(),
-            expected_parents.clone().sort(),
-            "Failed for node: {}",
-            node
-        );
+        let mut parent_nodes = graph.get_compute_parent_nodes(node);
+        parent_nodes.sort();
+        expected_parents.sort();
+
+        assert_eq!(parent_nodes, expected_parents, "Failed for node: {}", node);
     }
 
     #[test]

--- a/server/metrics/src/lib.rs
+++ b/server/metrics/src/lib.rs
@@ -99,7 +99,11 @@ pub fn init_provider() -> prometheus::Registry {
     let exporter = opentelemetry_prometheus::exporter()
         .with_registry(registry.clone())
         .build();
-    let mut provider = SdkMeterProvider::builder();
+    let mut provider =
+        SdkMeterProvider::builder().with_resource(opentelemetry_sdk::Resource::new(vec![
+            opentelemetry::KeyValue::new("service.name", "indexify-server"),
+            opentelemetry::KeyValue::new("service.version", env!("CARGO_PKG_VERSION")),
+        ]));
 
     let low_latency_boundaries = &[
         0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1.0, 5.0, 10.0, 25.0, 50.0, 75.0, 100.0, 250.0, 500.0,

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -3,25 +3,29 @@ use std::{env, fmt::Debug, net::SocketAddr};
 use anyhow::Result;
 use blob_store::BlobStorageConfig;
 use figment::{
-    providers::{Format, Yaml},
+    providers::{Format, Serialized, Yaml},
     Figment,
 };
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ServerConfig {
+    pub dev: bool,
     pub state_store_path: String,
     pub listen_addr: String,
     pub blob_storage: BlobStorageConfig,
+    pub tracing: TracingConfig,
 }
 
 impl Default for ServerConfig {
     fn default() -> Self {
         let state_store_path = env::current_dir().unwrap().join("indexify_storage/state");
         ServerConfig {
+            dev: false,
             state_store_path: state_store_path.to_str().unwrap().to_string(),
             listen_addr: "0.0.0.0:8900".to_string(),
             blob_storage: Default::default(),
+            tracing: TracingConfig::default(),
         }
     }
 }
@@ -29,7 +33,9 @@ impl Default for ServerConfig {
 impl ServerConfig {
     pub fn from_path(path: &str) -> Result<ServerConfig> {
         let config_str = std::fs::read_to_string(path)?;
-        let config: ServerConfig = Figment::new().merge(Yaml::string(&config_str)).extract()?;
+        let config: ServerConfig = Figment::from(Serialized::defaults(ServerConfig::default()))
+            .merge(Yaml::string(&config_str))
+            .extract()?;
         config.validate()?;
         Ok(config)
     }
@@ -43,4 +49,13 @@ impl ServerConfig {
         }
         Ok(())
     }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct TracingConfig {
+    // Enable tracing.
+    pub enabled: bool,
+    // OpenTelemetry collector grpc endpoint. Defaults to using OTEL_EXPORTER_OTLP_ENDPOINT env var
+    // or to localhost:4317 if empty.
+    pub endpoint: Option<String>,
 }

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -1,6 +1,11 @@
-use std::path::PathBuf;
+use std::{env, path::PathBuf};
 
+use anyhow::Result;
 use clap::Parser;
+use config::ServerConfig;
+use opentelemetry::{global, trace::TracerProvider};
+use opentelemetry_otlp::WithExportConfig;
+use opentelemetry_sdk::{propagation::TraceContextPropagator, trace::Sampler};
 use service::Service;
 use tracing::error;
 use tracing_subscriber::{
@@ -9,7 +14,7 @@ use tracing_subscriber::{
         format::{Format, JsonFields},
     },
     layer::SubscriberExt,
-    util::SubscriberInitExt,
+    Layer,
 };
 
 mod config;
@@ -30,44 +35,107 @@ struct Cli {
     config: Option<PathBuf>,
 }
 
-fn setup_tracing(structured_logging: bool) {
+fn get_env_filter() -> tracing_subscriber::EnvFilter {
     // RUST_LOG used to control logging level.
-    let env_filter_layer =
-        tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| {
-            tracing_subscriber::EnvFilter::default()
-                .add_directive(tracing_subscriber::filter::LevelFilter::INFO.into())
-        });
+    tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| {
+        tracing_subscriber::EnvFilter::default()
+            .add_directive(tracing_subscriber::filter::LevelFilter::INFO.into())
+    })
+}
 
+fn get_log_layer<S>(structured_logging: bool) -> Box<dyn Layer<S> + Send + Sync + 'static>
+where
+    S: for<'a> tracing_subscriber::registry::LookupSpan<'a>,
+    S: tracing::Subscriber,
+{
+    // Create an OTLP pipeline exporter for a `trace_demo` service.
     if structured_logging {
-        let log_layer = fmt::layer()
-            .event_format(
-                Format::default()
-                    .json()
-                    .with_span_list(false)
-                    .flatten_event(true),
-            )
-            .fmt_fields(JsonFields::default());
-        tracing_subscriber::registry()
-            .with(env_filter_layer)
-            .with(log_layer)
-            .init();
-        return;
+        return Box::new(
+            fmt::layer()
+                .event_format(
+                    Format::default()
+                        .json()
+                        .with_span_list(false)
+                        .flatten_event(true),
+                )
+                .fmt_fields(JsonFields::default()),
+        );
     }
 
-    tracing_subscriber::registry()
+    Box::new(tracing_subscriber::fmt::layer().compact())
+}
+
+fn setup_tracing(config: ServerConfig) -> Result<()> {
+    let structured_logging = !config.dev;
+    let env_filter_layer = get_env_filter();
+    let log_layer = get_log_layer(structured_logging);
+    let subscriber = tracing_subscriber::Registry::default()
         .with(env_filter_layer)
-        .with(tracing_subscriber::fmt::layer().compact())
-        .init();
+        .with(log_layer);
+
+    if !config.tracing.enabled {
+        if let Err(e) = tracing::subscriber::set_global_default(subscriber) {
+            error!("logger was already initiated, continuing: {:?}", e);
+        }
+        return Ok(());
+    }
+
+    let mut span_exporter: Option<opentelemetry_otlp::TonicExporterBuilder> = None;
+    // If endpoint is configured use it, otherwise use the otlp defaults.
+    if let Some(endpoint) = config.tracing.endpoint.clone() {
+        span_exporter.replace(
+            opentelemetry_otlp::new_exporter()
+                .tonic()
+                .with_endpoint(endpoint),
+        );
+    }
+    let span_exporter = span_exporter.unwrap_or(opentelemetry_otlp::new_exporter().tonic());
+
+    let tracer_provider = opentelemetry_otlp::new_pipeline()
+        .tracing()
+        .with_trace_config(
+            opentelemetry_sdk::trace::Config::default()
+                .with_sampler(Sampler::AlwaysOn)
+                .with_resource(opentelemetry_sdk::Resource::new(vec![
+                    opentelemetry::KeyValue::new("service.name", "indexify-server"),
+                    opentelemetry::KeyValue::new("service.version", env!("CARGO_PKG_VERSION")),
+                ])),
+        )
+        .with_exporter(span_exporter)
+        .install_batch(opentelemetry_sdk::runtime::Tokio)?;
+
+    global::set_tracer_provider(tracer_provider.clone());
+    let tracer = tracer_provider.tracer("tracing-otel-subscriber");
+
+    // Create a layer with the configured tracer
+    let otel_layer = tracing_opentelemetry::layer()
+        .with_error_records_to_exceptions(true)
+        .with_tracer(tracer);
+    global::set_tracer_provider(tracer_provider.clone());
+
+    opentelemetry::global::set_text_map_propagator(TraceContextPropagator::new());
+    tracing::subscriber::set_global_default(subscriber.with(otel_layer))?;
+
+    Ok(())
 }
 
 #[tokio::main]
 async fn main() {
     let cli = Cli::parse();
-    let config = match cli.config {
+    let mut config = match cli.config {
         Some(path) => config::ServerConfig::from_path(path.to_str().unwrap()).unwrap(),
         None => config::ServerConfig::default(),
     };
-    setup_tracing(!cli.dev);
+
+    // Override config with cli arguments.
+    if cli.dev {
+        config.dev = true;
+    }
+
+    if let Err(err) = setup_tracing(config.clone()) {
+        error!("Error setting up tracing: {:?}", err);
+        return;
+    }
 
     let service = Service::new(config).await;
     if let Err(err) = service {
@@ -77,4 +145,7 @@ async fn main() {
     if let Err(err) = service.unwrap().start().await {
         error!("Error starting service: {:?}", err);
     }
+
+    // export traces before shutdown
+    opentelemetry::global::shutdown_tracer_provider();
 }

--- a/server/src/scheduler.rs
+++ b/server/src/scheduler.rs
@@ -18,7 +18,7 @@ use task_scheduler::{
     TaskScheduler,
 };
 use tokio::{self, sync::watch::Receiver};
-use tracing::{error, info, span};
+use tracing::{error, info, instrument, span};
 
 pub struct Scheduler {
     indexify_state: Arc<IndexifyState>,
@@ -36,6 +36,7 @@ impl Scheduler {
         }
     }
 
+    #[instrument(skip(self))]
     pub async fn run_scheduler(&self) -> Result<()> {
         let _timer = Timer::start(&self.metrics.scheduler_invocations);
         let state_changes = self

--- a/server/src/service.rs
+++ b/server/src/service.rs
@@ -105,8 +105,8 @@ impl Service {
         axum_server::bind(addr)
             .handle(handle)
             .serve(app.into_make_service())
-            .await
-            .unwrap();
+            .await?;
+
         Ok(())
     }
 }

--- a/server/state_store/src/requests.rs
+++ b/server/state_store/src/requests.rs
@@ -11,13 +11,14 @@ use data_model::{
     TaskDiagnostics,
     TaskId,
 };
+use strum::AsRefStr;
 
 pub struct StateMachineUpdateRequest {
     pub payload: RequestPayload,
     pub state_changes_processed: Vec<StateChangeId>,
 }
 
-#[derive(strum::Display)]
+#[derive(AsRefStr, strum::Display)]
 pub enum RequestPayload {
     InvokeComputeGraph(InvokeComputeGraphRequest),
     ReplayComputeGraph(ReplayComputeGraphRequest),

--- a/server/state_store/src/scanner.rs
+++ b/server/state_store/src/scanner.rs
@@ -21,6 +21,7 @@ use metrics::Timer;
 use opentelemetry::KeyValue;
 use rocksdb::{Direction, IteratorMode, ReadOptions, TransactionDB};
 use serde::de::DeserializeOwned;
+use tracing::instrument;
 
 use super::state_machine::IndexifyObjectsColumns;
 use crate::serializer::{JsonEncode, JsonEncoder};
@@ -418,6 +419,7 @@ impl StateReader {
         Ok(urls)
     }
 
+    #[instrument(skip(self))]
     pub fn get_unprocessed_state_changes(&self) -> Result<Vec<StateChange>> {
         let kvs = &[KeyValue::new("op", "get_unprocessed_state_changes")];
         let _timer = Timer::start_with_labels(&self.metrics.state_read, kvs);

--- a/server/state_store/src/state_machine.rs
+++ b/server/state_store/src/state_machine.rs
@@ -32,7 +32,7 @@ use rocksdb::{
     TransactionDB,
 };
 use strum::AsRefStr;
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, instrument};
 
 use super::serializer::{JsonEncode, JsonEncoder};
 use crate::requests::{
@@ -629,6 +629,7 @@ pub(crate) enum InvocationCompletion {
 }
 
 // returns true if system task has finished
+#[instrument(skip(db, txn, req, sm_metrics))]
 pub(crate) fn create_tasks(
     db: Arc<TransactionDB>,
     txn: &Transaction<TransactionDB>,


### PR DESCRIPTION
## What

<!--
In a few sentences, please summarize the change to help reviewers.

Consider providing screenshots, logs, code or other visual aids to help the reviewer understand the approach taken.
-->
This PR enables exporting opentelemetry traces to a given endpoint. The endpoint can be either configured in the config file or using the standard opentelemetry environment variables.

config.yml example:
```
tracing:
  enabled: true
```

Changes:
- Config change to support enabling tracing
- Change to how the config parsing work to merge config values with the default
- 

### A look at existing traces

As we start using traces more and more, we'll need to format and add new traces as needed.

<img width="900" alt="image" src="https://github.com/user-attachments/assets/034e5410-23d2-4a51-a919-e71880ece95a">


### Tracing propagation

We are using W3C Tracecontext to propagate traces. It reads a parent trace-id from the `traceparent` header and returns a new trace + span back in the response headers.

```
curl -v -H "traceparent: 00-d5fe1dc9035165ce36952daf29686b6c-14330be33197dd1a-01" http://localhost:8900/namespaces
* Host localhost:8900 was resolved.
* IPv6: ::1
* IPv4: 127.0.0.1
*   Trying [::1]:8900...
* connect to ::1 port 8900 from ::1 port 53044 failed: Connection refused
*   Trying 127.0.0.1:8900...
* Connected to localhost (127.0.0.1) port 8900
> GET /namespaces HTTP/1.1
> Host: localhost:8900
> User-Agent: curl/8.7.1
> Accept: */*
> traceparent: 00-d5fe1dc9035165ce36952daf29686b6c-14330be33197dd1a-01
>
* Request completely sent off
< HTTP/1.1 200 OK
< content-type: application/json
< traceparent: 00-d5fe1dc9035165ce36952daf29686b6c-574acef8aad9a667-01
< tracestate:
< vary: origin, access-control-request-method, access-control-request-headers
< access-control-allow-origin: *
< content-length: 62
< date: Wed, 04 Dec 2024 20:21:45 GMT
<
* Connection #0 to host localhost left intact
{"namespaces":[{"name":"default","created_at":1733342892666}]}
```


## Testing

<!--
Please include steps used to verify the change.

Consider providing screenshots, logs, code or other visual aids to help the reviewer in their testing.
-->

Run server with the config:
```
tracing:
  enabled: true
```

```
run --rm --name jaeger \
                                        -e COLLECTOR_OTLP_ENABLED:true \
                                        -p 16686:16686 \
                                        -p 4317:4317 \
                                        -p 4318:4318 \
                                       jaegertracing/all-in-one:1.49
```

Open http://localhost:16686

## Contribution Checklist

- [x] If the python-sdk was changed, please run `make fmt` in `python-sdk/`.
- [x] If the server was changed, please run `make fmt` in `server/`.
- [x] Make sure all PR Checks are passing.
<!--
You can run the tests manually:

Notes:

- Tests can be run manually: in `python-sdk/`, run the run `pip install -e .`,
  start the server and executor, and run `python test_graph_behaviours.py`.
- To test if changes to the server are backward compatible with the latest
  release, label the PR with `ci_compat_test`. This might report failures
  unrelated to your change if previous incompatible changes were pushed without
  being released yet -->
