### PR TITLE
bug(sdk): increase task reporting timeout from 5s to 5m

### DIFF
--- a/python-sdk/indexify/executor/task_reporter.py
+++ b/python-sdk/indexify/executor/task_reporter.py
@@ -2,6 +2,8 @@ import io
 from typing import Optional
 
 import nanoid
+from httpx import Timeout
+from pydantic import BaseModel
 from rich import print
 
 from indexify.common_util import get_httpx_client
@@ -21,6 +23,15 @@ FORCE_MULTIPART = ForceMultipartDict()
 UTF_8_CONTENT_TYPE = "application/octet-stream"
 
 
+class ReportingData(BaseModel):
+    output_count: int = 0
+    output_total_bytes: int = 0
+    stdout_count: int = 0
+    stdout_total_bytes: int = 0
+    stderr_count: int = 0
+    stderr_total_bytes: int = 0
+
+
 class TaskReporter:
     def __init__(
         self, base_url: str, executor_id: str, config_path: Optional[str] = None
@@ -30,11 +41,10 @@ class TaskReporter:
         self._client = get_httpx_client(config_path)
 
     def report_task_outcome(self, completed_task: CompletedTask):
+
+        report = ReportingData()
         fn_outputs = []
         for output in completed_task.outputs or []:
-            print(
-                f"[bold]task-reporter[/bold] uploading output of size: {len(output.payload)} bytes"
-            )
             serializer = get_serializer(output.encoder)
             serialized_output = serializer.serialize(output.payload)
             fn_outputs.append(
@@ -43,11 +53,10 @@ class TaskReporter:
                     (nanoid.generate(), serialized_output, serializer.content_type),
                 )
             )
+            report.output_count += 1
+            report.output_total_bytes += len(serialized_output)
 
         if completed_task.stdout:
-            print(
-                f"[bold]task-reporter[/bold] uploading stdout of size: {len(completed_task.stdout)}"
-            )
             fn_outputs.append(
                 (
                     "stdout",
@@ -58,11 +67,10 @@ class TaskReporter:
                     ),
                 )
             )
+            report.stdout_count += 1
+            report.stdout_total_bytes += len(completed_task.stdout)
 
         if completed_task.stderr:
-            print(
-                f"[bold]task-reporter[/bold] uploading stderr of size: {len(completed_task.stderr)}"
-            )
             fn_outputs.append(
                 (
                     "stderr",
@@ -73,6 +81,8 @@ class TaskReporter:
                     ),
                 )
             )
+            report.stderr_count += 1
+            report.stderr_total_bytes += len(completed_task.stderr)
 
         router_output = (
             ApiRouterOutput(edges=completed_task.router_output.edges)
@@ -93,7 +103,30 @@ class TaskReporter:
         )
         task_result_data = task_result.model_dump_json(exclude_none=True)
 
-        kwargs = {"data": {"task_result": task_result_data}}
+        total_bytes = (
+            report.output_total_bytes
+            + report.stdout_total_bytes
+            + report.stderr_total_bytes
+        )
+
+        print(
+            f"[bold]task-reporter[/bold] reporting task outcome "
+            f"task_id={completed_task.task.id} retries={completed_task.reporting_retries} "
+            f"total_bytes={total_bytes} total_files={report.output_count + report.stdout_count + report.stderr_count} "
+            f"output_files={report.output_count} output_bytes={total_bytes} "
+            f"stdout_bytes={report.stdout_total_bytes} stderr_bytes={report.stderr_total_bytes} "
+        )
+
+        #
+        kwargs = {
+            "data": {"task_result": task_result_data},
+            # Use httpx default timeout of 5s for all timeout types.
+            # For read timeouts, use 5 minutes to allow for large file uploads.
+            "timeout": Timeout(
+                5.0,
+                read=5.0 * 60,
+            ),
+        }
         if fn_outputs and len(fn_outputs) > 0:
             kwargs["files"] = fn_outputs
         else:
@@ -104,11 +137,15 @@ class TaskReporter:
                 **kwargs,
             )
         except Exception as e:
-            print(f"failed to report task outcome {e}")
+            print(
+                f"[bold]task-reporter[/bold] failed to report task outcome retries={completed_task.reporting_retries} {type(e).__name__}({e})"
+            )
             raise e
 
         try:
             response.raise_for_status()
         except Exception as e:
-            print(f"failed to report task outcome {response.text}")
+            print(
+                f"[bold]task-reporter[/bold] failed to report task outcome retries={completed_task.reporting_retries} {response.text}"
+            )
             raise e

--- a/python-sdk/indexify/executor/task_store.py
+++ b/python-sdk/indexify/executor/task_store.py
@@ -17,6 +17,7 @@ class CompletedTask(BaseModel):
     stdout: Optional[str] = None
     stderr: Optional[str] = None
     reducer: bool = False
+    reporting_retries: int = 0
 
 
 class TaskStore:

--- a/server/src/routes/internal_ingest.rs
+++ b/server/src/routes/internal_ingest.rs
@@ -81,7 +81,7 @@ pub struct InvokeWithFile {
 /// Upload data to a compute graph
 #[utoipa::path(
     post,
-    path = "/namespaces/{namespace}/compute_graphs/{compute_graph}/invoke_file",
+    path = "internal/ingest_files",
     request_body(content_type = "multipart/form-data", content = inline(InvokeWithFile)),
     tag = "ingestion",
     responses(


### PR DESCRIPTION
## Context

<!--
In a few sentences or less, please explain the context behind this change to help answer why this change is needed.

If this is a bug fix, make sure to include "fixes #xxxx", or
"closes #xxxx".

Screenshots, logs, code or other visual aids are greatly appreciated.
 -->

Fixes https://github.com/tensorlakeai/indexify/issues/1037

The httpx client library sets various timeouts to 5s. Unfortunately, when uploading large files or a lot of files, this is not sufficient.

## What

<!--
In a few sentences, please summarize the change to help reviewers.

Consider providing screenshots, logs, code or other visual aids to help the reviewer understand the approach taken.
-->

This PR does 2 things:
- increase visibility into task reporting retries by modifying logs and adding a retry counter.
- increase the default 5s Read Timeout to 5 minutes.

Note that while this should increase the success rate of most graphs outcome reporting, there are still some graphs with a very big number of files or very large files that would still have issues being uploaded. An alternative solution will be needed for example writing directly to blob storage using a pre-signed URL, splitting uploads in multiple requests to the server, doing chunk uploads, ...

## Testing

<!--
Please include steps used to verify the change.

Consider providing screenshots, logs, code or other visual aids to help the reviewer in their testing.
-->

Using S3 run this graph:

<details>
<summary>Code</summary>

```python
import subprocess, os, platform, sys
from typing import List, Tuple
from indexify import RemoteGraph, Graph, Image, indexify_function
import time

from pydantic import BaseModel


# @indexify_function(encoder="json")
@indexify_function()
def start_node(text: str) -> List[Tuple[int, str]]:
    return [(index, char) for index, char in enumerate(text)]


@indexify_function()
def concat_char_idx(char_data: Tuple[int, str]) -> str:
    return f"{char_data[1]}={char_data[0]}"


class Acc(BaseModel):
    values: List[str] = list()


@indexify_function(accumulate=Acc)
def append_to_list(acc: Acc, char_data: str) -> List[str]:
    char, index = char_data.split("=")
    if len(acc.values) <= int(index):
        acc.values.extend([""] * (int(index) - len(acc.values) + 1))
    acc.values[int(index)] = char
    return acc


@indexify_function()
def end_node(acc: Acc) -> str:
    return "".join(acc.values)


if __name__ == "__main__":
    graph = Graph(name="stress-test_graph", start_node=start_node)
    graph.add_edge(start_node, concat_char_idx)
    graph.add_edge(concat_char_idx, append_to_list)
    graph.add_edge(append_to_list, end_node)
    graph = RemoteGraph.deploy(graph)

    text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi metus ipsum, tincidunt a ligula sed, feugiat luctus dui."
    # text = "hello world"
    invocation_id = graph.run(block_until_done=True, text=text)
    output = graph.output(invocation_id, "end_node")

    print(output)

```

</details>

## Contribution Checklist

- [ ] If the python-sdk was changed, please run `make fmt` in `python-sdk/`.
- [ ] If the server was changed, please run `make fmt` in `server/`.
- [ ] Make sure all PR Checks are passing.
<!--
You can run the tests manually:

Notes:

- Tests can be run manually: in `python-sdk/`, run the run `pip install -e .`,
  start the server and executor, and run `python test_graph_behaviours.py`.
- To test if changes to the server are backward compatible with the latest
  release, label the PR with `ci_compat_test`. This might report failures
  unrelated to your change if previous incompatible changes were pushed without
  being released yet -->
