### PR TITLE
Pass the config_path to the Downloader

### DIFF
--- a/python-sdk/indexify/executor/agent.py
+++ b/python-sdk/indexify/executor/agent.py
@@ -100,7 +100,7 @@ class ExtractorAgent:
         self._server_addr = server_addr
         self._base_url = f"{self._protocol}://{self._server_addr}"
         self._code_path = code_path
-        self._downloader = Downloader(code_path=code_path, base_url=self._base_url)
+        self._downloader = Downloader(code_path=code_path, base_url=self._base_url, config_path=self._config_path)
         self._max_queued_tasks = 10
         self._task_reporter = TaskReporter(
             base_url=self._base_url,


### PR DESCRIPTION
## Context

Actually executing graphs when using mTLS was not working because the graphs could not be downloaded.

## What

This PR passes the config_path so mTLS is enforced for download requests.

## Testing

This was tested in prod. 

## Contribution Checklist

- [ ] If the python-sdk was changed, please run `make fmt` in `python-sdk/`.
- [ ] If the server was changed, please run `make fmt` in `server/`.
- [ ] Make sure all PR Checks are passing.
<!--
You can run the tests manually:

Notes:

- Tests can be run manually: in `python-sdk/`, run the run `pip install -e .`,
  start the server and executor, and run `python test_graph_behaviours.py`.
- To test if changes to the server are backward compatible with the latest
  release, label the PR with `ci_compat_test`. This might report failures
  unrelated to your change if previous incompatible changes were pushed without
  being released yet -->
