### PR TITLE
ui(feat): Download output of a function from the UI

### DIFF
--- a/server/ui/src/components/tables/InvocationOutputTable.tsx
+++ b/server/ui/src/components/tables/InvocationOutputTable.tsx
@@ -72,7 +72,6 @@ function InvocationOutputTable({ indexifyServiceURL, invocationId, namespace, co
     try {
       const url = `${indexifyServiceURL}/namespaces/${namespace}/compute_graphs/${computeGraph}/invocations/${invocationId}/fn/${function_name}/output/${output_id}`;
       const response = await axios.get(url);
-      console.log("response", response.data,);
       const content_type = response.headers['content-type']
       const fileExtension = content_type === 'application/json' ? 'json' : 
           content_type === 'application/octet-stream' ? 'bin' : 'txt';
@@ -84,7 +83,6 @@ function InvocationOutputTable({ indexifyServiceURL, invocationId, namespace, co
       downloadLink.click();
       document.body.removeChild(downloadLink);
     } catch(error) {
-      console.error(`Error fetching output for function: ${function_name} in compute graph: ${computeGraph} for output id: ${output_id}"`, error);
       toast.error(`Failed to fetch output for function: ${function_name} for output id: ${output_id}`)
     }
   }, [indexifyServiceURL, invocationId, namespace, computeGraph])


### PR DESCRIPTION
## Context
A small feature to download the execution output of a function within an invocation. If the encoder is `json` a file with `.json` extension will download, and if the encoder is `cloudpickle` a file with `.bin` extension will download. Addresses #1054.

## Testing
### Download button - 
![Screenshot 2024-11-21 at 8 29 28 PM](https://github.com/user-attachments/assets/f6a92541-beb0-4679-9af7-fe68b5ca73c0)
### Clicking on the download button - 
![Screenshot 2024-11-21 at 8 30 15 PM](https://github.com/user-attachments/assets/99ec7937-bd61-4acb-af9e-068d5cca6710)
### Viewing the `.json` file.
![Screenshot 2024-11-21 at 8 30 38 PM](https://github.com/user-attachments/assets/7e6ff3bd-831a-48f4-8cfc-eb0c36f6aee5)

## Contribution Checklist

- [N/A] If the python-sdk was changed, please run `make fmt` in `python-sdk/`.
- [N/A] If the server was changed, please run `make fmt` in `server/`.
- [] Make sure all PR Checks are passing.
