### PR TITLE
Run Poetry install before poetry build command in Makefile

### DIFF
--- a/python-sdk/Makefile
+++ b/python-sdk/Makefile
@@ -2,6 +2,7 @@ all: build
 
 build:
 	@rm -rf dist
+	@poetry install
 	@poetry build
 
 fmt:


### PR DESCRIPTION
Building Python SDK project requires all Poetry dependencies to be installed first. Also adding install command ensures that all dependencies are updating during development if they are changes in pyproject.toml.

Poetry install is exiting in a few ms if everything is installed already so this doesn't add extra delay.

## Contribution Checklist

- [X] If the python-sdk was changed, please run `make fmt` in `python-sdk/`.
- [n/a] If the server was changed, please run `make fmt` in `server/`.
- [X] Make sure all PR Checks are passing.