### PR TITLE
Use python-sdk `make test` target to run all python-sdk tests

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -35,8 +35,8 @@ You can run the tests manually:
 
 Notes:
 
-- Tests can be run manually: in `python-sdk/`, run the run `pip install -e .`,
-  start the server and executor, and run `python test_graph_behaviours.py`.
+- Tests can be run manually: start the server and executor, `cd python-sdk`,
+  run `make test`.
 - To test if changes to the server are backward compatible with the latest
   release, label the PR with `ci_compat_test`. This might report failures
   unrelated to your change if previous incompatible changes were pushed without

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -75,10 +75,10 @@ jobs:
         with:
           python-version: 3.11
           cache: 'poetry'
-      - name: Install python dependencies
+      - name: Build python-sdk
         run: |
           cd python-sdk
-          poetry install
+          make build
       - name: Lint python-sdk
         run: |
           cd python-sdk
@@ -101,10 +101,10 @@ jobs:
         with:
           python-version: 3.11
           cache: 'poetry'
-      - name: Install python dependencies
+      - name: Build python-sdk
         run: |
           cd python-sdk
-          poetry install
+          make build
       - name: Lint python-sdk
         run: |
           cd python-sdk
@@ -159,23 +159,11 @@ jobs:
             fi
           done
 
-      - name: Run Acceptance Tests (graph behaviours)
+      - name: Run All Tests
         run: |
           cd python-sdk
           export INDEXIFY_URL=http://localhost:8900
-          poetry run python tests/test_graph_behaviours.py
-
-      - name: Run Acceptance Tests (update)
-        run: |
-          cd python-sdk
-          export INDEXIFY_URL=http://localhost:8900
-          poetry run python tests/test_graph_update.py
-
-      - name: Run Acceptance Tests (validation)
-        run: |
-          cd python-sdk
-          export INDEXIFY_URL=http://localhost:8900
-          poetry run python tests/test_graph_validation.py
+          make test
 
   last_release_acceptance_tests:
     name: 'Last Release Acceptance Tests (trigger with label: ci_compat_test)'
@@ -200,10 +188,10 @@ jobs:
         with:
           python-version: 3.11
           cache: 'poetry'
-      - name: Install python dependencies
+      - name: Build python-sdk
         run: |
           cd python-sdk
-          poetry install
+          make build
       - name: Start Background Indexify Server
         uses: JarvusInnovations/background-action@v1
         with:
@@ -254,20 +242,8 @@ jobs:
             fi
           done
 
-      - name: Run Acceptance Tests (graph behaviours)
+      - name: Run All Tests
         run: |
           cd python-sdk
           export INDEXIFY_URL=http://localhost:8900
-          poetry run python tests/test_graph_behaviours.py
-
-      - name: Run Acceptance Tests (update)
-        run: |
-          cd python-sdk
-          export INDEXIFY_URL=http://localhost:8900
-          poetry run python tests/test_graph_update.py
-
-      - name: Run Acceptance Tests (validation)
-        run: |
-          cd python-sdk
-          export INDEXIFY_URL=http://localhost:8900
-          poetry run python tests/test_graph_validation.py
+          make test


### PR DESCRIPTION
`make test` command now provides full official set of unit and integration tests for python-sdk. They can be started using the command during development and in CI. This is why PR template is updated with the command and GitHub CI actions run it now.

## Contribution Checklist

- [n/a] If the python-sdk was changed, please run `make fmt` in `python-sdk/`.
- [n/a] If the server was changed, please run `make fmt` in `server/`.
- [X] Make sure all PR Checks are passing.