### PR TITLE
No panic on create tasks if the graph ctx is none

### DIFF
--- a/server/state_store/src/scanner.rs
+++ b/server/state_store/src/scanner.rs
@@ -599,7 +599,7 @@ impl StateReader {
             &IndexifyObjectsColumns::GraphInvocationCtx.cf_db(&self.db),
             &key,
         )?;
-        if let None = value {
+        if value.is_none() {
             return Ok(None);
         }
         let invocation_ctx: GraphInvocationCtx = JsonEncoder::decode(&value.unwrap())


### PR DESCRIPTION
## Context

<!--
In a few sentences or less, please explain the context behind this change to help answer why this change is needed.

If this is a bug fix, make sure to include "fixes #xxxx", or
"closes #xxxx".

Screenshots, logs, code or other visual aids are greatly appreciated.
 -->

Fixes https://github.com/tensorlakeai/indexify/issues/1067

## What

<!--
In a few sentences, please summarize the change to help reviewers.

Consider providing screenshots, logs, code or other visual aids to help the reviewer understand the approach taken.
-->

Removing unwraps in start_tasks and replay_compute_graph.

## Testing

<!--
Please include steps used to verify the change.

Consider providing screenshots, logs, code or other visual aids to help the reviewer in their testing.
-->

Using the graph behavior test.

## Contribution Checklist

- [x] If the python-sdk was changed, please run `make fmt` in `python-sdk/`.
- [x] If the server was changed, please run `make fmt` in `server/`.
- [x] Make sure all PR Checks are passing.
<!--
You can run the tests manually:

Notes:

- Tests can be run manually: start the server and executor, `cd python-sdk`,
  run `make test`.
- To test if changes to the server are backward compatible with the latest
  release, label the PR with `ci_compat_test`. This might report failures
  unrelated to your change if previous incompatible changes were pushed without
  being released yet -->
