### PR TITLE
not updating tasks for graphs which are completed

### DIFF
--- a/server/state_store/src/state_machine.rs
+++ b/server/state_store/src/state_machine.rs
@@ -717,14 +717,20 @@ pub fn mark_task_completed(
     req: FinalizeTaskRequest,
     sm_metrics: Arc<StateStoreMetrics>,
 ) -> Result<bool> {
-    // Check if the graph exists before proceeding since 
+    // Check if the graph exists before proceeding since
     // the graph might have been deleted before the task completes
     let graph_key = ComputeGraph::key_from(&req.namespace, &req.compute_graph);
     let graph = txn
-        .get_cf(&IndexifyObjectsColumns::ComputeGraphs.cf_db(&db), &graph_key)
+        .get_cf(
+            &IndexifyObjectsColumns::ComputeGraphs.cf_db(&db),
+            &graph_key,
+        )
         .map_err(|e| anyhow!("failed to get compute graph: {}", e))?;
     if graph.is_none() {
-        error!("Compute graph not found: {} for task completion update for task id: {}", &req.compute_graph, &req.task_id);
+        error!(
+            "Compute graph not found: {} for task completion update for task id: {}",
+            &req.compute_graph, &req.task_id
+        );
         return Ok(false);
     }
     let task_key = format!(


### PR DESCRIPTION
## Bug Fix 

When a task is completed the graph or invocation could already be deleted by the user. 
1. Currently this fails ingestion and the executor keeps on retrying file uploads.
2. Checking if the invocation was deleted before updating the task