### PR TITLE
chore(dead code): remove unused invocation_finished on scheduler TaskCreationResult

### DIFF
--- a/server/src/routes.rs
+++ b/server/src/routes.rs
@@ -165,7 +165,6 @@ pub fn create_routes(route_state: RouteState) -> Router {
         .build();
     Router::new()
         .merge(SwaggerUi::new("/docs/swagger").url("/docs/openapi.json", ApiDoc::openapi()))
-        .merge(axum_metrics.routes())
         .route("/", get(index))
         .route(
             "/namespaces",
@@ -207,7 +206,6 @@ pub fn create_routes(route_state: RouteState) -> Router {
             "/internal/namespaces/:namespace/compute_graphs/:compute_graph/invocations/:invocation_id/ctx",
             get(get_ctx_state_key).with_state(route_state.clone()),
         )
-
         .layer(
             TraceLayer::new_for_http()
                 .make_span_with(|req: &Request| {
@@ -223,6 +221,7 @@ pub fn create_routes(route_state: RouteState) -> Router {
                 })
         )
         // No tracing starting here.
+        .merge(axum_metrics.routes())
         .route("/ui", get(ui_index_handler))
         .route("/ui/*rest", get(ui_handler))
         .layer(cors)

--- a/server/state_store/src/state_machine.rs
+++ b/server/state_store/src/state_machine.rs
@@ -707,6 +707,7 @@ pub fn allocate_tasks(
     executor_id: &ExecutorId,
     sm_metrics: Arc<StateStoreMetrics>,
 ) -> Result<()> {
+    // TODO: check if executor is registered
     txn.put_cf(
         &IndexifyObjectsColumns::TaskAllocations.cf_db(&db),
         task.make_allocation_key(executor_id),

--- a/server/task_scheduler/src/lib.rs
+++ b/server/task_scheduler/src/lib.rs
@@ -15,22 +15,15 @@ pub struct TaskCreationResult {
     pub tasks: Vec<Task>,
     pub new_reduction_tasks: Vec<ReduceTask>,
     pub processed_reduction_tasks: Vec<String>,
-    pub invocation_finished: bool,
     pub invocation_id: String,
 }
 
 impl TaskCreationResult {
-    pub fn no_tasks(
-        namespace: &str,
-        compute_graph: &str,
-        invocation_id: &str,
-        invocation_finished: bool,
-    ) -> Self {
+    pub fn no_tasks(namespace: &str, compute_graph: &str, invocation_id: &str) -> Self {
         Self {
             namespace: namespace.to_string(),
             compute_graph: compute_graph.to_string(),
             invocation_id: invocation_id.to_string(),
-            invocation_finished,
             tasks: vec![],
             new_reduction_tasks: vec![],
             processed_reduction_tasks: vec![],


### PR DESCRIPTION
## Context

<!--
In a few sentences or less, please explain the context behind this change to help answer why this change is needed.

If this is a bug fix, make sure to include "fixes #xxxx", or
"closes #xxxx".

Screenshots, logs, code or other visual aids are greatly appreciated.
 -->
 
 CreationResult has an invocation_finished attribute that is misleading since it is not used even though we have lots of logic around it in the scheduler.

## What

<!--
In a few sentences, please summarize the change to help reviewers.

Consider providing screenshots, logs, code or other visual aids to help the reviewer understand the approach taken.
-->

Delete the attribute and simplify code setting it.

## Testing

<!--
Please include steps used to verify the change.

Consider providing screenshots, logs, code or other visual aids to help the reviewer in their testing.
-->

## Contribution Checklist

- [x] If the python-sdk was changed, please run `make fmt` in `python-sdk/`.
- [x] If the server was changed, please run `make fmt` in `server/`.
- [x] Make sure all PR Checks are passing.
<!--
You can run the tests manually:

Notes:

- Tests can be run manually: start the server and executor, `cd python-sdk`,
  run `make test`.
- To test if changes to the server are backward compatible with the latest
  release, label the PR with `ci_compat_test`. This might report failures
  unrelated to your change if previous incompatible changes were pushed without
  being released yet -->
