### PR TITLE
feat(sdk): improved dict function output and positional arguments support

### DIFF
--- a/python-sdk/indexify/functions_sdk/graph.py
+++ b/python-sdk/indexify/functions_sdk/graph.py
@@ -147,6 +147,11 @@ class Graph:
         from_node: Union[Type[IndexifyFunction], Type[IndexifyRouter]],
         to_node: List[Union[Type[IndexifyFunction], Type[IndexifyRouter]]],
     ) -> "Graph":
+        if issubclass(from_node, IndexifyRouter):
+            raise ValueError(
+                "Cannot add edges from a router node, use route method instead"
+            )
+
         self.add_node(from_node)
         from_node_name = from_node.name
         for node in to_node:

--- a/python-sdk/indexify/functions_sdk/indexify_functions.py
+++ b/python-sdk/indexify/functions_sdk/indexify_functions.py
@@ -294,7 +294,6 @@ class IndexifyFunctionWrapper:
     def run_router(
         self, input: Union[Dict, Type[BaseModel]]
     ) -> Tuple[List[str], Optional[str]]:
-        # kwargs = input if isinstance(input, dict) else {"input": input}
         args = []
         kwargs = {}
         try:

--- a/python-sdk/indexify/functions_sdk/indexify_functions.py
+++ b/python-sdk/indexify/functions_sdk/indexify_functions.py
@@ -134,8 +134,8 @@ def _process_dict_arg(dict_arg: dict, sig: inspect.Signature):
     elif len(remaining_kwargs) > 0:
         # If there are remaining kwargs, add them as a single dict argument
         new_args.append(remaining_kwargs)
-
-    return new_args, new_kwargs
+    else:
+        return new_args, new_kwargs
 
 
 def indexify_router(

--- a/python-sdk/indexify/functions_sdk/indexify_functions.py
+++ b/python-sdk/indexify/functions_sdk/indexify_functions.py
@@ -117,7 +117,7 @@ from inspect import Parameter, signature
 from typing_extensions import get_type_hints
 
 
-def _process_dict_arg(dict_arg: dict, sig: inspect.Signature):
+def _process_dict_arg(dict_arg: dict, sig: inspect.Signature) -> Tuple[list, dict]:
     new_args = []
     new_kwargs = {}
     remaining_kwargs = dict_arg.copy()
@@ -134,8 +134,8 @@ def _process_dict_arg(dict_arg: dict, sig: inspect.Signature):
     elif len(remaining_kwargs) > 0:
         # If there are remaining kwargs, add them as a single dict argument
         new_args.append(remaining_kwargs)
-    else:
-        return new_args, new_kwargs
+
+    return new_args, new_kwargs
 
 
 def indexify_router(

--- a/python-sdk/indexify/functions_sdk/indexify_functions.py
+++ b/python-sdk/indexify/functions_sdk/indexify_functions.py
@@ -112,9 +112,30 @@ class IndexifyRouter:
         pass
 
 
-from inspect import signature
+from inspect import Parameter, signature
 
 from typing_extensions import get_type_hints
+
+
+def _process_dict_arg(dict_arg: dict, sig: inspect.Signature):
+    new_args = []
+    new_kwargs = {}
+    remaining_kwargs = dict_arg.copy()
+
+    # Match dictionary keys to function parameters
+    for param_name, param in sig.parameters.items():
+        if param_name in dict_arg:
+            new_args.append(dict_arg[param_name])
+            remaining_kwargs.pop(param_name, None)
+
+    if any(v.kind == Parameter.VAR_KEYWORD for v in sig.parameters.values()):
+        # Combine remaining dict items with additional kwargs
+        new_kwargs.update(remaining_kwargs)
+    elif len(remaining_kwargs) > 0:
+        # If there are remaining kwargs, add them as a single dict argument
+        new_args.append(remaining_kwargs)
+
+    return new_args, new_kwargs
 
 
 def indexify_router(
@@ -132,6 +153,13 @@ def indexify_router(
 
         # Create run method that preserves signature
         def run(self, *args, **kwargs):
+            # Process dictionary argument mapping it to args or to kwargs.
+            if len(args) == 1 and isinstance(args[0], dict):
+                sig = inspect.signature(fn)
+                dict_arg = args[0]
+                new_args, new_kwargs = _process_dict_arg(dict_arg, sig)
+                return fn(*new_args, **new_kwargs)
+
             return fn(*args, **kwargs)
 
         # Apply original signature and annotations to run method
@@ -173,6 +201,20 @@ def indexify_function(
 
         # Create run method that preserves signature
         def run(self, *args, **kwargs):
+            # Process dictionary argument mapping it to args or to kwargs.
+            if self.accumulate and len(args) == 2 and isinstance(args[1], dict):
+                sig = inspect.signature(fn)
+                new_args = [args[0]]  # Keep the accumulate argument
+                dict_arg = args[1]
+                new_args_from_dict, new_kwargs = _process_dict_arg(dict_arg, sig)
+                new_args.extend(new_args_from_dict)
+                return fn(*new_args, **new_kwargs)
+            elif len(args) == 1 and isinstance(args[0], dict):
+                sig = inspect.signature(fn)
+                dict_arg = args[0]
+                new_args, new_kwargs = _process_dict_arg(dict_arg, sig)
+                return fn(*new_args, **new_kwargs)
+
             return fn(*args, **kwargs)
 
         # Apply original signature and annotations to run method
@@ -252,14 +294,16 @@ class IndexifyFunctionWrapper:
     def run_router(
         self, input: Union[Dict, Type[BaseModel]]
     ) -> Tuple[List[str], Optional[str]]:
-        kwargs = input if isinstance(input, dict) else {"input": input}
+        # kwargs = input if isinstance(input, dict) else {"input": input}
         args = []
         kwargs = {}
-        if isinstance(input, dict):
-            kwargs = input
-        else:
-            args.append(input)
         try:
+            # tuple and list are considered positional arguments, list is used for compatibility
+            # with json encoding which won't deserialize in tuple.
+            if isinstance(input, tuple) or isinstance(input, list):
+                args += input
+            else:
+                args.append(input)
             extracted_data = self.indexify_function.run(*args, **kwargs)
         except Exception as e:
             return [], traceback.format_exc()
@@ -271,14 +315,18 @@ class IndexifyFunctionWrapper:
         return edges, None
 
     def run_fn(
-        self, input: Union[Dict, Type[BaseModel]], acc: Type[Any] = None
+        self, input: Union[Dict, Type[BaseModel], List, Tuple], acc: Type[Any] = None
     ) -> Tuple[List[Any], Optional[str]]:
         args = []
         kwargs = {}
+
         if acc is not None:
             args.append(acc)
-        if isinstance(input, dict):
-            kwargs = input
+
+        # tuple and list are considered positional arguments, list is used for compatibility
+        # with json encoding which won't deserialize in tuple.
+        if isinstance(input, tuple) or isinstance(input, list):
+            args += input
         else:
             args.append(input)
 

--- a/python-sdk/indexify/remote_graph.py
+++ b/python-sdk/indexify/remote_graph.py
@@ -23,7 +23,7 @@ class RemoteGraph:
         :param server_url: The URL of the server where the graph will be registered.
             Not used if client is provided.
         :param client: The IndexifyClient used to communicate with the server.
-            Prefered over server_url.
+            Preferred over server_url.
         """
         self._name = name
         if client:
@@ -88,7 +88,7 @@ class RemoteGraph:
         :param server_url: The URL of the server where the graph will be registered.
             Not used if client is provided.
         :param client: The IndexifyClient used to communicate with the server.
-            Prefered over server_url.
+            Preferred over server_url.
         """
         g.validate_graph()
         if not client:
@@ -110,7 +110,7 @@ class RemoteGraph:
         :param server_url: The URL of the server where the graph will be registered.
             Not used if client is provided.
         :param client: The IndexifyClient used to communicate with the server.
-            Prefered over server_url.
+            Preferred over server_url.
         :return: A RemoteGraph object.
         """
         return cls(name=name, server_url=server_url, client=client)

--- a/python-sdk/tests/test_graph_behaviours.py
+++ b/python-sdk/tests/test_graph_behaviours.py
@@ -357,7 +357,7 @@ class TestGraphBehaviors(unittest.TestCase):
     @parameterized.expand([(False), (True)])
     def test_return_dict_as_args(self, is_remote):
         @indexify_function()
-        def my_func(x: int) -> tuple:
+        def my_func(x: int) -> dict:
             return dict(x=1, y=2, z=3)
 
         @indexify_function()
@@ -377,9 +377,38 @@ class TestGraphBehaviors(unittest.TestCase):
         self.assertEqual(output[0], 6)
 
     @parameterized.expand([(False), (True)])
+    def test_return_multiple_dict_as_args(self, is_remote):
+        @indexify_function()
+        def my_func(x: int) -> dict:
+            return dict(x=1, y=2, z=3), dict(x=1, y=2, z=3)
+
+        @indexify_function()
+        def my_func_2(input1: dict, input2: dict) -> int:
+            return (
+                input1["x"]
+                + input1["y"]
+                + input1["z"]
+                + input2["x"]
+                + input2["y"]
+                + input2["z"]
+            )
+
+        graph = Graph(
+            name="test_multiple_return_dict_as_args",
+            description="test",
+            start_node=my_func,
+        )
+        graph.add_edge(my_func, my_func_2)
+        graph = remote_or_local_graph(graph, is_remote)
+        invocation_id = graph.run(block_until_done=True, x=1)
+        output = graph.output(invocation_id, my_func_2.name)
+        self.assertEqual(len(output), 1)
+        self.assertEqual(output[0], 12)
+
+    @parameterized.expand([(False), (True)])
     def test_return_dict_as_kwargs(self, is_remote):
         @indexify_function()
-        def my_func(x: int) -> tuple:
+        def my_func(x: int) -> dict:
             return dict(x=1, y=2, z=3)
 
         @indexify_function()
@@ -443,9 +472,38 @@ class TestGraphBehaviors(unittest.TestCase):
         self.assertEqual(output[0], 6)
 
     @parameterized.expand([(False), (True)])
+    def test_return_multiple_dict_as_args(self, is_remote):
+        @indexify_function(input_encoder="json", output_encoder="json")
+        def my_func(x: int) -> dict:
+            return dict(x=1, y=2, z=3), dict(x=1, y=2, z=3)
+
+        @indexify_function(input_encoder="json", output_encoder="json")
+        def my_func_2(input1: dict, input2: dict) -> int:
+            return (
+                input1["x"]
+                + input1["y"]
+                + input1["z"]
+                + input2["x"]
+                + input2["y"]
+                + input2["z"]
+            )
+
+        graph = Graph(
+            name="test_multiple_return_dict_as_args",
+            description="test",
+            start_node=my_func,
+        )
+        graph.add_edge(my_func, my_func_2)
+        graph = remote_or_local_graph(graph, is_remote)
+        invocation_id = graph.run(block_until_done=True, x=1)
+        output = graph.output(invocation_id, my_func_2.name)
+        self.assertEqual(len(output), 1)
+        self.assertEqual(output[0], 12)
+
+    @parameterized.expand([(False), (True)])
     def test_return_dict_as_kwargs_json(self, is_remote):
         @indexify_function(input_encoder="json", output_encoder="json")
-        def my_func(x: int) -> tuple:
+        def my_func(x: int) -> dict:
             return dict(x=1, y=2, z=3)
 
         @indexify_function(input_encoder="json", output_encoder="json")

--- a/python-sdk/tests/test_graph_behaviours.py
+++ b/python-sdk/tests/test_graph_behaviours.py
@@ -239,6 +239,18 @@ class TestGraphBehaviors(unittest.TestCase):
         output = graph.output(invocation_id, "simple_function")
         self.assertEqual(output, [MyObject(x="ab")])
 
+    @parameterized.expand([(False), (True)])
+    def test_simple_function_with_json_encoding(self, is_remote):
+        graph = Graph(
+            name="test_simple_function_with_json_encoding",
+            description="test",
+            start_node=simple_function_with_json_encoder,
+        )
+        graph = remote_or_local_graph(graph, is_remote)
+        invocation_id = graph.run(block_until_done=True, x="a")
+        output = graph.output(invocation_id, "simple_function_with_json_encoder")
+        self.assertEqual(output, ["ab"])
+
     @parameterized.expand([(True)])
     def test_remote_graph_by_name(self, is_remote):
         graph = Graph(
@@ -277,18 +289,6 @@ class TestGraphBehaviors(unittest.TestCase):
         self.assertEqual(output, ["abbbbbbbbbb"])
 
     @parameterized.expand([(False), (True)])
-    def test_simple_function_with_json_encoding(self, is_remote):
-        graph = Graph(
-            name="test_simple_function_with_json_encoding",
-            description="test",
-            start_node=simple_function_with_json_encoder,
-        )
-        graph = remote_or_local_graph(graph, is_remote)
-        invocation_id = graph.run(block_until_done=True, x="a")
-        output = graph.output(invocation_id, "simple_function_with_json_encoder")
-        self.assertEqual(output, ["ab"])
-
-    @parameterized.expand([(False), (True)])
     def test_simple_function_with_invalid_encoding(self, is_remote):
         graph = Graph(
             name="test_simple_function_with_invalid_encoding",
@@ -299,6 +299,170 @@ class TestGraphBehaviors(unittest.TestCase):
         self.assertRaises(
             ValueError, graph.run, block_until_done=True, x=MyObject(x="a")
         )
+
+    @parameterized.expand([(False), (True)])
+    def test_multiple_return_values(self, is_remote):
+        @indexify_function()
+        def my_func(x: int) -> tuple:
+            return 1, 2, 3
+
+        @indexify_function()
+        def my_func_2(x: int, y: int, z: int) -> int:
+            return x + y + z
+
+        graph = Graph(
+            name="test_multiple_return_values", description="test", start_node=my_func
+        )
+        graph.add_edge(my_func, my_func_2)
+        graph = remote_or_local_graph(graph, is_remote)
+        invocation_id = graph.run(block_until_done=True, x=1)
+        output = graph.output(invocation_id, my_func_2.name)
+        self.assertEqual(len(output), 1)
+        self.assertEqual(output[0], 6)
+
+    @parameterized.expand([(False), (True)])
+    def test_multiple_return_values_router(self, is_remote):
+        @indexify_function()
+        def my_func(x: int) -> tuple:
+            return 1, 2, 3
+
+        @indexify_function()
+        def my_func_2(x: int, y: int, z: int) -> int:
+            return x + y + z
+
+        @indexify_function()
+        def my_func_3(x: int, y: int, z: int) -> int:
+            raise Exception("Should not be called")
+
+        @indexify_router()
+        def my_router(x: int, y: int, z: int) -> List[Union[my_func_2, my_func_3]]:
+            if x + y + z == 0:
+                return my_func_3
+            else:
+                return my_func_2
+
+        graph = Graph(
+            name="test_multiple_return_values_router",
+            description="test",
+            start_node=my_func,
+        )
+        graph.add_edge(my_func, my_router)
+        graph.route(my_router, [my_func_2, my_func_3])
+        graph = remote_or_local_graph(graph, is_remote)
+        invocation_id = graph.run(block_until_done=True, x=1)
+        output = graph.output(invocation_id, my_func_2.name)
+        self.assertEqual(len(output), 1)
+        self.assertEqual(output[0], 6)
+
+    @parameterized.expand([(False), (True)])
+    def test_return_dict_as_args(self, is_remote):
+        @indexify_function()
+        def my_func(x: int) -> tuple:
+            return dict(x=1, y=2, z=3)
+
+        @indexify_function()
+        def my_func_2(input: dict) -> int:
+            return input["x"] + input["y"] + input["z"]
+
+        graph = Graph(
+            name="test_multiple_return_dict_as_args",
+            description="test",
+            start_node=my_func,
+        )
+        graph.add_edge(my_func, my_func_2)
+        graph = remote_or_local_graph(graph, is_remote)
+        invocation_id = graph.run(block_until_done=True, x=1)
+        output = graph.output(invocation_id, my_func_2.name)
+        self.assertEqual(len(output), 1)
+        self.assertEqual(output[0], 6)
+
+    @parameterized.expand([(False), (True)])
+    def test_return_dict_as_kwargs(self, is_remote):
+        @indexify_function()
+        def my_func(x: int) -> tuple:
+            return dict(x=1, y=2, z=3)
+
+        @indexify_function()
+        def my_func_2(x: int, y: int, z: int) -> int:
+            return x + y + z
+
+        graph = Graph(
+            name="test_multiple_return_dict_as_kwargs",
+            description="test",
+            start_node=my_func,
+        )
+        graph.add_edge(my_func, my_func_2)
+        graph = remote_or_local_graph(graph, is_remote)
+        invocation_id = graph.run(block_until_done=True, x=1)
+        output = graph.output(invocation_id, my_func_2.name)
+        self.assertEqual(len(output), 1)
+        self.assertEqual(output[0], 6)
+
+    @parameterized.expand([(False), (True)])
+    def test_multiple_return_values_json(self, is_remote):
+        @indexify_function(input_encoder="json", output_encoder="json")
+        def my_func(x: int) -> tuple:
+            return 1, 2, 3
+
+        @indexify_function(input_encoder="json", output_encoder="json")
+        def my_func_2(x: int, y: int, z: int) -> int:
+            return x + y + z
+
+        graph = Graph(
+            name="test_multiple_return_values_json",
+            description="test",
+            start_node=my_func,
+        )
+        graph.add_edge(my_func, my_func_2)
+        graph = remote_or_local_graph(graph, is_remote)
+        invocation_id = graph.run(block_until_done=True, x=1)
+        output = graph.output(invocation_id, my_func_2.name)
+        self.assertEqual(len(output), 1)
+        self.assertEqual(output[0], 6)
+
+    @parameterized.expand([(False), (True)])
+    def test_return_dict_args_json(self, is_remote):
+        @indexify_function(input_encoder="json", output_encoder="json")
+        def my_func(x: int) -> tuple:
+            return dict(x=1, y=2, z=3)
+
+        @indexify_function(input_encoder="json", output_encoder="json")
+        def my_func_2(input: dict) -> int:
+            return input["x"] + input["y"] + input["z"]
+
+        graph = Graph(
+            name="test_multiple_return_dict_args_json",
+            description="test",
+            start_node=my_func,
+        )
+        graph.add_edge(my_func, my_func_2)
+        graph = remote_or_local_graph(graph, is_remote)
+        invocation_id = graph.run(block_until_done=True, x=1)
+        output = graph.output(invocation_id, my_func_2.name)
+        self.assertEqual(len(output), 1)
+        self.assertEqual(output[0], 6)
+
+    @parameterized.expand([(False), (True)])
+    def test_return_dict_as_kwargs_json(self, is_remote):
+        @indexify_function(input_encoder="json", output_encoder="json")
+        def my_func(x: int) -> tuple:
+            return dict(x=1, y=2, z=3)
+
+        @indexify_function(input_encoder="json", output_encoder="json")
+        def my_func_2(x: int, y: int, z: int) -> int:
+            return x + y + z
+
+        graph = Graph(
+            name="test_multiple_return_dict_as_kwargs",
+            description="test",
+            start_node=my_func,
+        )
+        graph.add_edge(my_func, my_func_2)
+        graph = remote_or_local_graph(graph, is_remote)
+        invocation_id = graph.run(block_until_done=True, x=1)
+        output = graph.output(invocation_id, my_func_2.name)
+        self.assertEqual(len(output), 1)
+        self.assertEqual(output[0], 6)
 
     @parameterized.expand([(False), (True)])
     def test_map_operation(self, is_remote):
@@ -435,6 +599,7 @@ class TestGraphBehaviors(unittest.TestCase):
         graph1 = RemoteGraph.deploy(graph1)
         invocation_id = graph1.run(block_until_done=True, x=MyObject(x="a"))
         output2 = graph1.output(invocation_id, "SimpleFunctionCtxC")
+        self.assertEqual(len(output2), 1)
         self.assertEqual(output2[0], 11)
 
     @parameterized.expand([(False), (True)])

--- a/python-sdk/tests/test_graph_validation.py
+++ b/python-sdk/tests/test_graph_validation.py
@@ -138,12 +138,34 @@ class TestValidations(unittest.TestCase):
             return 1
 
         @indexify_router()
-        def route1(**kwargs: dict) -> Union[int, float]:
+        def route1(**kwargs: dict) -> Union[start, end]:
             return 10
 
         g = Graph(name="test", start_node=start)
         g.add_edge(start, route1)
-        g.route(route1, [end, end])
+        g.route(route1, [start, end])
+
+    def test_route_validation_used_as_edge(self):
+        @indexify_function()
+        def start() -> int:
+            return 1
+
+        @indexify_function()
+        def end() -> int:
+            return 1
+
+        @indexify_router()
+        def route1(**kwargs: dict) -> Union[start, end]:
+            return 10
+
+        g = Graph(name="test", start_node=start)
+        g.add_edge(start, route1)
+        with self.assertRaises(Exception) as cm:
+            g.add_edge(route1, [end, end])
+        self.assertEqual(
+            "Cannot add edges from a router node, use route method instead",
+            str(cm.exception),
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Context

<!--
In a few sentences or less, please explain the context behind this change to help answer why this change is needed.

If this is a bug fix, make sure to include "fixes #xxxx", or
"closes #xxxx".

Screenshots, logs, code or other visual aids are greatly appreciated.
 -->

Fixes #1081

Currently dict outputs would always become kwargs which can be surprising.

## What

<!--
In a few sentences, please summarize the change to help reviewers.

Consider providing screenshots, logs, code or other visual aids to help the reviewer understand the approach taken.
-->

This PR makes it possible to
- return a tuple and correctly turn it in to args for the next function.
- return a dict and correctly turn it into an arg OR a kwargs depending on function signature.
- kwargs method of doing graph.run still works.

Working examples:

- New: Returning a multiple values / tuple
```py
@indexify_function()
def my_func(x: int) -> tuple:
    return 1, 2, 3

@indexify_function()
def my_func_2(x: int, y: int, z: int) -> int:
    return x + y + z
```

- New: Returning a multiple values / tuple (JSON)
```py
@indexify_function(input_encoder="json", output_encoder="json")
def my_func(x: int) -> tuple:
    return 1, 2, 3

@indexify_function(input_encoder="json", output_encoder="json")
def my_func_2(x: int, y: int, z: int) -> int:
    return x + y + z
```

- New: Returning a dict and args
```py
@indexify_function()
def my_func(x: int) -> dict:
    return dict(x=1, y=2, z=3)

@indexify_function()
def my_func_2(input: dict) -> int:
    return input["x"] + input["y"] + input["z"]
```

- New: Returning a dict and args (JSON)
```py
@indexify_function(input_encoder="json", output_encoder="json")
def my_func(x: int) -> dict:
    return dict(x=1, y=2, z=3)

@indexify_function(input_encoder="json", output_encoder="json")
def my_func_2(input: dict) -> int:
    return input["x"] + input["y"] + input["z"]
```

- Backward compatible: Returning a dict and kwargs
```py
@indexify_function()
def my_func(x: int) -> dict:
    return dict(x=1, y=2, z=3)

@indexify_function()
def my_func_2(x: int, y: int, z: int) -> int:
    return x + y + z
```

- Returning a dict and kwargs (JSON)
```py
@indexify_function(input_encoder="json", output_encoder="json")
def my_func(x: int) -> dict:
    return dict(x=1, y=2, z=3)

@indexify_function(input_encoder="json", output_encoder="json")
def my_func_2(x: int, y: int, z: int) -> int:
    return x + y + z
```



## Testing

<!--
Please include steps used to verify the change.

Consider providing screenshots, logs, code or other visual aids to help the reviewer in their testing.
-->

## Contribution Checklist

- [x] If the python-sdk was changed, please run `make fmt` in `python-sdk/`.
- [x] If the server was changed, please run `make fmt` in `server/`.
- [x] Make sure all PR Checks are passing.
<!--
You can run the tests manually:

Notes:

- Tests can be run manually: start the server and executor, `cd python-sdk`,
  run `make test`.
- To test if changes to the server are backward compatible with the latest
  release, label the PR with `ci_compat_test`. This might report failures
  unrelated to your change if previous incompatible changes were pushed without
  being released yet -->
