### PR TITLE
feat(ui): exposing SDK version on graph cards

### DIFF
--- a/server/ui/src/components/cards/ComputeGraphsCard.tsx
+++ b/server/ui/src/components/cards/ComputeGraphsCard.tsx
@@ -80,29 +80,32 @@ export function ComputeGraphsCard({
             <Typography variant="subtitle2" color="text.secondary">
               Number of Nodes: {Object.keys(graph.nodes || {}).length}
             </Typography>
-            {graph.created_at && (
+            {graph.created_at !== undefined && graph.created_at > 0 && (
               <Typography variant="subtitle2" color="text.secondary">
                 Created At: {new Date(graph.created_at).toLocaleString()}
               </Typography>
             )}
             <Typography variant="subtitle2" color="text.secondary">
-              Tags:
-              {Object.keys(graph.tags || {}).length > 0 && (
-                <Box display="flex" flexWrap="wrap" mt={1}>
-                  {Object.entries(graph.tags).map(([key, value]) => (
-                    <ListItem key={key}>
-                      <Chip
-                        key={key}
-                        label={`${key}: ${value}`}
-                        color="primary"
-                        size="small"
-                        sx={{ m: 0.5 }}
-                      />
-                    </ListItem>
-                  ))}
-                </Box>
-              )}
+              SDK Version: {graph?.runtime_information?.sdk_version || 'unknown'}
             </Typography>
+            {Object.keys(graph.tags || {}).length > 0 && (
+              <Typography variant="subtitle2" color="text.secondary">
+                Tags:
+                  <Box display="flex" flexWrap="wrap" mt={1}>
+                    {Object.entries(graph.tags).map(([key, value]) => (
+                      <ListItem key={key}>
+                        <Chip
+                          key={key}
+                          label={`${key}: ${value}`}
+                          color="primary"
+                          size="small"
+                          sx={{ m: 0.5 }}
+                        />
+                      </ListItem>
+                    ))}
+                  </Box>
+              </Typography>
+            )}
           </CardContent>
         </Card>
       </Grid>

--- a/server/ui/src/types.ts
+++ b/server/ui/src/types.ts
@@ -1,107 +1,106 @@
 export interface ComputeFn {
-  name: string;
-  fn_name: string;
-  description: string;
-  reducer: boolean;
-  payload_encoder: string;
-  image_name: string;
+  name: string
+  fn_name: string
+  description: string
+  reducer: boolean
+  payload_encoder: string
+  image_name: string
 }
 
 export interface DynamicRouter {
-  name: string;
-  source_fn: string;
-  description: string;
-  target_fns: string[];
-  payload_encoder: string;
-  image_name: string;
+  name: string
+  source_fn: string
+  description: string
+  target_fns: string[]
+  payload_encoder: string
+  image_name: string
 }
 
-export type Node = 
-  | { dynamic_router: DynamicRouter }
-  | { compute_fn: ComputeFn };
+export type Node = { dynamic_router: DynamicRouter } | { compute_fn: ComputeFn }
 
 export interface ComputeGraph {
-  name: string;
-  namespace: string;
-  description: string;
-  version?: string;
-  tags: Record<string, string>;
-  start_node: Node;
-  nodes: Record<string, Node>;
-  edges: Record<string, string[]>;
-  created_at?: number;
+  name: string
+  namespace: string
+  description: string
+  version?: string
+  tags: Record<string, string>
+  runtime_information: Record<string, string>
+  start_node: Node
+  nodes: Record<string, Node>
+  edges: Record<string, string[]>
+  created_at?: number
 }
 
 export interface ComputeGraphsList {
-  compute_graphs: ComputeGraph[];
-  cursor?: string | null;
+  compute_graphs: ComputeGraph[]
+  cursor?: string | null
 }
 
 export interface CreateNamespace {
-  name: string;
+  name: string
 }
 
 export interface DataObject {
-  id: string;
-  payload_size: number;
-  payload_sha_256: string;
-  created_at?: number;
+  id: string
+  payload_size: number
+  payload_sha_256: string
+  created_at?: number
 }
 
 export interface GraphInvocations {
-  invocations: DataObject[];
-  cursor?: string | null;
+  invocations: DataObject[]
+  cursor?: string | null
 }
 
 export interface IndexifyAPIError {
-  status_code: number;
-  message: string;
+  status_code: number
+  message: string
 }
 
 export interface InvocationResult {
-  outputs: Record<string, DataObject[]>;
-  cursor?: string | null;
+  outputs: Record<string, DataObject[]>
+  cursor?: string | null
 }
 
 export interface Namespace {
-  name: string;
-  created_at: number;
+  name: string
+  created_at: number
 }
 
 export interface NamespaceList {
-  namespaces: Namespace[];
+  namespaces: Namespace[]
 }
 
-export type TaskOutcome = "Unknown" | "Success" | "Failure";
+export type TaskOutcome = 'Unknown' | 'Success' | 'Failure'
 
-export type GraphVersion = string;
+export type GraphVersion = string
 
 export interface Task {
-  id: string;
-  namespace: string;
-  compute_fn: string;
-  compute_graph: string;
-  invocation_id: string;
-  input_key: string;
-  outcome: TaskOutcome;
-  graph_version: GraphVersion;
-  reducer_output_id?: string | null;
+  id: string
+  namespace: string
+  compute_fn: string
+  compute_graph: string
+  invocation_id: string
+  input_key: string
+  outcome: TaskOutcome
+  graph_version: GraphVersion
+  reducer_output_id?: string | null
 }
 
 export interface Tasks {
-  tasks: Task[];
-  cursor?: string | null;
+  tasks: Task[]
+  cursor?: string | null
 }
 
 export interface ComputeGraphCreateType {
-  compute_graph: ComputeGraph;
-  code: string;
+  compute_graph: ComputeGraph
+  code: string
 }
 
 export interface ExecutorMetadata {
-  id: string;
-  executor_version: string;
-  addr: string;
-  image_name: string;
-  labels: Record<string, any>;
+  id: string
+  executor_version: string
+  addr: string
+  image_name: string
+  labels: Record<string, any>
 }


### PR DESCRIPTION
## Context

<!--
In a few sentences or less, please explain the context behind this change to help answer why this change is needed.

If this is a bug fix, make sure to include "fixes #xxxx", or
"closes #xxxx".

Screenshots, logs, code or other visual aids are greatly appreciated.
 -->

With the addition of the SDK version on the graph runtime information, we were lacking a way to view it on the UI.

## What

<!--
In a few sentences, please summarize the change to help reviewers.

Consider providing screenshots, logs, code or other visual aids to help the reviewer understand the approach taken.
-->

<img width="529" alt="image" src="https://github.com/user-attachments/assets/58d4ff75-bbb9-44b2-b8a0-5de0a1ce7701" />



## Testing

<!--
Please include steps used to verify the change.

Consider providing screenshots, logs, code or other visual aids to help the reviewer in their testing.
-->

## Contribution Checklist

- [x] If the python-sdk was changed, please run `make fmt` in `python-sdk/`.
- [x] If the server was changed, please run `make fmt` in `server/`.
- [x] Make sure all PR Checks are passing.
<!--
You can run the tests manually:

Notes:

- Tests can be run manually: start the server and executor, `cd python-sdk`,
  run `make test`.
- To test if changes to the server are backward compatible with the latest
  release, label the PR with `ci_compat_test`. This might report failures
  unrelated to your change if previous incompatible changes were pushed without
  being released yet -->
