### PR TITLE
fix(sdk): stop end nodes becoming routers on validation

### DIFF
--- a/python-sdk/indexify/functions_sdk/graph.py
+++ b/python-sdk/indexify/functions_sdk/graph.py
@@ -264,9 +264,14 @@ class Graph:
             current_node_name = queue.popleft()
             neighbours = (
                 self.edges[current_node_name]
-                if self.edges[current_node_name]
-                else self.routers[current_node_name]
+                if current_node_name in self.edges
+                else (
+                    self.routers[current_node_name]
+                    if current_node_name in self.routers
+                    else []
+                )
             )
+
             for neighbour in neighbours:
                 if neighbour in visited:
                     continue
@@ -276,9 +281,7 @@ class Graph:
 
         if total_number_of_nodes != len(visited):
             # all the nodes are not reachable from the start_node.
-            raise Exception(
-                "Some nodes in the graph are not reachable from start node."
-            )
+            raise Exception("Some nodes in the graph are not reachable from start node")
 
     def _run(
         self,

--- a/python-sdk/tests/test_graph_validation.py
+++ b/python-sdk/tests/test_graph_validation.py
@@ -167,6 +167,69 @@ class TestValidations(unittest.TestCase):
             str(cm.exception),
         )
 
+    def test_unreachable_graph_nodes(self):
+        @indexify_function()
+        def start() -> int:
+            return 1
+
+        @indexify_function()
+        def middle() -> int:
+            return 1
+
+        @indexify_function()
+        def end() -> int:
+            return 1
+
+        graph = Graph(
+            name="test_unreachable_graph_nodes",
+            start_node=start,
+        )
+        graph.add_edge(middle, end)
+        with self.assertRaises(Exception) as cm:
+            graph.validate_graph()
+        self.assertEqual(
+            "Some nodes in the graph are not reachable from start node",
+            str(cm.exception),
+        )
+
+    def test_validation_does_not_change_graph(self):
+        """
+        Ensure that the graph is not changed when calling validate_graph.
+
+        This is to catch potential regressions like doing a defaultdict key creation.
+        """
+
+        @indexify_function()
+        def start() -> int:
+            return 1
+
+        @indexify_function()
+        def middle() -> int:
+            return 1
+
+        @indexify_function()
+        def end() -> int:
+            return 1
+
+        graph = Graph(
+            name="test_unreachable_graph_nodes",
+            start_node=start,
+        )
+        graph.add_edge(start, middle)
+        graph.add_edge(middle, end)
+
+        graph_def = graph.definition()
+
+        graph.validate_graph()
+
+        graph_def2 = graph.definition()
+
+        self.assertEqual(
+            graph_def,
+            graph_def2,
+            "ensure graph is not changed for example by triggering a defaultdict key creation",
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Context

<!--
In a few sentences or less, please explain the context behind this change to help answer why this change is needed.

If this is a bug fix, make sure to include "fixes #xxxx", or
"closes #xxxx".

Screenshots, logs, code or other visual aids are greatly appreciated.
 -->

https://github.com/tensorlakeai/indexify/pull/1063 introduced a bug where all nodes without a neighbour would become dynamic router nodes.

This is caused by looking up neighbours in the edge and router dicts via square bracket as opposed to using the `in` operator. Since these dicts are defaultdict, this lookup ends up creating a key in them.

Fixing this is particularly important since placement of router nodes is different than placement of compute nodes at present.

## What

<!--
In a few sentences, please summarize the change to help reviewers.

Consider providing screenshots, logs, code or other visual aids to help the reviewer understand the approach taken.
-->

Change the validation logic and add a test to prevent future regressions.

## Testing

<!--
Please include steps used to verify the change.

Consider providing screenshots, logs, code or other visual aids to help the reviewer in their testing.
-->

## Contribution Checklist

- [x] If the python-sdk was changed, please run `make fmt` in `python-sdk/`.
- [x] If the server was changed, please run `make fmt` in `server/`.
- [x] Make sure all PR Checks are passing.
<!--
You can run the tests manually:

Notes:

- Tests can be run manually: start the server and executor, `cd python-sdk`,
  run `make test`.
- To test if changes to the server are backward compatible with the latest
  release, label the PR with `ci_compat_test`. This might report failures
  unrelated to your change if previous incompatible changes were pushed without
  being released yet -->
