### PR TITLE
Add tests for function cold and warm start durations

### DIFF
--- a/python-sdk/tests/test_invoke_duration.py
+++ b/python-sdk/tests/test_invoke_duration.py
@@ -1,0 +1,68 @@
+import time
+import unittest
+
+from indexify import Graph, indexify_function
+from indexify.remote_graph import RemoteGraph
+
+
+@indexify_function()
+def get_start_time(x: int) -> str:
+    return str(time.time())
+
+
+class TestInvokeDurations(unittest.TestCase):
+    def test_cold_start_duration_is_less_than_hundred_ms(self):
+        graph = Graph(
+            name="test_cold_start_duration_is_less_than_hundred_ms",
+            description="test",
+            start_node=get_start_time,
+        )
+        graph = RemoteGraph.deploy(graph)
+
+        invoke_start_time = time.time()
+        invocation_id = graph.run(block_until_done=True, x=1)
+        output = graph.output(invocation_id, "get_start_time")
+        self.assertEqual(len(output), 1)
+
+        func_start_time = float(output[0])
+        cold_start_duration = func_start_time - invoke_start_time
+        print(f"cold_start_duration: {cold_start_duration} seconds")
+        # The current duration we see in tests is about 10 ms.
+        #
+        # We give a large headroom to prevent this test getting flaky
+        # while still notifiying us if the cold start duration regresses
+        # significantly.
+        self.assertLess(cold_start_duration, 0.1)
+
+    def test_warm_start_duration_is_less_than_hundred_ms(self):
+        graph = Graph(
+            name="test_warm_start_duration_is_less_than_hundred_ms",
+            description="test",
+            start_node=get_start_time,
+        )
+        graph = RemoteGraph.deploy(graph)
+
+        # Cold start first.
+        invocation_id = graph.run(block_until_done=True, x=1)
+        output = graph.output(invocation_id, "get_start_time")
+        self.assertEqual(len(output), 1)
+
+        # Measure warm start duration.
+        invoke_start_time = time.time()
+        invocation_id = graph.run(block_until_done=True, x=2)
+        output = graph.output(invocation_id, "get_start_time")
+        self.assertEqual(len(output), 1)
+
+        func_start_time = float(output[0])
+        warm_start_duration = func_start_time - invoke_start_time
+        print(f"warm_start_duration: {warm_start_duration} seconds")
+        # The current duration we see in tests is about 10 ms.
+        #
+        # We give a large 100 ms headroom to prevent this test getting flaky
+        # while still notifiying us if the warm start duration regresses
+        # significantly.
+        self.assertLess(warm_start_duration, 0.1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Cold start duration: how long it takes to start running a funciton where there's no idle Function Executor available for it.

Warm start duration: how long it takes to start running a function when there's an idle Function Executor available for it.

These tests put a limit on these durations. It'll notify us if we regress on them significantly.

Current values we usually see:

```
cold_start_duration: 0.009701967239379883 seconds
warm_start_duration: 0.006789207458496094 seconds
```

Testing:

make fmt
make check
make test

## Contribution Checklist

- [X] If the python-sdk was changed, please run `make fmt` in `python-sdk/`.
- [n/a] If the server was changed, please run `make fmt` in `server/`.
- [X] Make sure all PR Checks are passing.