### PR TITLE
Update cold start duration test threshold to 2 sec

### DIFF
--- a/python-sdk/tests/test_invoke_duration.py
+++ b/python-sdk/tests/test_invoke_duration.py
@@ -11,9 +11,9 @@ def get_start_time(x: int) -> str:
 
 
 class TestInvokeDurations(unittest.TestCase):
-    def test_cold_start_duration_is_less_than_hundred_ms(self):
+    def test_cold_start_duration_is_less_than_two_sec(self):
         graph = Graph(
-            name="test_cold_start_duration_is_less_than_hundred_ms",
+            name="test_cold_start_duration_is_less_than_two_sec",
             description="test",
             start_node=get_start_time,
         )
@@ -28,11 +28,12 @@ class TestInvokeDurations(unittest.TestCase):
         cold_start_duration = func_start_time - invoke_start_time
         print(f"cold_start_duration: {cold_start_duration} seconds")
         # The current duration we see in tests is about 10 ms.
+        # In rare cases it jumps up to 700 ms.
         #
         # We give a large headroom to prevent this test getting flaky
         # while still notifiying us if the cold start duration regresses
         # significantly.
-        self.assertLess(cold_start_duration, 0.1)
+        self.assertLess(cold_start_duration, 2.0)
 
     def test_warm_start_duration_is_less_than_hundred_ms(self):
         graph = Graph(


### PR DESCRIPTION
I got test failure in CI:

> AssertionError: 0.6306946277618408 not less than 0.1

So it looks like in CI the hosts can be slower.

Testing:

make check
make test

## Contribution Checklist

- [X] If the python-sdk was changed, please run `make fmt` in `python-sdk/`.
- [n/a] If the server was changed, please run `make fmt` in `server/`.
- [X] Make sure all PR Checks are passing.