### PR TITLE
fix(server): make graph versioning backward compatible by falling back on compute graph for latest

### DIFF
--- a/server/data_model/src/lib.rs
+++ b/server/data_model/src/lib.rs
@@ -417,20 +417,24 @@ impl ComputeGraph {
             }
             self.nodes = updated_nodes;
 
-            graph_version = Some(ComputeGraphVersion {
-                namespace: self.namespace.clone(),
-                compute_graph_name: self.name.clone(),
-                created_at: get_epoch_time_in_ms(),
-                version: self.version,
-                code: self.code.clone(),
-                start_fn: self.start_fn.clone(),
-                nodes: self.nodes.clone(),
-                edges: self.edges.clone(),
-                runtime_information: self.runtime_information.clone(),
-            });
+            graph_version = Some(self.into_version());
         }
 
         (self, graph_version)
+    }
+
+    pub fn into_version(&self) -> ComputeGraphVersion {
+        ComputeGraphVersion {
+            namespace: self.namespace.clone(),
+            compute_graph_name: self.name.clone(),
+            created_at: self.created_at,
+            version: self.version,
+            code: self.code.clone(),
+            start_fn: self.start_fn.clone(),
+            nodes: self.nodes.clone(),
+            edges: self.edges.clone(),
+            runtime_information: self.runtime_information.clone(),
+        }
     }
 }
 

--- a/server/state_store/src/scanner.rs
+++ b/server/state_store/src/scanner.rs
@@ -23,7 +23,7 @@ use metrics::Timer;
 use opentelemetry::KeyValue;
 use rocksdb::{Direction, IteratorMode, ReadOptions, TransactionDB};
 use serde::de::DeserializeOwned;
-use tracing::{info, instrument};
+use tracing::{debug, instrument};
 
 use super::state_machine::IndexifyObjectsColumns;
 use crate::serializer::{JsonEncode, JsonEncoder};
@@ -555,7 +555,7 @@ impl StateReader {
             return Ok(compute_graph_version);
         }
 
-        info!(
+        debug!(
             "Falling back to compute graph to get version for graph {}",
             name
         );

--- a/server/state_store/src/scanner.rs
+++ b/server/state_store/src/scanner.rs
@@ -23,7 +23,7 @@ use metrics::Timer;
 use opentelemetry::KeyValue;
 use rocksdb::{Direction, IteratorMode, ReadOptions, TransactionDB};
 use serde::de::DeserializeOwned;
-use tracing::instrument;
+use tracing::{info, instrument};
 
 use super::state_machine::IndexifyObjectsColumns;
 use crate::serializer::{JsonEncode, JsonEncoder};
@@ -551,7 +551,19 @@ impl StateReader {
         let key = ComputeGraphVersion::key_from(namespace, name, version);
         let compute_graph_version =
             self.get_from_cf(&IndexifyObjectsColumns::ComputeGraphVersions, key)?;
-        Ok(compute_graph_version)
+        if compute_graph_version.is_some() {
+            return Ok(compute_graph_version);
+        }
+
+        info!(
+            "Falling back to compute graph to get version for graph {}",
+            name
+        );
+        let compute_graph = self.get_compute_graph(namespace, name)?;
+        match compute_graph {
+            Some(compute_graph) => Ok(Some(compute_graph.into_version())),
+            None => Ok(None),
+        }
     }
 
     pub fn list_outputs_by_compute_graph(


### PR DESCRIPTION
## Context

<!--
In a few sentences or less, please explain the context behind this change to help answer why this change is needed.

If this is a bug fix, make sure to include "fixes #xxxx", or
"closes #xxxx".

Screenshots, logs, code or other visual aids are greatly appreciated.
 -->

In https://github.com/tensorlakeai/indexify/commit/416ecd8edf42d5051164360788d31969e096b5b7, we introduced running invocations on the same graph version for its duration.

Doing so, we did not take into account backward compatibility support for invocations getting to graphs without a compute graph version. 

## What

<!--
In a few sentences, please summarize the change to help reviewers.

Consider providing screenshots, logs, code or other visual aids to help the reviewer understand the approach taken.
-->

In that case, we will rely on the version info stored on the compute graph.

## Testing

<!--
Please include steps used to verify the change.

Consider providing screenshots, logs, code or other visual aids to help the reviewer in their testing.
-->

## Contribution Checklist

- [x] If the python-sdk was changed, please run `make fmt` in `python-sdk/`.
- [x] If the server was changed, please run `make fmt` in `server/`.
- [x] Make sure all PR Checks are passing.
<!--
You can run the tests manually:

Notes:

- Tests can be run manually: start the server and executor, `cd python-sdk`,
  run `make test`.
- To test if changes to the server are backward compatible with the latest
  release, label the PR with `ci_compat_test`. This might report failures
  unrelated to your change if previous incompatible changes were pushed without
  being released yet -->
