### PR TITLE
Build Indexify python-sdk using `make build` in GH Actions

### DIFF
--- a/.github/workflows/publish_indexify_pypi.yaml
+++ b/.github/workflows/publish_indexify_pypi.yaml
@@ -71,9 +71,9 @@ jobs:
         with:
           python-version: "3.9"
       - name: Install Poetry
-        run: python3 -m pip install poetry --user
-      - name: Build Packages
-        run: python3 -m poetry build
+        run: pipx install poetry
+      - name: Build python-sdk
+        run: make build
       - name: Publish Indexify Client to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:


### PR DESCRIPTION
Change .github/workflows/publish_indexify_pypi.yaml workflow to use the same python-sdk build commands as .github/workflows/tests.yaml.

With the addition of protobufs we can't just run `poetry build` to build python-sdk. We need to use the 'official' and more complex `make build` command.

## Contribution Checklist

- [n/a] If the python-sdk was changed, please run `make fmt` in `python-sdk/`.
- [n/a] If the server was changed, please run `make fmt` in `server/`.
- [X] Make sure all PR Checks are passing.