### PR TITLE
feat(server): allocate by image hash instead of version

### DIFF
--- a/python-sdk/indexify/cli.py
+++ b/python-sdk/indexify/cli.py
@@ -191,10 +191,10 @@ def executor(
         "~/.indexify/executor_cache", help="Path to the executor cache directory"
     ),
     name_alias: Optional[str] = typer.Option(
-        None, help="Name alias for the executor if it's spun up with the base image"
+        None, help="Image name override for the executor"
     ),
-    image_version: Optional[int] = typer.Option(
-        "1", help="Requested Image Version for this executor"
+    image_hash: Optional[str] = typer.Option(
+        None, help="Image hash override for the executor"
     ),
 ):
     if not dev:
@@ -210,7 +210,7 @@ def executor(
         executor_version=executor_version,
         executor_cache=executor_cache,
         name_alias=name_alias,
-        image_version=image_version,
+        image_hash=image_hash,
         dev_mode=dev,
     )
 
@@ -227,7 +227,7 @@ def executor(
         config_path=config_path,
         code_path=executor_cache,
         name_alias=name_alias,
-        image_version=image_version,
+        image_hash=image_hash,
         development_mode=dev,
     )
 

--- a/python-sdk/indexify/executor/agent.py
+++ b/python-sdk/indexify/executor/agent.py
@@ -36,10 +36,10 @@ class ExtractorAgent:
         development_mode: bool = False,
         config_path: Optional[str] = None,
         name_alias: Optional[str] = None,
-        image_version: Optional[int] = None,
+        image_hash: Optional[str] = None,
     ):
         self.name_alias = name_alias
-        self.image_version = image_version
+        self.image_hash = image_hash
         self._config_path = config_path
         self._probe = RuntimeProbes()
 
@@ -254,10 +254,10 @@ class ExtractorAgent:
                 else runtime_probe.image_name
             )
 
-            image_version: int = (
-                self.image_version
-                if self.image_version is not None
-                else runtime_probe.image_version
+            image_hash: str = (
+                self.image_hash
+                if self.image_hash is not None
+                else runtime_probe.image_hash
             )
 
             data = ExecutorMetadata(
@@ -265,7 +265,7 @@ class ExtractorAgent:
                 executor_version=executor_version,
                 addr="",
                 image_name=image_name,
-                image_version=image_version,
+                image_hash=image_hash,
                 labels=runtime_probe.labels,
             ).model_dump()
             logger.info(
@@ -273,6 +273,9 @@ class ExtractorAgent:
                 executor_id=self._executor_id,
                 url=url,
                 executor_version=executor_version,
+                image=image_name,
+                image_hash=image_hash,
+                labels=runtime_probe.labels,
             )
             try:
                 async with get_httpx_client(self._config_path, True) as client:

--- a/python-sdk/indexify/executor/api_objects.py
+++ b/python-sdk/indexify/executor/api_objects.py
@@ -19,7 +19,7 @@ class ExecutorMetadata(BaseModel):
     executor_version: str
     addr: str
     image_name: str
-    image_version: int
+    image_hash: str
     labels: Dict[str, Any]
 
 

--- a/python-sdk/indexify/executor/runtime_probes.py
+++ b/python-sdk/indexify/executor/runtime_probes.py
@@ -6,13 +6,13 @@ from typing import Any, Dict, Tuple
 from pydantic import BaseModel
 
 DEFAULT_EXECUTOR = "tensorlake/indexify-executor-default"
-DEFAULT_VERSION = 1
-DEFAULT_HASH = "deadbeefcafe"
+# Empty string is used as a default hash which tells the scheduler to accept any hash.
+DEFAULT_HASH = ""
 
 
 class ProbeInfo(BaseModel):
     image_name: str
-    image_version: int
+    image_hash: str
     python_major_version: int
     labels: Dict[str, Any] = {}
     is_default_executor: bool
@@ -21,9 +21,7 @@ class ProbeInfo(BaseModel):
 class RuntimeProbes:
     def __init__(self) -> None:
         self._image_name = self._read_image_name()
-        self._image_version = self._read_image_version()
         self._image_hash = self._read_image_hash()
-
         self._os_name = platform.system()
         self._architecture = platform.machine()
         (
@@ -38,18 +36,11 @@ class RuntimeProbes:
                 return file.read().strip()
         return DEFAULT_EXECUTOR
 
-    def _read_image_version(self) -> int:
-        file_path = os.path.expanduser("~/.indexify/image_version")
-        if os.path.exists(file_path):
-            with open(file_path, "r") as file:
-                return int(file.read().strip())
-        return DEFAULT_VERSION
-
-    def _read_image_hash(self) -> int:
+    def _read_image_hash(self) -> str:
         file_path = os.path.expanduser("~/.indexify/image_hash")
         if os.path.exists(file_path):
             with open(file_path, "r") as file:
-                return int(file.read().strip())
+                return file.read().strip()
         return DEFAULT_HASH
 
     def _get_python_version(self) -> Tuple[int, int]:
@@ -70,7 +61,7 @@ class RuntimeProbes:
 
         return ProbeInfo(
             image_name=self._image_name,
-            image_version=self._image_version,
+            image_hash=self._image_hash,
             python_major_version=self._python_version_major,
             labels=labels,
             is_default_executor=self._is_default_executor(),

--- a/server/data_model/src/test_objects.rs
+++ b/server/data_model/src/test_objects.rs
@@ -47,33 +47,23 @@ pub mod tests {
             .unwrap()
     }
 
-    pub fn test_compute_fn(name: &str, image_hash: Option<String>) -> ComputeFn {
-        let mut image_information = ImageInformation::default();
-        image_information.image_name = TEST_EXECUTOR_IMAGE_NAME.to_string();
-        match image_hash {
-            Some(image_hash) => {
-                image_information.image_hash = image_hash.to_string();
-
-                ComputeFn {
-                    name: name.to_string(),
-                    description: format!("description {}", name),
-                    fn_name: name.to_string(),
-                    image_information,
-                    ..Default::default()
-                }
-            }
-            _ => ComputeFn {
-                name: name.to_string(),
-                description: format!("description {}", name),
-                fn_name: name.to_string(),
-                image_information,
-                ..Default::default()
-            },
+    pub fn test_compute_fn(name: &str, image_hash: String) -> ComputeFn {
+        let image_information = ImageInformation {
+            image_name: TEST_EXECUTOR_IMAGE_NAME.to_string(),
+            image_hash,
+            ..Default::default()
+        };
+        ComputeFn {
+            name: name.to_string(),
+            description: format!("description {}", name),
+            fn_name: name.to_string(),
+            image_information,
+            ..Default::default()
         }
     }
 
     pub fn reducer_fn(name: &str) -> ComputeFn {
-        let mut compute_fn = test_compute_fn(name, None);
+        let mut compute_fn = test_compute_fn(name, "image_hash".to_string());
         compute_fn.reducer = true;
         compute_fn
     }
@@ -157,7 +147,7 @@ pub mod tests {
             .unwrap()
     }
 
-    pub fn mock_graph_a(image_hash: Option<String>) -> ComputeGraph {
+    pub fn mock_graph_a(image_hash: String) -> ComputeGraph {
         let fn_a = test_compute_fn("fn_a", image_hash.clone());
         let fn_b = test_compute_fn("fn_b", image_hash.clone());
         let fn_c = test_compute_fn("fn_c", image_hash.clone());
@@ -197,7 +187,7 @@ pub mod tests {
     }
 
     pub fn mock_graph_b() -> ComputeGraph {
-        let fn_a = test_compute_fn("fn_a", None);
+        let fn_a = test_compute_fn("fn_a", "image_hash".to_string());
         let router_x = DynamicEdgeRouter {
             name: "router_x".to_string(),
             description: "description router_x".to_string(),
@@ -220,8 +210,8 @@ pub mod tests {
                 sdk_version: Some("1.2.3".to_string()),
             },
         };
-        let fn_b = test_compute_fn("fn_b", None);
-        let fn_c = test_compute_fn("fn_c", None);
+        let fn_b = test_compute_fn("fn_b", "image_hash".to_string());
+        let fn_c = test_compute_fn("fn_c", "image_hash".to_string());
         ComputeGraph {
             namespace: TEST_NAMESPACE.to_string(),
             name: "graph_B".to_string(),
@@ -255,9 +245,9 @@ pub mod tests {
     }
 
     pub fn mock_graph_with_reducer() -> ComputeGraph {
-        let fn_a = test_compute_fn("fn_a", None);
+        let fn_a = test_compute_fn("fn_a", "image_hash".to_string());
         let fn_b = reducer_fn("fn_b");
-        let fn_c = test_compute_fn("fn_c", None);
+        let fn_c = test_compute_fn("fn_c", "image_hash".to_string());
         ComputeGraph {
             namespace: TEST_NAMESPACE.to_string(),
             name: "graph_R".to_string(),
@@ -303,7 +293,7 @@ pub mod tests {
             image_name: TEST_EXECUTOR_IMAGE_NAME.to_string(),
             addr: "".to_string(),
             labels: Default::default(),
-            image_version: 1,
+            image_hash: "image_hash".to_string(),
         }
     }
 }

--- a/server/src/executors.rs
+++ b/server/src/executors.rs
@@ -95,7 +95,7 @@ mod tests {
             id: ExecutorId::new("test".to_string()),
             executor_version: "1.0".to_string(),
             image_name: "test".to_string(),
-            image_version: 1,
+            image_hash: "image_hash".to_string(),
             addr: "".to_string(),
             labels: Default::default(),
         };
@@ -119,7 +119,7 @@ mod tests {
             id: ExecutorId::new("test".to_string()),
             executor_version: "1.0".to_string(),
             image_name: "test".to_string(),
-            image_version: 0,
+            image_hash: "image_hash".to_string(),
             addr: "".to_string(),
             labels: Default::default(),
         };

--- a/server/src/gc.rs
+++ b/server/src/gc.rs
@@ -108,7 +108,7 @@ mod tests {
             info!("garbage collector shutdown");
         });
         // Create a compute graph
-        let compute_graph = mock_graph_a(None);
+        let compute_graph = mock_graph_a("image_hash".to_string());
         state
             .write(StateMachineUpdateRequest {
                 payload: RequestPayload::CreateOrUpdateComputeGraph(

--- a/server/src/http_objects.rs
+++ b/server/src/http_objects.rs
@@ -527,7 +527,8 @@ pub struct ExecutorMetadata {
     pub executor_version: String,
     pub addr: String,
     pub image_name: String,
-    pub image_version: u32,
+    #[serde(default)]
+    pub image_hash: String,
     pub labels: HashMap<String, serde_json::Value>,
 }
 
@@ -538,7 +539,7 @@ impl From<data_model::ExecutorMetadata> for ExecutorMetadata {
             executor_version: executor.executor_version,
             addr: executor.addr,
             image_name: executor.image_name,
-            image_version: executor.image_version,
+            image_hash: executor.image_hash,
             labels: executor.labels,
         }
     }

--- a/server/src/routes.rs
+++ b/server/src/routes.rs
@@ -647,7 +647,7 @@ async fn executor_tasks(
             image_name: payload.image_name.clone(),
             addr: payload.addr.clone(),
             labels: payload.labels.clone(),
-            image_version: payload.image_version,
+            image_hash: payload.image_hash,
         })
         .await;
     if let Err(e) = err {

--- a/server/src/scheduler.rs
+++ b/server/src/scheduler.rs
@@ -615,10 +615,10 @@ mod tests {
         );
 
         let graph = {
-            let fn_gen = test_compute_fn("fn_gen", None);
-            let fn_map = test_compute_fn("fn_map", None);
+            let fn_gen = test_compute_fn("fn_gen", "image_hash".to_string());
+            let fn_map = test_compute_fn("fn_map", "image_hash".to_string());
             let fn_reduce = reducer_fn("fn_reduce");
-            let fn_convert = test_compute_fn("fn_convert", None);
+            let fn_convert = test_compute_fn("fn_convert", "image_hash".to_string());
             ComputeGraph {
                 namespace: TEST_NAMESPACE.to_string(),
                 name: "graph_R".to_string(),
@@ -864,10 +864,10 @@ mod tests {
         );
 
         let graph = {
-            let fn_gen = test_compute_fn("fn_gen", None);
-            let fn_map = test_compute_fn("fn_map", None);
+            let fn_gen = test_compute_fn("fn_gen", "image_hash".to_string());
+            let fn_map = test_compute_fn("fn_map", "image_hash".to_string());
             let fn_reduce = reducer_fn("fn_reduce");
-            let fn_convert = test_compute_fn("fn_convert", None);
+            let fn_convert = test_compute_fn("fn_convert", "image_hash".to_string());
             ComputeGraph {
                 namespace: TEST_NAMESPACE.to_string(),
                 name: "graph_R".to_string(),
@@ -1178,10 +1178,10 @@ mod tests {
         );
 
         let graph = {
-            let fn_gen = test_compute_fn("fn_gen", None);
-            let fn_map = test_compute_fn("fn_map", None);
+            let fn_gen = test_compute_fn("fn_gen", "image_hash".to_string());
+            let fn_map = test_compute_fn("fn_map", "image_hash".to_string());
             let fn_reduce = reducer_fn("fn_reduce");
-            let fn_convert = test_compute_fn("fn_convert", None);
+            let fn_convert = test_compute_fn("fn_convert", "image_hash".to_string());
             ComputeGraph {
                 namespace: TEST_NAMESPACE.to_string(),
                 name: "graph_R".to_string(),
@@ -1459,10 +1459,10 @@ mod tests {
         );
 
         let graph = {
-            let fn_gen = test_compute_fn("fn_gen", None);
-            let fn_map = test_compute_fn("fn_map", None);
+            let fn_gen = test_compute_fn("fn_gen", "image_hash".to_string());
+            let fn_map = test_compute_fn("fn_map", "image_hash".to_string());
             let fn_reduce = reducer_fn("fn_reduce");
-            let fn_convert = test_compute_fn("fn_convert", None);
+            let fn_convert = test_compute_fn("fn_convert", "image_hash".to_string());
             ComputeGraph {
                 namespace: TEST_NAMESPACE.to_string(),
                 name: "graph_R".to_string(),
@@ -1840,10 +1840,10 @@ mod tests {
         );
 
         let graph = {
-            let fn_gen = test_compute_fn("fn_gen", None);
-            let fn_map = test_compute_fn("fn_map", None);
+            let fn_gen = test_compute_fn("fn_gen", "image_hash".to_string());
+            let fn_map = test_compute_fn("fn_map", "image_hash".to_string());
             let fn_reduce = reducer_fn("fn_reduce");
-            let fn_convert = test_compute_fn("fn_convert", None);
+            let fn_convert = test_compute_fn("fn_convert", "image_hash".to_string());
             ComputeGraph {
                 namespace: TEST_NAMESPACE.to_string(),
                 name: "graph_R".to_string(),

--- a/server/src/system_tasks.rs
+++ b/server/src/system_tasks.rs
@@ -257,7 +257,7 @@ mod tests {
         );
         let mut executor = SystemTasksExecutor::new(state.clone(), shutdown_rx);
 
-        let graph = mock_graph_a(None);
+        let graph = mock_graph_a("image_hash".to_string());
         let cg_request = CreateOrUpdateComputeGraphRequest {
             namespace: graph.namespace.clone(),
             compute_graph: graph.clone(),
@@ -618,7 +618,7 @@ mod tests {
         );
         let mut executor = SystemTasksExecutor::new(state.clone(), shutdown_rx);
 
-        let graph = mock_graph_a(None);
+        let graph = mock_graph_a("image_hash".to_string());
         let cg_request = CreateOrUpdateComputeGraphRequest {
             namespace: graph.namespace.clone(),
             compute_graph: graph.clone(),

--- a/server/state_store/src/lib.rs
+++ b/server/state_store/src/lib.rs
@@ -711,7 +711,7 @@ mod tests {
         let indexify_state = IndexifyState::new(temp_dir.path().join("state")).await?;
 
         // Create a compute graph
-        let compute_graph = mock_graph_a(None);
+        let compute_graph = mock_graph_a("image_hash".to_string());
         _write_to_test_state_store(&indexify_state, compute_graph).await?;
 
         // Read the compute graph
@@ -746,7 +746,7 @@ mod tests {
         let indexify_state = IndexifyState::new(temp_dir.path().join("state")).await?;
 
         // Create a compute graph and write it
-        let compute_graph = mock_graph_a(Some("Old Hash".to_string()));
+        let compute_graph = mock_graph_a("Old Hash".to_string());
         _write_to_test_state_store(&indexify_state, compute_graph).await?;
 
         // Read the compute graph
@@ -767,7 +767,7 @@ mod tests {
         for i in 2..4 {
             // Update the graph
             let new_hash = format!("this is a new hash {}", i);
-            let compute_graph = mock_graph_a(Some(new_hash.clone()));
+            let compute_graph = mock_graph_a(new_hash.clone());
 
             _write_to_test_state_store(&indexify_state, compute_graph).await?;
 
@@ -796,7 +796,7 @@ mod tests {
         let indexify_state = IndexifyState::new(temp_dir.path().join("state")).await?;
 
         let executor_id = ExecutorId::new("executor1".to_string());
-        let cg = mock_graph_a(None);
+        let cg = mock_graph_a("image_hash".to_string());
         let task = create_mock_task(
             &cg,
             "fn",

--- a/server/state_store/src/test_state_store.rs
+++ b/server/state_store/src/test_state_store.rs
@@ -47,7 +47,7 @@ pub mod tests {
         pub async fn with_simple_graph(&self) -> String {
             let cg_request = CreateOrUpdateComputeGraphRequest {
                 namespace: TEST_NAMESPACE.to_string(),
-                compute_graph: tests::mock_graph_a(None),
+                compute_graph: tests::mock_graph_a("image_hash".to_string()),
             };
             self.indexify_state
                 .write(StateMachineUpdateRequest {

--- a/server/task_scheduler/src/lib.rs
+++ b/server/task_scheduler/src/lib.rs
@@ -150,7 +150,7 @@ impl TaskScheduler {
                             executor.id
                         );
                         diagnostic_msgs.push(format!(
-                            "executor {} python version: {} does not match function python version: {}",
+                            "executor {} python version: 3.{} does not match function python version: 3.{}",
                             executor.id, executor_python_minor_version, graph_runtime.minor_version
                         ));
                         continue;
@@ -159,16 +159,6 @@ impl TaskScheduler {
                     error!("failed to parse python_minor_version label");
                     continue;
                 }
-            }
-
-            if executor.image_name != node.image_name() {
-                diagnostic_msgs.push(format!(
-                    "executor {}, image name: {} does not match function image name {}",
-                    executor.id,
-                    executor.image_name,
-                    node.image_name()
-                ));
-                continue;
             }
 
             if node.matches_executor(executor, &mut diagnostic_msgs) {


### PR DESCRIPTION
## Context

<!--
In a few sentences or less, please explain the context behind this change to help answer why this change is needed.

If this is a bug fix, make sure to include "fixes #xxxx", or
"closes #xxxx".

Screenshots, logs, code or other visual aids are greatly appreciated.
 -->

Image hash is deterministic and does not rely on the server to keep track of the next versions. This allows for a better OSS user experience since the hash can be put in the image automatically.

The image version could not be put on the image without more complexity like the image bootstrapper process that was started.

## What

<!--
In a few sentences, please summarize the change to help reviewers.

Consider providing screenshots, logs, code or other visual aids to help the reviewer understand the approach taken.
-->

- Change the scheduler selector code to pick an executor with the right image hash
- Change the executor to emit the image hash on registration
- Improved allocation diagnostic message

## Testing

<!--
Please include steps used to verify the change.

Consider providing screenshots, logs, code or other visual aids to help the reviewer in their testing.
-->


- [x] Ensure default executor as an image work as expected

## Contribution Checklist

- [x] If the python-sdk was changed, please run `make fmt` in `python-sdk/`.
- [x] If the server was changed, please run `make fmt` in `server/`.
- [x] Make sure all PR Checks are passing.
<!--
You can run the tests manually:

Notes:

- Tests can be run manually: start the server and executor, `cd python-sdk`,
  run `make test`.
- To test if changes to the server are backward compatible with the latest
  release, label the PR with `ci_compat_test`. This might report failures
  unrelated to your change if previous incompatible changes were pushed without
  being released yet -->
