### PR TITLE
fix(server): fix support for unversioned code download

### DIFF
--- a/server/src/routes.rs
+++ b/server/src/routes.rs
@@ -172,11 +172,11 @@ pub fn create_routes(route_state: RouteState) -> Router {
         )
         .route(
             "/internal/namespaces/:namespace/compute_graphs/:compute_graph/code",
-            get(get_code).with_state(route_state.clone()),
+            get(get_unversioned_code).with_state(route_state.clone()),
         )
         .route(
             "/internal/namespaces/:namespace/compute_graphs/:compute_graph/versions/:version/code",
-            get(get_code).with_state(route_state.clone()),
+            get(get_versioned_code).with_state(route_state.clone()),
         )
         .route(
             "/internal/ingest_files",
@@ -807,7 +807,14 @@ async fn delete_invocation(
     Ok(())
 }
 
-async fn get_code(
+async fn get_unversioned_code(
+    Path((namespace, compute_graph)): Path<(String, String)>,
+    State(state): State<RouteState>,
+) -> Result<impl IntoResponse, IndexifyAPIError> {
+    get_versioned_code(Path((namespace, compute_graph, None)), State(state)).await
+}
+
+async fn get_versioned_code(
     Path((namespace, compute_graph, version)): Path<(String, String, Option<GraphVersion>)>,
     State(state): State<RouteState>,
 ) -> Result<impl IntoResponse, IndexifyAPIError> {


### PR DESCRIPTION
## Context

<!--
In a few sentences or less, please explain the context behind this change to help answer why this change is needed.

If this is a bug fix, make sure to include "fixes #xxxx", or
"closes #xxxx".

Screenshots, logs, code or other visual aids are greatly appreciated.
 -->

Previous version of the executor are not be able to get unversioned code.

## What

<!--
In a few sentences, please summarize the change to help reviewers.

Consider providing screenshots, logs, code or other visual aids to help the reviewer understand the approach taken.
-->

Fix backward compatibility support .

## Testing

<!--
Please include steps used to verify the change.

Consider providing screenshots, logs, code or other visual aids to help the reviewer in their testing.
-->

- Last release server + executor + make test
- Run main server  + main executor + main make test

## Contribution Checklist

- [x] If the python-sdk was changed, please run `make fmt` in `python-sdk/`.
- [x] If the server was changed, please run `make fmt` in `server/`.
- [x] Make sure all PR Checks are passing.
<!--
You can run the tests manually:

Notes:

- Tests can be run manually: start the server and executor, `cd python-sdk`,
  run `make test`.
- To test if changes to the server are backward compatible with the latest
  release, label the PR with `ci_compat_test`. This might report failures
  unrelated to your change if previous incompatible changes were pushed without
  being released yet -->
