### PR TITLE
fix(sdk): fix to support python 3.10

### DIFF
--- a/python-sdk/indexify/function_executor/proto/message_validator.py
+++ b/python-sdk/indexify/function_executor/proto/message_validator.py
@@ -1,4 +1,4 @@
-from typing import Any, Self
+from typing import Any
 
 from .function_executor_pb2 import SerializedObject
 
@@ -7,21 +7,21 @@ class MessageValidator:
     def __init__(self, message: Any):
         self._message = message
 
-    def required_field(self, field_name: str) -> Self:
+    def required_field(self, field_name: str) -> "MessageValidator":
         if not self._message.HasField(field_name):
             raise ValueError(
                 f"Field '{field_name}' is required in {type(self._message).__name__}"
             )
         return self
 
-    def required_serialized_object(self, field_name: str) -> Self:
+    def required_serialized_object(self, field_name: str) -> "MessageValidator":
         """Validates the SerializedObject.
 
         Raises: ValueError: If the SerializedObject is invalid or not present."""
         self.required_field(field_name)
         return self.optional_serialized_object(field_name)
 
-    def optional_serialized_object(self, field_name: str) -> Self:
+    def optional_serialized_object(self, field_name: str) -> "MessageValidator":
         """Validates the SerializedObject.
 
         Raises: ValueError: If the SerializedObject is invalid."""
@@ -32,7 +32,7 @@ class MessageValidator:
         if not serializedObject.HasField("string") and not serializedObject.HasField(
             "bytes"
         ):
-            raise ValueError("oneof 'data' is requred in SerializedObject")
+            raise ValueError("oneof 'data' is required in SerializedObject")
         if not serializedObject.HasField("content_type"):
-            raise ValueError("Field 'content_type' is requred in SerializedObject")
+            raise ValueError("Field 'content_type' is required in SerializedObject")
         return self


### PR DESCRIPTION
## Context

<!--
In a few sentences or less, please explain the context behind this change to help answer why this change is needed.

If this is a bug fix, make sure to include "fixes #xxxx", or
"closes #xxxx".

Screenshots, logs, code or other visual aids are greatly appreciated.
 -->

In python 3.10, we get `ImportError: cannot import name 'Self' from 'typing' (/usr/lib/python3.10/typing.py)`

## What

<!--
In a few sentences, please summarize the change to help reviewers.

Consider providing screenshots, logs, code or other visual aids to help the reviewer understand the approach taken.
-->

Uses the class name as the return type instead of the 3.11 Self feature. 
This uses String 

https://realpython.com/python-type-self string type hinting.

## Testing

<!--
Please include steps used to verify the change.

Consider providing screenshots, logs, code or other visual aids to help the reviewer in their testing.
-->

## Contribution Checklist

- [x] If the python-sdk was changed, please run `make fmt` in `python-sdk/`.
- [x] If the server was changed, please run `make fmt` in `server/`.
- [ ] Make sure all PR Checks are passing.
<!--
You can run the tests manually:

Notes:

- Tests can be run manually: start the server and executor, `cd python-sdk`,
  run `make test`.
- To test if changes to the server are backward compatible with the latest
  release, label the PR with `ci_compat_test`. This might report failures
  unrelated to your change if previous incompatible changes were pushed without
  being released yet -->
