### PR TITLE
chore: popover for copy on breadcrumbs

### DIFF
--- a/server/ui/src/components/CopyTextPopover.tsx
+++ b/server/ui/src/components/CopyTextPopover.tsx
@@ -1,0 +1,85 @@
+import { Popover, Typography } from '@mui/material'
+import { ContentCopy } from '@mui/icons-material'
+import { useState, type ReactNode } from 'react'
+
+interface CopyTextPopoverProps {
+  text: string
+  children: ReactNode
+}
+
+function CopyTextPopover({ text, children }: CopyTextPopoverProps) {
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null)
+  const [isCopied, setIsCopied] = useState(false)
+
+  const handlePopoverOpen = (event: React.MouseEvent<HTMLElement>) => {
+    setAnchorEl(event.currentTarget)
+  }
+
+  const handlePopoverClose = () => {
+    setAnchorEl(null)
+  }
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(text)
+      setIsCopied(true)
+      setTimeout(() => {
+        setIsCopied(false)
+        handlePopoverClose()
+      }, 1000)
+    } catch (err) {
+      console.error('Failed to copy text:', err)
+    }
+  }
+
+  const open = Boolean(anchorEl)
+
+  return (
+    <div 
+      onMouseEnter={handlePopoverOpen} 
+      onMouseLeave={handlePopoverClose}
+      style={{ display: 'inline-block' }}
+    >
+      {children}
+      <Popover
+        open={open}
+        anchorEl={anchorEl}
+        onClose={handlePopoverClose}
+        anchorOrigin={{
+          vertical: 'bottom',
+          horizontal: 'center',
+        }}
+        transformOrigin={{
+          vertical: 'top',
+          horizontal: 'center',
+        }}
+        sx={{
+          pointerEvents: 'none',
+          '& .MuiPopover-paper': {
+            pointerEvents: 'auto'
+          }
+        }}
+      >
+        <Typography
+          sx={{
+            p: 1,
+            display: 'flex',
+            alignItems: 'center',
+            gap: 1,
+            cursor: 'pointer',
+            '&:hover': {
+              bgcolor: 'action.hover'
+            },
+            fontSize: 12
+          }}
+          onClick={handleCopy}
+        >
+          <ContentCopy sx={{ fontSize: 12 }} />
+          {isCopied ? 'Copied!' : 'Click to copy'}
+        </Typography>
+      </Popover>
+    </div>
+  )
+}
+
+export default CopyTextPopover

--- a/server/ui/src/components/cards/ComputeGraphsCard.tsx
+++ b/server/ui/src/components/cards/ComputeGraphsCard.tsx
@@ -61,7 +61,7 @@ export function ComputeGraphsCard({
               <Link to={`/${namespace}/compute-graphs/${graph.name}`}>
                 <TruncatedText text={graph.name} maxLength={20} />
               </Link>
-              <Box display="flex" flexDirection="row">
+              <Box display="flex" flexDirection="row" alignItems="center">
                 <CopyText text={graph.name} />
                 <IconButton
                   onClick={() => handleDeleteGraph(graph.name)}

--- a/server/ui/src/components/tables/InvocationOutputTable.tsx
+++ b/server/ui/src/components/tables/InvocationOutputTable.tsx
@@ -23,6 +23,7 @@ import SearchIcon from '@mui/icons-material/Search';
 import { toast, ToastContainer } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
 import { formatTimestamp } from '../../utils/helpers';
+import CopyText from '../CopyText';
 
 interface Output {
   compute_fn: string;
@@ -151,7 +152,9 @@ function InvocationOutputTable({ indexifyServiceURL, invocationId, namespace, co
             id={`panel${index}-header`}
           >
             <Box sx={{ display: 'flex', alignItems: 'center', width: '100%', justifyContent: 'space-between' }}>
-              <Typography>Compute Function - {computeFn} ({outputs.length} outputs)</Typography>
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                <Typography>Compute Function - {computeFn} ({outputs.length} outputs) <CopyText text={computeFn} /></Typography>
+              </Box>
               <Box 
                 sx={{ display: 'flex', alignItems: 'center' }}
                 onClick={(e) => e.stopPropagation()}
@@ -185,7 +188,12 @@ function InvocationOutputTable({ indexifyServiceURL, invocationId, namespace, co
                 <TableBody>
                   {outputs.map((output, idx) => (
                     <TableRow key={idx}>
-                      <TableCell>{output.id}</TableCell>
+                      <TableCell>
+                        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                          {output.id}
+                          <CopyText text={output.id} />
+                        </Box>
+                      </TableCell>
                       <TableCell>{formatTimestamp(output.created_at)}</TableCell>
                       <TableCell>
                         <Button

--- a/server/ui/src/components/tables/InvocationTasksTable.tsx
+++ b/server/ui/src/components/tables/InvocationTasksTable.tsx
@@ -23,6 +23,7 @@ import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import SearchIcon from '@mui/icons-material/Search';
 import { toast, ToastContainer } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
+import CopyText from '../CopyText';
 
 interface Task {
   id: string;
@@ -214,7 +215,12 @@ export function InvocationTasksTable({ indexifyServiceURL, invocationId, namespa
                 <TableBody>
                   {tasks.map((task) => (
                     <TableRow key={task.id}>
-                      <TableCell>{task.id}</TableCell>
+                      <TableCell>
+                        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                          {task.id}
+                          <CopyText text={task.id} />
+                        </Box>
+                      </TableCell>
                       <TableCell>
                         <Chip
                           label={task.outcome}

--- a/server/ui/src/routes/Namespace/IndividualComputeGraphPage.tsx
+++ b/server/ui/src/routes/Namespace/IndividualComputeGraphPage.tsx
@@ -8,6 +8,7 @@ import type { IndividualComputeGraphLoaderData } from './types'
 import ComputeGraphTable from '../../components/tables/ComputeGraphTable'
 import CopyText from '../../components/CopyText'
 import InvocationsTable from '../../components/tables/InvocationsTable'
+import CopyTextPopover from '../../components/CopyTextPopover'
 
 const IndividualComputeGraphPage = () => {
   const { invocationsList, computeGraph, namespace } =
@@ -32,13 +33,18 @@ const IndividualComputeGraphPage = () => {
         aria-label="breadcrumb"
         separator={<NavigateNextIcon fontSize="small" />}
       >
-        <Typography color="text.primary">{namespace}</Typography>
+        <CopyTextPopover text={namespace}>
+          <Typography color="text.primary">{namespace}</Typography>
+        </CopyTextPopover>
         <Link to={`/${namespace}/compute-graphs`}>
-          <Typography color="text.primary">Compute Graphs</Typography>
+          <CopyTextPopover text="Compute Graphs">
+            <Typography color="text.primary">Compute Graphs</Typography>
+          </CopyTextPopover>
         </Link>
-        <Typography color="text.primary">{computeGraph.name}</Typography>
+        <CopyTextPopover text={computeGraph.name}>
+          <Typography color="text.primary">{computeGraph.name}</Typography>
+        </CopyTextPopover>
       </Breadcrumbs>
-
       <Box>
         <Box sx={{ mb: 3 }}>
           <div className="content-table-header">

--- a/server/ui/src/routes/Namespace/IndividualInvocationPage.tsx
+++ b/server/ui/src/routes/Namespace/IndividualInvocationPage.tsx
@@ -10,6 +10,7 @@ import { Link, useLoaderData } from 'react-router-dom';
 import CopyText from '../../components/CopyText';
 import InvocationOutputTable from '../../components/tables/InvocationOutputTable';
 import InvocationTasksTable from '../../components/tables/InvocationTasksTable';
+import CopyTextPopover from '../../components/CopyTextPopover';
 
 const IndividualInvocationPage = () => {
   const {
@@ -31,14 +32,22 @@ const IndividualInvocationPage = () => {
         aria-label="breadcrumb"
         separator={<NavigateNextIcon fontSize="small" />}
       >
-        <Typography color="text.primary">{namespace}</Typography>
+        <CopyTextPopover text={namespace}>
+          <Typography color="text.primary">{namespace}</Typography>
+        </CopyTextPopover>
         <Link color="inherit" to={`/${namespace}/compute-graphs`}>
-          <Typography color="text.primary">Compute Graphs</Typography>
+          <CopyTextPopover text="Compute Graphs">
+            <Typography color="text.primary">Compute Graphs</Typography>
+          </CopyTextPopover>
         </Link>
         <Link color="inherit" to={`/${namespace}/compute-graphs/${computeGraph}`}>
-          <Typography color="text.primary">{computeGraph}</Typography>
+          <CopyTextPopover text={computeGraph}>
+            <Typography color="text.primary">{computeGraph}</Typography>
+          </CopyTextPopover>
         </Link>
-        <Typography color="text.primary">{invocationId}</Typography>
+        <CopyTextPopover text={invocationId}>
+          <Typography color="text.primary">{invocationId}</Typography>
+        </CopyTextPopover>
       </Breadcrumbs>
       <Box sx={{ p: 0 }}>
         <Box sx={{ mb: 3 }}>


### PR DESCRIPTION
**Description:**

- This PR fixes https://github.com/tensorlakeai/platform-ui/issues/64
- Adds a copy button on hover for the breadcrumbs and id text

**Screenshot:**

<img width="958" alt="image" src="https://github.com/user-attachments/assets/ee531ee9-dc16-46b7-94fa-4eaccf4f2787" />
