### PR TITLE
chore: preparing release sdk=0.2.42

### DIFF
--- a/python-sdk/pyproject.toml
+++ b/python-sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "indexify"
-version = "0.2.41"
+version = "0.2.42"
 description = "Python Client for Indexify"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 license = "Apache 2.0"


### PR DESCRIPTION
preparing release sdk=0.2.42

0.2.41 is not compatible with python 3.10