### PR TITLE
chore(ci): fix executor image building

### DIFF
--- a/.github/workflows/publish_executor_containers.yaml
+++ b/.github/workflows/publish_executor_containers.yaml
@@ -2,6 +2,13 @@ name: Publish Example Executor Containers
 
 on:
   workflow_dispatch:
+    inputs:
+      indexify_version:
+        type: string
+        description: |
+          Indexify version to use to build the executor containers.
+          Note: Should ideally match the tag used for this workflow.
+        required: true
 
 jobs:
   build-and-push-docker-images:
@@ -9,9 +16,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: main
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
@@ -23,10 +32,18 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - run: |
           curl -LsSf https://astral.sh/uv/install.sh | sh  # install uv
-          uv pip install --system indexify -U
-          indexify-cli build-default-image
+          uv pip install --system 'indexify==${{ inputs.indexify_version }}' -U
+          indexify-cli build-default-image --python-version 3.10
           docker push tensorlake/indexify-executor-default:3.10
+
+          indexify-cli build-default-image --python-version 3.11
           docker push tensorlake/indexify-executor-default:3.11
+
+          indexify-cli build-default-image --python-version 3.12
+          docker push tensorlake/indexify-executor-default:3.12
+
+          indexify-cli build-default-image --python-version 3.13
+          docker push tensorlake/indexify-executor-default:3.13
 
           indexify-cli build-image examples/pdf_document_extraction/images.py
           indexify-cli build-image examples/pdf_structured_extraction/workflow.py

--- a/.github/workflows/publish_indexify_pypi.yaml
+++ b/.github/workflows/publish_indexify_pypi.yaml
@@ -97,8 +97,8 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - run: |
-          sleep 15
-          pip install indexify -U
-          indexify-cli build-default-image 
-          docker push tensorlake/indexify-executor-default:3.10
-          docker push tensorlake/indexify-executor-default:3.11
+          # wait for the indexify-cli to be available
+          sleep 60
+      - uses: ./.github/workflows/publish_executor_containers.yaml
+        with:
+          indexify_version: ${{ needs.extract-version.outputs.version }}

--- a/examples/pdf_document_extraction/images.py
+++ b/examples/pdf_document_extraction/images.py
@@ -1,14 +1,16 @@
 from indexify import Image
 
 http_client_image = (
-    Image(python="3.11")
+    Image()
     .name("tensorlake/pdf-blueprint-download")
+    .base_image(f"python:3.11-slim-bookworm")
     .run("pip install httpx")
 )
 
 chroma_image = (
-    Image(python="3.11")
+    Image()
     .name("tensorlake/blueprints-chromadb")
+    .base_image(f"python:3.11-slim-bookworm")
     .run("pip install chromadb")
     .run("pip install pillow")
 )
@@ -24,8 +26,9 @@ st_image = (
 )
 
 lance_image = (
-    Image(python="3.11")
+    Image()
     .name("tensorlake/pdf-blueprint-lancdb")
+    .base_image(f"python:3.11-slim-bookworm")
     .run("pip install lancedb")
 )
 


### PR DESCRIPTION
## Context

<!--
In a few sentences or less, please explain the context behind this change to help answer why this change is needed.

If this is a bug fix, make sure to include "fixes #xxxx", or
"closes #xxxx".

Screenshots, logs, code or other visual aids are greatly appreciated.
 -->

There is a disconnect between the pipy building images and building all container images.

## What

We now reuse the executer container workflow after publishing to pipy.

<!--
In a few sentences, please summarize the change to help reviewers.

Consider providing screenshots, logs, code or other visual aids to help the reviewer understand the approach taken.
-->

## Testing

<!--
Please include steps used to verify the change.

Consider providing screenshots, logs, code or other visual aids to help the reviewer in their testing.
-->

## Contribution Checklist

- [x] If the python-sdk was changed, please run `make fmt` in `python-sdk/`.
- [x] If the server was changed, please run `make fmt` in `server/`.
- [x] Make sure all PR Checks are passing.
<!--
You can run the tests manually:

Notes:

- Tests can be run manually: start the server and executor, `cd python-sdk`,
  run `make test`.
- To test if changes to the server are backward compatible with the latest
  release, label the PR with `ci_compat_test`. This might report failures
  unrelated to your change if previous incompatible changes were pushed without
  being released yet -->
