### PR TITLE
feat(sdk): tag default executor images with the sdk version

### DIFF
--- a/.github/workflows/publish_executor_containers.yaml
+++ b/.github/workflows/publish_executor_containers.yaml
@@ -34,16 +34,20 @@ jobs:
           curl -LsSf https://astral.sh/uv/install.sh | sh  # install uv
           uv pip install --system 'indexify==${{ inputs.indexify_version }}' -U
           indexify-cli build-default-image --python-version 3.10
-          docker push tensorlake/indexify-executor-default:3.10
+          docker tag tensorlake/indexify-executor-default:3.10 tensorlake/indexify-executor-default:3.10-${{ inputs.indexify_version }}
+          docker push tensorlake/indexify-executor-default:3.10 tensorlake/indexify-executor-default:3.10-${{ inputs.indexify_version }}
 
           indexify-cli build-default-image --python-version 3.11
-          docker push tensorlake/indexify-executor-default:3.11
+          docker tag tensorlake/indexify-executor-default:3.11 tensorlake/indexify-executor-default:3.11-${{ inputs.indexify_version }}
+          docker push tensorlake/indexify-executor-default:3.11 tensorlake/indexify-executor-default:3.11-${{ inputs.indexify_version }}
 
           indexify-cli build-default-image --python-version 3.12
-          docker push tensorlake/indexify-executor-default:3.12
+          docker tag tensorlake/indexify-executor-default:3.12 tensorlake/indexify-executor-default:3.12-${{ inputs.indexify_version }}
+          docker push tensorlake/indexify-executor-default:3.12 tensorlake/indexify-executor-default:3.12-${{ inputs.indexify_version }}
 
           indexify-cli build-default-image --python-version 3.13
-          docker push tensorlake/indexify-executor-default:3.13
+          docker tag tensorlake/indexify-executor-default:3.13 tensorlake/indexify-executor-default:3.13-${{ inputs.indexify_version }}
+          docker push tensorlake/indexify-executor-default:3.13 tensorlake/indexify-executor-default:3.13-${{ inputs.indexify_version }}
 
           indexify-cli build-image examples/pdf_document_extraction/images.py
           indexify-cli build-image examples/pdf_structured_extraction/workflow.py


### PR DESCRIPTION
## Context

<!--
In a few sentences or less, please explain the context behind this change to help answer why this change is needed.

If this is a bug fix, make sure to include "fixes #xxxx", or
"closes #xxxx".

Screenshots, logs, code or other visual aids are greatly appreciated.
 -->

We currently only tag default executor with the python version. Ex: `tensorlake/indexify-executor-default:3.11`
This means the images have the latest version of the SDK / executor in them. These tag are updated on every release.

## What

<!--
In a few sentences, please summarize the change to help reviewers.

Consider providing screenshots, logs, code or other visual aids to help the reviewer understand the approach taken.
-->

We will now push two tags for these images: `tensorlake/indexify-executor-default:3.11` and `tensorlake/indexify-executor-default:3.11-{indexify-version}`.

## Testing

<!--
Please include steps used to verify the change.

Consider providing screenshots, logs, code or other visual aids to help the reviewer in their testing.
-->

## Contribution Checklist

- [x] If the python-sdk was changed, please run `make fmt` in `python-sdk/`.
- [x] If the server was changed, please run `make fmt` in `server/`.
- [x] Make sure all PR Checks are passing.
<!--
You can run the tests manually:

Notes:

- Tests can be run manually: start the server and executor, `cd python-sdk`,
  run `make test`.
- To test if changes to the server are backward compatible with the latest
  release, label the PR with `ci_compat_test`. This might report failures
  unrelated to your change if previous incompatible changes were pushed without
  being released yet -->
