### PR TITLE
fix:(server) fix glibc compatibility

### DIFF
--- a/.github/workflows/publish_indexify_server.yaml
+++ b/.github/workflows/publish_indexify_server.yaml
@@ -68,69 +68,69 @@ jobs:
           mv /tmp/release/indexify-server-linux-amd64/indexify-server /tmp/release/indexify-server-${{ needs.extract-version.outputs.version }}-linux-amd64
           mv /tmp/release/indexify-server-deb-linux-amd64/indexify-server_${{ needs.extract-version.outputs.version }}-1_amd64.deb /tmp/release/indexify-server-${{ needs.extract-version.outputs.version }}-linux-amd64.deb
           mv /tmp/release/indexify-server-deb-linux-aarch64/indexify-server_${{ needs.extract-version.outputs.version }}-1_arm64.deb /tmp/release/indexify-server-${{ needs.extract-version.outputs.version }}-linux-arm64.deb
-      # - name: Create GitHub Release
-      #   id: create_release
-      #   uses: actions/create-release@v1
-      #   with:
-      #     tag_name: "v${{ needs.extract-version.outputs.version }}"
-      #     prerelease: ${{ github.event.inputs.prerelease }}
-      #     body: ${{ github.event.inputs.release_message }}
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      # #- name: Upload Windows Binary
-      # #  uses: actions/upload-release-asset@v1
-      # #  with:
-      # #    upload_url: ${{ steps.create_release.outputs.upload_url }}
-      # #    asset_path: /tmp/release/indexify-server-${{ needs.extract-version.outputs.version }}-windows-amd64.exe
-      # #    asset_name: indexify-server-${{ needs.extract-version.outputs.version }}-windows-amd64.exe
-      # #    asset_content_type: application/octet-stream
-      # #  env:
-      # #    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      # - name: Upload Linux Binary
+      - name: Create GitHub Release
+        id: create_release
+        uses: actions/create-release@v1
+        with:
+          tag_name: "v${{ needs.extract-version.outputs.version }}"
+          prerelease: ${{ github.event.inputs.prerelease }}
+          body: ${{ github.event.inputs.release_message }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #- name: Upload Windows Binary
+      #  uses: actions/upload-release-asset@v1
+      #  with:
+      #    upload_url: ${{ steps.create_release.outputs.upload_url }}
+      #    asset_path: /tmp/release/indexify-server-${{ needs.extract-version.outputs.version }}-windows-amd64.exe
+      #    asset_name: indexify-server-${{ needs.extract-version.outputs.version }}-windows-amd64.exe
+      #    asset_content_type: application/octet-stream
+      #  env:
+      #    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload Linux Binary
+        uses: actions/upload-release-asset@v1
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: /tmp/release/indexify-server-${{ needs.extract-version.outputs.version }}-linux-amd64
+          asset_name: indexify-server-${{ needs.extract-version.outputs.version }}-linux-amd64
+          asset_content_type: application/octet-stream
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload macOS Binary
+        uses: actions/upload-release-asset@v1
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: /tmp/release/indexify-server-${{ needs.extract-version.outputs.version }}-darwin-arm64
+          asset_name: indexify-server-${{ needs.extract-version.outputs.version }}-darwin-arm64
+          asset_content_type: application/octet-stream
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # - name: Upload macOS x86 Binary
       #   uses: actions/upload-release-asset@v1
       #   with:
       #     upload_url: ${{ steps.create_release.outputs.upload_url }}
-      #     asset_path: /tmp/release/indexify-server-${{ needs.extract-version.outputs.version }}-linux-amd64
-      #     asset_name: indexify-server-${{ needs.extract-version.outputs.version }}-linux-amd64
+      #     asset_path: /tmp/release/indexify-server-${{ needs.extract-version.outputs.version }}-darwin-amd64
+      #     asset_name: indexify-server-${{ needs.extract-version.outputs.version }}-darwin-amd64
       #     asset_content_type: application/octet-stream
       #   env:
       #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      # - name: Upload macOS Binary
-      #   uses: actions/upload-release-asset@v1
-      #   with:
-      #     upload_url: ${{ steps.create_release.outputs.upload_url }}
-      #     asset_path: /tmp/release/indexify-server-${{ needs.extract-version.outputs.version }}-darwin-arm64
-      #     asset_name: indexify-server-${{ needs.extract-version.outputs.version }}-darwin-arm64
-      #     asset_content_type: application/octet-stream
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      # # - name: Upload macOS x86 Binary
-      # #   uses: actions/upload-release-asset@v1
-      # #   with:
-      # #     upload_url: ${{ steps.create_release.outputs.upload_url }}
-      # #     asset_path: /tmp/release/indexify-server-${{ needs.extract-version.outputs.version }}-darwin-amd64
-      # #     asset_name: indexify-server-${{ needs.extract-version.outputs.version }}-darwin-amd64
-      # #     asset_content_type: application/octet-stream
-      # #   env:
-      # #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      # - name: Upload Linux Deb Package for amd64
-      #   uses: actions/upload-release-asset@v1
-      #   with:
-      #     upload_url: ${{ steps.create_release.outputs.upload_url }}
-      #     asset_path: /tmp/release/indexify-server-${{ needs.extract-version.outputs.version }}-linux-amd64.deb
-      #     asset_name: indexify-server-${{ needs.extract-version.outputs.version }}-linux-amd64.deb
-      #     asset_content_type: application/octet-stream
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      # - name: Upload Linux Deb Package for arm64
-      #   uses: actions/upload-release-asset@v1
-      #   with:
-      #     upload_url: ${{ steps.create_release.outputs.upload_url }}
-      #     asset_path: /tmp/release/indexify-server-${{ needs.extract-version.outputs.version }}-linux-arm64.deb
-      #     asset_name: indexify-server-${{ needs.extract-version.outputs.version }}-linux-arm64.deb
-      #     asset_content_type: application/octet-stream
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload Linux Deb Package for amd64
+        uses: actions/upload-release-asset@v1
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: /tmp/release/indexify-server-${{ needs.extract-version.outputs.version }}-linux-amd64.deb
+          asset_name: indexify-server-${{ needs.extract-version.outputs.version }}-linux-amd64.deb
+          asset_content_type: application/octet-stream
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload Linux Deb Package for arm64
+        uses: actions/upload-release-asset@v1
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: /tmp/release/indexify-server-${{ needs.extract-version.outputs.version }}-linux-arm64.deb
+          asset_name: indexify-server-${{ needs.extract-version.outputs.version }}-linux-arm64.deb
+          asset_content_type: application/octet-stream
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: install reprepro
         run: sudo apt-get update && sudo apt-get install -y reprepro
       - name: Run reprepro

--- a/.github/workflows/publish_indexify_server.yaml
+++ b/.github/workflows/publish_indexify_server.yaml
@@ -12,6 +12,11 @@ on:
         description: Is this a pre-release version?
         required: false
         default: false
+      ref:
+        type: string
+        description: The ref to checkout before running the workflow
+        required: false
+        default: main
 
 permissions:
   contents: write
@@ -48,6 +53,8 @@ jobs:
       - extract-version
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
       - run: mkdir -p /tmp/release
       - name: Download Artifacts
         uses: actions/download-artifact@v4
@@ -61,69 +68,69 @@ jobs:
           mv /tmp/release/indexify-server-linux-amd64/indexify-server /tmp/release/indexify-server-${{ needs.extract-version.outputs.version }}-linux-amd64
           mv /tmp/release/indexify-server-deb-linux-amd64/indexify-server_${{ needs.extract-version.outputs.version }}-1_amd64.deb /tmp/release/indexify-server-${{ needs.extract-version.outputs.version }}-linux-amd64.deb
           mv /tmp/release/indexify-server-deb-linux-aarch64/indexify-server_${{ needs.extract-version.outputs.version }}-1_arm64.deb /tmp/release/indexify-server-${{ needs.extract-version.outputs.version }}-linux-arm64.deb
-      - name: Create GitHub Release
-        id: create_release
-        uses: actions/create-release@v1
-        with:
-          tag_name: "v${{ needs.extract-version.outputs.version }}"
-          prerelease: ${{ github.event.inputs.prerelease }}
-          body: ${{ github.event.inputs.release_message }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #- name: Upload Windows Binary
-      #  uses: actions/upload-release-asset@v1
-      #  with:
-      #    upload_url: ${{ steps.create_release.outputs.upload_url }}
-      #    asset_path: /tmp/release/indexify-server-${{ needs.extract-version.outputs.version }}-windows-amd64.exe
-      #    asset_name: indexify-server-${{ needs.extract-version.outputs.version }}-windows-amd64.exe
-      #    asset_content_type: application/octet-stream
-      #  env:
-      #    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Upload Linux Binary
-        uses: actions/upload-release-asset@v1
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: /tmp/release/indexify-server-${{ needs.extract-version.outputs.version }}-linux-amd64
-          asset_name: indexify-server-${{ needs.extract-version.outputs.version }}-linux-amd64
-          asset_content_type: application/octet-stream
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Upload macOS Binary
-        uses: actions/upload-release-asset@v1
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: /tmp/release/indexify-server-${{ needs.extract-version.outputs.version }}-darwin-arm64
-          asset_name: indexify-server-${{ needs.extract-version.outputs.version }}-darwin-arm64
-          asset_content_type: application/octet-stream
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      # - name: Upload macOS x86 Binary
+      # - name: Create GitHub Release
+      #   id: create_release
+      #   uses: actions/create-release@v1
+      #   with:
+      #     tag_name: "v${{ needs.extract-version.outputs.version }}"
+      #     prerelease: ${{ github.event.inputs.prerelease }}
+      #     body: ${{ github.event.inputs.release_message }}
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # #- name: Upload Windows Binary
+      # #  uses: actions/upload-release-asset@v1
+      # #  with:
+      # #    upload_url: ${{ steps.create_release.outputs.upload_url }}
+      # #    asset_path: /tmp/release/indexify-server-${{ needs.extract-version.outputs.version }}-windows-amd64.exe
+      # #    asset_name: indexify-server-${{ needs.extract-version.outputs.version }}-windows-amd64.exe
+      # #    asset_content_type: application/octet-stream
+      # #  env:
+      # #    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # - name: Upload Linux Binary
       #   uses: actions/upload-release-asset@v1
       #   with:
       #     upload_url: ${{ steps.create_release.outputs.upload_url }}
-      #     asset_path: /tmp/release/indexify-server-${{ needs.extract-version.outputs.version }}-darwin-amd64
-      #     asset_name: indexify-server-${{ needs.extract-version.outputs.version }}-darwin-amd64
+      #     asset_path: /tmp/release/indexify-server-${{ needs.extract-version.outputs.version }}-linux-amd64
+      #     asset_name: indexify-server-${{ needs.extract-version.outputs.version }}-linux-amd64
       #     asset_content_type: application/octet-stream
       #   env:
       #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Upload Linux Deb Package for amd64
-        uses: actions/upload-release-asset@v1
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: /tmp/release/indexify-server-${{ needs.extract-version.outputs.version }}-linux-amd64.deb
-          asset_name: indexify-server-${{ needs.extract-version.outputs.version }}-linux-amd64.deb
-          asset_content_type: application/octet-stream
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Upload Linux Deb Package for arm64
-        uses: actions/upload-release-asset@v1
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: /tmp/release/indexify-server-${{ needs.extract-version.outputs.version }}-linux-arm64.deb
-          asset_name: indexify-server-${{ needs.extract-version.outputs.version }}-linux-arm64.deb
-          asset_content_type: application/octet-stream
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # - name: Upload macOS Binary
+      #   uses: actions/upload-release-asset@v1
+      #   with:
+      #     upload_url: ${{ steps.create_release.outputs.upload_url }}
+      #     asset_path: /tmp/release/indexify-server-${{ needs.extract-version.outputs.version }}-darwin-arm64
+      #     asset_name: indexify-server-${{ needs.extract-version.outputs.version }}-darwin-arm64
+      #     asset_content_type: application/octet-stream
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # # - name: Upload macOS x86 Binary
+      # #   uses: actions/upload-release-asset@v1
+      # #   with:
+      # #     upload_url: ${{ steps.create_release.outputs.upload_url }}
+      # #     asset_path: /tmp/release/indexify-server-${{ needs.extract-version.outputs.version }}-darwin-amd64
+      # #     asset_name: indexify-server-${{ needs.extract-version.outputs.version }}-darwin-amd64
+      # #     asset_content_type: application/octet-stream
+      # #   env:
+      # #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # - name: Upload Linux Deb Package for amd64
+      #   uses: actions/upload-release-asset@v1
+      #   with:
+      #     upload_url: ${{ steps.create_release.outputs.upload_url }}
+      #     asset_path: /tmp/release/indexify-server-${{ needs.extract-version.outputs.version }}-linux-amd64.deb
+      #     asset_name: indexify-server-${{ needs.extract-version.outputs.version }}-linux-amd64.deb
+      #     asset_content_type: application/octet-stream
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # - name: Upload Linux Deb Package for arm64
+      #   uses: actions/upload-release-asset@v1
+      #   with:
+      #     upload_url: ${{ steps.create_release.outputs.upload_url }}
+      #     asset_path: /tmp/release/indexify-server-${{ needs.extract-version.outputs.version }}-linux-arm64.deb
+      #     asset_name: indexify-server-${{ needs.extract-version.outputs.version }}-linux-arm64.deb
+      #     asset_content_type: application/octet-stream
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: install reprepro
         run: sudo apt-get update && sudo apt-get install -y reprepro
       - name: Run reprepro
@@ -132,6 +139,7 @@ jobs:
           (cd .repo && reprepro includedeb buster /tmp/release/*.deb)
           (cd .repo && reprepro includedeb focal /tmp/release/*.deb)
           (cd .repo && reprepro includedeb jammy /tmp/release/*.deb)
+          # (cd .repo && reprepro includedeb noble /tmp/release/*.deb)
           ls .repo/
       - uses: ryand56/r2-upload-action@latest
         with:

--- a/server/Makefile
+++ b/server/Makefile
@@ -15,10 +15,12 @@ build: ## Build rust application
 
 build-release: ## Build rust release
 	cargo install cross
+	# cargo install cross --git https://github.com/cross-rs/cross
 	cross build --target x86_64-unknown-linux-gnu --release
 
 build-release-aarch64:
 	cargo install cross
+	# cargo install cross --git https://github.com/cross-rs/cross
 	cross build --target aarch64-unknown-linux-gnu --release
 
 clean: ## Clean rust build artifacts

--- a/server/dockerfiles/Dockerfile.builder_linux_aarch64
+++ b/server/dockerfiles/Dockerfile.builder_linux_aarch64
@@ -1,4 +1,4 @@
-FROM ubuntu:24.04
+FROM ubuntu:22.04
 
 RUN apt-get update && \
     apt-get install --assume-yes --no-install-recommends \

--- a/server/dockerfiles/Dockerfile.builder_linux_x86
+++ b/server/dockerfiles/Dockerfile.builder_linux_x86
@@ -1,4 +1,4 @@
-FROM ubuntu:24.04
+FROM ubuntu:22.04
 
 RUN apt-get update && \
     apt-get install --assume-yes --no-install-recommends \


### PR DESCRIPTION
## Context

<!--
In a few sentences or less, please explain the context behind this change to help answer why this change is needed.

If this is a bug fix, make sure to include "fixes #xxxx", or
"closes #xxxx".

Screenshots, logs, code or other visual aids are greatly appreciated.
 -->

Running indexify-server 0.2.13 resulted in an error and the container crashing.

```
indexify-server: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.38' not found (required by indexify-server)
``` 

This is because we were building the server on a more recent ubuntu version than the one were were releasing with.

## What

<!--
In a few sentences, please summarize the change to help reviewers.

Consider providing screenshots, logs, code or other visual aids to help the reviewer understand the approach taken.
-->

- [x] Align ubuntu versions between build and release. 
- [x] Fix the 0.2.13 container.

## Testing

<!--
Please include steps used to verify the change.

Consider providing screenshots, logs, code or other visual aids to help the reviewer in their testing.
-->

## Contribution Checklist

- [x] If the python-sdk was changed, please run `make fmt` in `python-sdk/`.
- [x] If the server was changed, please run `make fmt` in `server/`.
- [x] Make sure all PR Checks are passing.
<!--
You can run the tests manually:

Notes:

- Tests can be run manually: start the server and executor, `cd python-sdk`,
  run `make test`.
- To test if changes to the server are backward compatible with the latest
  release, label the PR with `ci_compat_test`. This might report failures
  unrelated to your change if previous incompatible changes were pushed without
  being released yet -->
