### PR TITLE
Relax typer

### DIFF
--- a/python-sdk/poetry.lock
+++ b/python-sdk/poetry.lock
@@ -1183,13 +1183,13 @@ files = [
 
 [[package]]
 name = "typer"
-version = "0.13.1"
+version = "0.12.5"
 description = "Typer, build great CLIs. Easy to code. Based on Python type hints."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "typer-0.13.1-py3-none-any.whl", hash = "sha256:5b59580fd925e89463a29d363e0a43245ec02765bde9fb77d39e5d0f29dd7157"},
-    {file = "typer-0.13.1.tar.gz", hash = "sha256:9d444cb96cc268ce6f8b94e13b4335084cef4c079998a9f4851a90229a3bd25c"},
+    {file = "typer-0.12.5-py3-none-any.whl", hash = "sha256:62fe4e471711b147e3365034133904df3e235698399bc4de2b36c8579298d52b"},
+    {file = "typer-0.12.5.tar.gz", hash = "sha256:f592f089bedcc8ec1b974125d64851029c3b1af145f04aca64d69410f0c9b722"},
 ]
 
 [package.dependencies]
@@ -1303,4 +1303,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "b3f653b63532a4d7599a97f522804b64dcd2f35ca8d590a39c36b63427e8c2eb"
+content-hash = "fdefe46e975b5869e1aa0e798bbc1cddccbcc25fe869962b01f8fbb31272e84d"

--- a/python-sdk/pyproject.toml
+++ b/python-sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "indexify"
-version = "0.2.42"
+version = "0.2.43"
 description = "Python Client for Indexify"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 license = "Apache 2.0"
@@ -20,7 +20,7 @@ cloudpickle = "^3.1.0"
 rich = "^13.9.2"
 nanoid = "^2.0.0"
 docker = "^7.1.0"
-typer = "^0.13.0"
+typer = "^0.12"
 httpx-sse = "^0.4.0"
 structlog = "^24.4.0"
 grpcio = "1.68.1"


### PR DESCRIPTION
## Context

I'm working on setting up an indexify example with docling and the issue I'm runing into is that docling and indexify both need typer but indexify needs `>=0.13.0` and docling needs `>=0.12.5`. We need to relax the dep for typer, otherwise uv will resolve to a much older version of indexify.

```bash
Using Python 3.11.10 environment at: ENV-docling
  × No solution found when resolving dependencies:
  ╰─▶ Because indexify==0.2.42 depends on typer>=0.13.0,<0.14.0 and docling==2.14.0 depends on typer>=0.12.5,<0.13.0, we can conclude that docling==2.14.0 and indexify==0.2.42 are incompatible.
      And because you require indexify==0.2.42 and docling==2.14.0, we can conclude that your requirements are unsatisfiable.
```

## What
- Add change to the lock file.
- Bump indexify python sdk version

## Testing
- Made the change.
- Installed new lock file to a python 3.11 env.
- Installed editable version of indexify.
- Ran `indexify-cli server-dev-mode` to verify typer is working.

Repeated for 3.10.

## Contribution Checklist

- [ ] If the python-sdk was changed, please run `make fmt` in `python-sdk/`.
- [ ] If the server was changed, please run `make fmt` in `server/`.
- [ ] Make sure all PR Checks are passing.
<!--
You can run the tests manually:

Notes:

- Tests can be run manually: start the server and executor, `cd python-sdk`,
  run `make test`.
- To test if changes to the server are backward compatible with the latest
  release, label the PR with `ci_compat_test`. This might report failures
  unrelated to your change if previous incompatible changes were pushed without
  being released yet -->
