### PR TITLE
Relax pydantic and keep the last pin as the base

### DIFF
--- a/python-sdk/poetry.lock
+++ b/python-sdk/poetry.lock
@@ -1303,4 +1303,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "fdefe46e975b5869e1aa0e798bbc1cddccbcc25fe869962b01f8fbb31272e84d"
+content-hash = "c67d5f9493d07244bc5ffa74ce34ba8603063df14290d584ae48eecd26bd13ef"

--- a/python-sdk/pyproject.toml
+++ b/python-sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "indexify"
-version = "0.2.43"
+version = "0.2.44"
 description = "Python Client for Indexify"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 license = "Apache 2.0"
@@ -15,7 +15,7 @@ indexify-cli = "indexify.cli:app"
 python = "^3.9"
 httpx = { version = "0.27.2", extras = ["http2"] }
 pyyaml = "^6"
-pydantic = "2.10.2"
+pydantic = "^2.10.2"
 cloudpickle = "^3.1.0"
 rich = "^13.9.2"
 nanoid = "^2.0.0"


### PR DESCRIPTION
## Context

Similar to https://github.com/tensorlakeai/indexify/pull/1124.

Project version is not updated because we haven't released it to pypi.

## What

Relax pydantic but pin the base version to a version that is working.

If we update the core dependencies and pydantic version changes we'll have to verify the remote graph execution before updating.

## Testing

On this PR and verify document AI. if things are broken I will revert and release a new deployment.

## Contribution Checklist

- [ ] If the python-sdk was changed, please run `make fmt` in `python-sdk/`.
- [ ] If the server was changed, please run `make fmt` in `server/`.
- [ ] Make sure all PR Checks are passing.
<!--
You can run the tests manually:

Notes:

- Tests can be run manually: start the server and executor, `cd python-sdk`,
  run `make test`.
- To test if changes to the server are backward compatible with the latest
  release, label the PR with `ci_compat_test`. This might report failures
  unrelated to your change if previous incompatible changes were pushed without
  being released yet -->
