### PR TITLE
fix(sdk): fix support for args when using IndexifyFunction and IndexifyRouter classes

### DIFF
--- a/python-sdk/indexify/__init__.py
+++ b/python-sdk/indexify/__init__.py
@@ -3,6 +3,7 @@ from .functions_sdk.graph import Graph
 from .functions_sdk.image import Image
 from .functions_sdk.indexify_functions import (
     IndexifyFunction,
+    IndexifyRouter,
     get_ctx,
     indexify_function,
     indexify_router,
@@ -23,6 +24,7 @@ __all__ = [
     "indexify_function",
     "get_ctx",
     "IndexifyFunction",
+    "IndexifyRouter",
     "indexify_router",
     "DEFAULT_SERVICE_URL",
     "IndexifyClient",

--- a/python-sdk/indexify/function_executor/handlers/run_function/handler.py
+++ b/python-sdk/indexify/function_executor/handlers/run_function/handler.py
@@ -139,9 +139,10 @@ def _indexify_client(
 
 
 def _is_router(func_wrapper: IndexifyFunctionWrapper) -> bool:
-    return (
-        str(type(func_wrapper.indexify_function))
-        == "<class 'indexify.functions_sdk.indexify_functions.IndexifyRouter'>"
+    return str(
+        type(func_wrapper.indexify_function)
+    ) == "<class 'indexify.functions_sdk.indexify_functions.IndexifyRouter'>" or isinstance(
+        func_wrapper.indexify_function, IndexifyRouter
     )
 
 

--- a/python-sdk/indexify/function_executor/handlers/run_function/handler.py
+++ b/python-sdk/indexify/function_executor/handlers/run_function/handler.py
@@ -139,6 +139,10 @@ def _indexify_client(
 
 
 def _is_router(func_wrapper: IndexifyFunctionWrapper) -> bool:
+    """Determines if the function is a router.
+
+    A function is a router if it is an instance of IndexifyRouter or if it is an IndexifyRouter class.
+    """
     return str(
         type(func_wrapper.indexify_function)
     ) == "<class 'indexify.functions_sdk.indexify_functions.IndexifyRouter'>" or isinstance(

--- a/python-sdk/indexify/functions_sdk/indexify_functions.py
+++ b/python-sdk/indexify/functions_sdk/indexify_functions.py
@@ -1,8 +1,9 @@
 import inspect
 import traceback
+from inspect import Parameter
+from typing_extensions import get_type_hints
 from typing import (
     Any,
-    Callable,
     Dict,
     List,
     Optional,
@@ -89,10 +90,22 @@ class IndexifyFunction:
     def run(self, *args, **kwargs) -> Union[List[Any], Any]:
         pass
 
-    def partial(self, **kwargs) -> Callable:
-        from functools import partial
+    def _call_run(self, *args, **kwargs) -> Union[List[Any], Any]:
+        # Process dictionary argument mapping it to args or to kwargs.
+        if self.accumulate and len(args) == 2 and isinstance(args[1], dict):
+            sig = inspect.signature(self.run)
+            new_args = [args[0]]  # Keep the accumulate argument
+            dict_arg = args[1]
+            new_args_from_dict, new_kwargs = _process_dict_arg(dict_arg, sig)
+            new_args.extend(new_args_from_dict)
+            return self.run(*new_args, **new_kwargs)
+        elif len(args) == 1 and isinstance(args[0], dict):
+            sig = inspect.signature(self.run)
+            dict_arg = args[0]
+            new_args, new_kwargs = _process_dict_arg(dict_arg, sig)
+            return self.run(*new_args, **new_kwargs)
 
-        return partial(self.run, **kwargs)
+        return self.run(*args, **kwargs)
 
     @classmethod
     def deserialize_output(cls, output: IndexifyData) -> Any:
@@ -111,10 +124,16 @@ class IndexifyRouter:
     def run(self, *args, **kwargs) -> Optional[List[IndexifyFunction]]:
         pass
 
+    # Create run method that preserves signature
+    def _call_run(self, *args, **kwargs):
+        # Process dictionary argument mapping it to args or to kwargs.
+        if len(args) == 1 and isinstance(args[0], dict):
+            sig = inspect.signature(self.run)
+            dict_arg = args[0]
+            new_args, new_kwargs = _process_dict_arg(dict_arg, sig)
+            return self.run(*new_args, **new_kwargs)
 
-from inspect import Parameter, signature
-
-from typing_extensions import get_type_hints
+        return self.run(*args, **kwargs)
 
 
 def _process_dict_arg(dict_arg: dict, sig: inspect.Signature) -> Tuple[list, dict]:
@@ -147,25 +166,6 @@ def indexify_router(
     output_encoder: Optional[str] = "cloudpickle",
 ):
     def construct(fn):
-        # Get function signature using inspect.signature
-        fn_sig = signature(fn)
-        fn_hints = get_type_hints(fn)
-
-        # Create run method that preserves signature
-        def run(self, *args, **kwargs):
-            # Process dictionary argument mapping it to args or to kwargs.
-            if len(args) == 1 and isinstance(args[0], dict):
-                sig = inspect.signature(fn)
-                dict_arg = args[0]
-                new_args, new_kwargs = _process_dict_arg(dict_arg, sig)
-                return fn(*new_args, **new_kwargs)
-
-            return fn(*args, **kwargs)
-
-        # Apply original signature and annotations to run method
-        run.__signature__ = fn_sig
-        run.__annotations__ = fn_hints
-
         attrs = {
             "name": name if name else fn.__name__,
             "description": (
@@ -177,7 +177,7 @@ def indexify_router(
             "placement_constraints": placement_constraints,
             "input_encoder": input_encoder,
             "output_encoder": output_encoder,
-            "run": run,
+            "run": staticmethod(fn),
         }
 
         return type("IndexifyRouter", (IndexifyRouter,), attrs)
@@ -195,32 +195,6 @@ def indexify_function(
     placement_constraints: List[PlacementConstraints] = [],
 ):
     def construct(fn):
-        # Get function signature using inspect.signature
-        fn_sig = signature(fn)
-        fn_hints = get_type_hints(fn)
-
-        # Create run method that preserves signature
-        def run(self, *args, **kwargs):
-            # Process dictionary argument mapping it to args or to kwargs.
-            if self.accumulate and len(args) == 2 and isinstance(args[1], dict):
-                sig = inspect.signature(fn)
-                new_args = [args[0]]  # Keep the accumulate argument
-                dict_arg = args[1]
-                new_args_from_dict, new_kwargs = _process_dict_arg(dict_arg, sig)
-                new_args.extend(new_args_from_dict)
-                return fn(*new_args, **new_kwargs)
-            elif len(args) == 1 and isinstance(args[0], dict):
-                sig = inspect.signature(fn)
-                dict_arg = args[0]
-                new_args, new_kwargs = _process_dict_arg(dict_arg, sig)
-                return fn(*new_args, **new_kwargs)
-
-            return fn(*args, **kwargs)
-
-        # Apply original signature and annotations to run method
-        run.__signature__ = fn_sig
-        run.__annotations__ = fn_hints
-
         attrs = {
             "name": name if name else fn.__name__,
             "description": (
@@ -233,7 +207,7 @@ def indexify_function(
             "accumulate": accumulate,
             "input_encoder": input_encoder,
             "output_encoder": output_encoder,
-            "run": run,
+            "run": staticmethod(fn),
         }
 
         return type("IndexifyFunction", (IndexifyFunction,), attrs)
@@ -303,7 +277,7 @@ class IndexifyFunctionWrapper:
                 args += input
             else:
                 args.append(input)
-            extracted_data = self.indexify_function.run(*args, **kwargs)
+            extracted_data = self.indexify_function._call_run(*args, **kwargs)
         except Exception as e:
             return [], traceback.format_exc()
         if not isinstance(extracted_data, list) and extracted_data is not None:
@@ -330,7 +304,7 @@ class IndexifyFunctionWrapper:
             args.append(input)
 
         try:
-            extracted_data = self.indexify_function.run(*args, **kwargs)
+            extracted_data = self.indexify_function._call_run(*args, **kwargs)
         except Exception as e:
             return [], traceback.format_exc()
         if extracted_data is None:

--- a/python-sdk/indexify/functions_sdk/indexify_functions.py
+++ b/python-sdk/indexify/functions_sdk/indexify_functions.py
@@ -1,7 +1,6 @@
 import inspect
 import traceback
 from inspect import Parameter
-from typing_extensions import get_type_hints
 from typing import (
     Any,
     Dict,
@@ -15,6 +14,7 @@ from typing import (
 )
 
 from pydantic import BaseModel, Field, PrivateAttr
+from typing_extensions import get_type_hints
 
 from .data_objects import IndexifyData
 from .image import DEFAULT_IMAGE, Image

--- a/python-sdk/tests/test_functions.py
+++ b/python-sdk/tests/test_functions.py
@@ -98,20 +98,6 @@ class TestFunctionWrapper(unittest.TestCase):
         result, _ = extractor_wrapper.run_fn({"url": "foo"})
         self.assertEqual(result[0], "123")
 
-    # FIXME: Partial extractor is not working
-    # def test_partial_extractor(self):
-    #    @extractor()
-    #    def extractor_c(url: str, some_other_param: str) -> str:
-    #        """
-    #        Random description of extractor_c
-    #        """
-    #        return f"hello {some_other_param}"
-
-    #    print(type(extractor_c))
-    #    partial_extractor = extractor_c.partial(some_other_param="world")
-    #    result = partial_extractor.extract(BaseData.from_data(url="foo"))
-    #    self.assertEqual(result[0].payload, "hello world")
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/python-sdk/tests/test_graph_behaviours.py
+++ b/python-sdk/tests/test_graph_behaviours.py
@@ -240,6 +240,26 @@ class TestGraphBehaviors(unittest.TestCase):
         self.assertEqual(output, [MyObject(x="ab")])
 
     @parameterized.expand([(False), (True)])
+    def test_simple_function_cls(self, is_remote):
+        class MyObject(BaseModel):
+            x: int
+
+        class SimpleFunctionCtxCls(IndexifyFunction):
+            name = "SimpleFunctionCtxCls"
+
+            def __init__(self):
+                super().__init__()
+
+            def run(self, obj: MyObject) -> MyObject:
+                return MyObject(x=obj.x + 1)
+
+        graph = Graph(name="test_simple_function_cls", start_node=SimpleFunctionCtxCls)
+        graph = remote_or_local_graph(graph, is_remote)
+        invocation_id = graph.run(block_until_done=True, obj=MyObject(x=1))
+        output = graph.output(invocation_id, "SimpleFunctionCtxCls")
+        self.assertEqual(output, [MyObject(x=2)])
+
+    @parameterized.expand([(False), (True)])
     def test_simple_function_with_json_encoding(self, is_remote):
         graph = Graph(
             name="test_simple_function_with_json_encoding",


### PR DESCRIPTION
## Context

<!--
In a few sentences or less, please explain the context behind this change to help answer why this change is needed.

If this is a bug fix, make sure to include "fixes #xxxx", or
"closes #xxxx".

Screenshots, logs, code or other visual aids are greatly appreciated.
 -->

We introduced a regression making this graph fail:

```py
        class MyObject(BaseModel):
            x: int

        class SimpleFunctionCtxCls(IndexifyFunction):
            name = "SimpleFunctionCtxCls"

            def __init__(self):
                super().__init__()

            def run(self, obj: MyObject) -> MyObject:
                return MyObject(x=obj.x + 1)

        graph = Graph(name="test_simple_function_cls", start_node=SimpleFunctionCtxCls)
        graph = remote_or_local_graph(graph, is_remote)
        invocation_id = graph.run(block_until_done=True, obj=MyObject(x=1))
        output = graph.output(invocation_id, "SimpleFunctionCtxCls")
        self.assertEqual(output, [MyObject(x=2)])
```

It failed because it called the run function with `dict(obj=MyObject(x=1))` instead of just `MyObject(x=1)`.

## What

<!--
In a few sentences, please summarize the change to help reviewers.

Consider providing screenshots, logs, code or other visual aids to help the reviewer understand the approach taken.
-->

Recent improvements to args and kwargs handling missed support for IndexifyFunction and IndexifyRouter classes.

This PR aligns the approach taken for function and classes.

## Testing

<!--
Please include steps used to verify the change.

Consider providing screenshots, logs, code or other visual aids to help the reviewer in their testing.
-->

Add a new test case for IndexifyFunction and IndexifyRouter classes.

## Contribution Checklist

- [x] If the python-sdk was changed, please run `make fmt` in `python-sdk/`.
- [x] If the server was changed, please run `make fmt` in `server/`.
- [x] Make sure all PR Checks are passing.
<!--
You can run the tests manually:

Notes:

- Tests can be run manually: start the server and executor, `cd python-sdk`,
  run `make test`.
- To test if changes to the server are backward compatible with the latest
  release, label the PR with `ci_compat_test`. This might report failures
  unrelated to your change if previous incompatible changes were pushed without
  being released yet -->
