### PR TITLE
Update publish_indexify_pypi.yaml to inherit secrets

### DIFF
--- a/.github/workflows/publish_indexify_pypi.yaml
+++ b/.github/workflows/publish_indexify_pypi.yaml
@@ -87,3 +87,4 @@ jobs:
     uses: ./.github/workflows/publish_executor_containers.yaml
     with:
       indexify_version: ${{ needs.extract-version.outputs.version }}
+    secrets: inherit


### PR DESCRIPTION
## Context

Fix github action to inherit the secret. Otherwise it will fail even though the secrets are correctly setup in the repo settings.

## What

Add

## Testing
N/A

## Contribution Checklist

- [ ] If the python-sdk was changed, please run `make fmt` in `python-sdk/`.
- [ ] If the server was changed, please run `make fmt` in `server/`.
- [ ] Make sure all PR Checks are passing.
<!--
You can run the tests manually:

Notes:

- Tests can be run manually: start the server and executor, `cd python-sdk`,
  run `make test`.
- To test if changes to the server are backward compatible with the latest
  release, label the PR with `ci_compat_test`. This might report failures
  unrelated to your change if previous incompatible changes were pushed without
  being released yet -->
