### PR TITLE
feat: expose image_uri in tasks for executor

### DIFF
--- a/python-sdk/indexify/executor/api_objects.py
+++ b/python-sdk/indexify/executor/api_objects.py
@@ -12,6 +12,8 @@ class Task(BaseModel):
     input_key: str
     reducer_output_id: Optional[str] = None
     graph_version: int
+    image_uri: Optional[str] = None
+    "image_uri defines the URI of the image of this task. Optional since some executors do not require it."
 
 
 class ExecutorMetadata(BaseModel):

--- a/server/data_model/src/lib.rs
+++ b/server/data_model/src/lib.rs
@@ -97,7 +97,6 @@ pub struct ImageInformation {
     pub base_image: String,
     pub run_strs: Vec<String>,
     pub image_hash: String,
-    pub version: ImageVersion, // this gets updated when the hash changes
     pub image_uri: Option<String>,
     pub sdk_version: Option<String>,
 }
@@ -122,7 +121,6 @@ impl ImageInformation {
             base_image,
             run_strs,
             image_hash: format!("{:x}", image_hasher.finalize()),
-            version: ImageVersion::default(),
             image_uri: None,
             sdk_version,
         }
@@ -390,17 +388,7 @@ impl ComputeGraph {
             self.edges = update.edges;
             self.start_fn = update.start_fn;
             self.runtime_information = update.runtime_information;
-
-            // if the image has changed, increment the version.
-            let mut updated_nodes = update.nodes.clone();
-            for (node_name, updated_node) in updated_nodes.iter_mut() {
-                if let Some(existing_node) = self.nodes.get(node_name) {
-                    if existing_node.image_hash() != updated_node.image_hash() {
-                        updated_node.set_image_version(existing_node.clone().image_version_next());
-                    }
-                }
-            }
-            self.nodes = updated_nodes;
+            self.nodes = update.nodes.clone();
 
             graph_version = Some(self.into_version());
         }
@@ -855,7 +843,6 @@ impl TaskBuilder {
             .ok_or(anyhow!("ingestion data object id is not present"))?;
         let graph_version = self
             .graph_version
-            .clone()
             .ok_or(anyhow!("graph version is not present"))?;
         let reducer_output_id = self.reducer_output_id.clone().flatten();
         let id = uuid::Uuid::new_v4().to_string();
@@ -1371,15 +1358,6 @@ mod tests {
                 assert_eq!(graph.version, GraphVersion(2), "update version");
                 assert_eq!(graph.nodes.len(), 2, "update nodes");
 
-                let fn_a_image_version = *graph
-                    .nodes
-                    .iter()
-                    .find(|(k, _)| *k == "fn_a")
-                    .unwrap()
-                    .1
-                    .image_version();
-                assert_eq!(fn_a_image_version, 1, "update node fn_a image version");
-
                 let version = version.expect("version should be created");
                 assert_eq!(version.version, GraphVersion(2), "update version");
                 assert_eq!(version.nodes.len(), 2, "version nodes");
@@ -1410,15 +1388,6 @@ mod tests {
                     "update node"
                 );
 
-                let fn_a_image_version = *graph
-                    .nodes
-                    .iter()
-                    .find(|(k, _)| *k == "fn_a")
-                    .unwrap()
-                    .1
-                    .image_version();
-                assert_eq!(fn_a_image_version, 2, "update node fn_a image version");
-
                 assert_eq!(graph.created_at, 5, "created_at should not change");
 
                 let version = version.expect("version should be created");
@@ -1429,14 +1398,6 @@ mod tests {
                     "some_hash_fn_a_updated",
                     "version node"
                 );
-                let fn_a_image_version = *version
-                    .nodes
-                    .iter()
-                    .find(|(k, _)| *k == "fn_a")
-                    .unwrap()
-                    .1
-                    .image_version();
-                assert_eq!(fn_a_image_version, 2, "version node fn_a image version");
             },
         );
     }

--- a/server/data_model/src/lib.rs
+++ b/server/data_model/src/lib.rs
@@ -188,24 +188,10 @@ impl Node {
         }
     }
 
-    pub fn image_version(&self) -> &u32 {
+    pub fn image_uri(&self) -> Option<String> {
         match self {
-            Node::Router(router) => &router.image_information.version.0,
-            Node::Compute(compute) => &compute.image_information.version.0,
-        }
-    }
-
-    pub fn set_image_version(&mut self, image_version: ImageVersion) {
-        match self {
-            Node::Router(ref mut router) => router.image_information.version = image_version,
-            Node::Compute(ref mut compute) => compute.image_information.version = image_version,
-        }
-    }
-
-    pub fn image_version_next(self) -> ImageVersion {
-        match self {
-            Node::Router(router) => router.image_information.version.next(),
-            Node::Compute(compute) => compute.image_information.version.next(),
+            Node::Router(router) => router.image_information.image_uri.clone(),
+            Node::Compute(compute) => compute.image_information.image_uri.clone(),
         }
     }
 
@@ -269,6 +255,7 @@ impl Node {
             .input_node_output_key(input_key.to_string())
             .reducer_output_id(reducer_output_id)
             .graph_version(graph_version)
+            .image_uri(self.image_uri())
             .build()?;
         Ok(task)
     }
@@ -764,6 +751,7 @@ pub struct Task {
     pub diagnostics: Option<TaskDiagnostics>,
     pub reducer_output_id: Option<String>,
     pub graph_version: GraphVersion,
+    pub image_uri: Option<String>,
 }
 
 impl Task {
@@ -883,6 +871,7 @@ impl TaskBuilder {
             diagnostics: None,
             reducer_output_id,
             graph_version,
+            image_uri: self.image_uri.clone().flatten(),
         };
         Ok(task)
     }

--- a/server/data_model/src/test_objects.rs
+++ b/server/data_model/src/test_objects.rs
@@ -205,7 +205,6 @@ pub mod tests {
                     "run 3".to_string(),
                 ],
                 image_hash: "".to_string(),
-                version: Default::default(),
                 image_uri: Some("1234567890.dkr.ecr.us-east-1.amazonaws.com/test".to_string()),
                 sdk_version: Some("1.2.3".to_string()),
             },

--- a/server/state_store/src/lib.rs
+++ b/server/state_store/src/lib.rs
@@ -756,10 +756,6 @@ mod tests {
         assert!(compute_graphs.iter().any(|cg| cg.name == "graph_A"));
 
         let nodes = &compute_graphs[0].nodes;
-        assert_eq!(*nodes["fn_a"].image_version(), 1);
-        assert_eq!(*nodes["fn_b"].image_version(), 1);
-        assert_eq!(*nodes["fn_c"].image_version(), 1);
-
         assert_eq!(nodes["fn_a"].image_hash(), "Old Hash");
         assert_eq!(nodes["fn_b"].image_hash(), "Old Hash");
         assert_eq!(nodes["fn_c"].image_hash(), "Old Hash");
@@ -781,10 +777,6 @@ mod tests {
             assert_eq!(nodes["fn_a"].image_hash(), new_hash.clone());
             assert_eq!(nodes["fn_b"].image_hash(), new_hash.clone());
             assert_eq!(nodes["fn_c"].image_hash(), new_hash.clone());
-
-            assert_eq!(*nodes["fn_a"].image_version(), i);
-            assert_eq!(*nodes["fn_b"].image_version(), i);
-            assert_eq!(*nodes["fn_c"].image_version(), i);
         }
 
         Ok(())


### PR DESCRIPTION
## Context

<!--
In a few sentences or less, please explain the context behind this change to help answer why this change is needed.

If this is a bug fix, make sure to include "fixes #xxxx", or
"closes #xxxx".

Screenshots, logs, code or other visual aids are greatly appreciated.
 -->

We need the image_uri to allow some executor to bring up containers.

## What

<!--
In a few sentences, please summarize the change to help reviewers.

Consider providing screenshots, logs, code or other visual aids to help the reviewer understand the approach taken.
-->

Expose image_uri in the Task for executors.
Also delete image_version now that we rely on image_hash.

## Testing

<!--
Please include steps used to verify the change.

Consider providing screenshots, logs, code or other visual aids to help the reviewer in their testing.
-->

## Contribution Checklist

- [x] If the python-sdk was changed, please run `make fmt` in `python-sdk/`.
- [x] If the server was changed, please run `make fmt` in `server/`.
- [x] Make sure all PR Checks are passing.
<!--
You can run the tests manually:

Notes:

- Tests can be run manually: start the server and executor, `cd python-sdk`,
  run `make test`.
- To test if changes to the server are backward compatible with the latest
  release, label the PR with `ci_compat_test`. This might report failures
  unrelated to your change if previous incompatible changes were pushed without
  being released yet -->
