### PR TITLE
fix(server): stop returning diagnostic messages of all invocations being placed

### DIFF
--- a/server/src/routes/invoke.rs
+++ b/server/src/routes/invoke.rs
@@ -223,7 +223,7 @@ pub async fn invoke_with_object(
         if let Some(rx) = rx.as_mut() {
             loop {
                 if let Ok(ev)  =  rx.recv().await {
-                    if ev.invocation_id() == id  || ev.invocation_id() == "" {
+                    if ev.invocation_id() == id {
                         yield Event::default().json_data(ev.clone());
 
                         if let InvocationStateChangeEvent::InvocationFinished(InvocationFinishedEvent{ id }) = ev {

--- a/server/src/scheduler.rs
+++ b/server/src/scheduler.rs
@@ -49,7 +49,7 @@ impl Scheduler {
             let mut processed_state_change_ids = vec![];
             let mut new_reduction_tasks = vec![];
             let mut processed_reduction_tasks = vec![];
-            let mut diagnostic_msgs = vec![];
+            let mut placement_diagnostics = vec![];
             let requires_task_allocation = state_change.change_type == ChangeType::TaskCreated ||
                 state_change.change_type == ChangeType::ExecutorAdded ||
                 state_change.change_type == ChangeType::ExecutorRemoved;
@@ -86,7 +86,7 @@ impl Scheduler {
             if requires_task_allocation {
                 let task_placement_result = self.task_allocator.schedule_unplaced_tasks()?;
                 new_allocations.extend(task_placement_result.task_placements);
-                diagnostic_msgs.extend(task_placement_result.diagnostic_msgs);
+                placement_diagnostics.extend(task_placement_result.placement_diagnostics);
             }
 
             let scheduler_update_request = StateMachineUpdateRequest {
@@ -97,7 +97,7 @@ impl Scheduler {
                         new_reduction_tasks,
                         processed_reduction_tasks,
                     },
-                    diagnostic_msgs,
+                    placement_diagnostics,
                 }),
                 state_changes_processed: processed_state_change_ids,
             };

--- a/server/state_store/src/invocation_events.rs
+++ b/server/state_store/src/invocation_events.rs
@@ -40,7 +40,10 @@ impl InvocationStateChangeEvent {
             InvocationStateChangeEvent::TaskCompleted(TaskCompleted { invocation_id, .. }) => {
                 invocation_id.clone()
             }
-            InvocationStateChangeEvent::DiagnosticMessage(_) => "".to_string(),
+            InvocationStateChangeEvent::DiagnosticMessage(DiagnosticMessage {
+                invocation_id,
+                ..
+            }) => invocation_id.clone(),
         }
     }
 }
@@ -64,6 +67,7 @@ pub struct TaskCreated {
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct DiagnosticMessage {
+    pub invocation_id: String,
     pub message: String,
 }
 

--- a/server/state_store/src/lib.rs
+++ b/server/state_store/src/lib.rs
@@ -463,12 +463,13 @@ impl IndexifyState {
                         error!("failed to send invocation state change: {:?}", err);
                     }
                 }
-                for diagnostic_msg in &sched_update.diagnostic_msgs {
+                for diagnostic in &sched_update.placement_diagnostics {
                     if let Err(err) =
                         self.task_event_tx
                             .send(InvocationStateChangeEvent::DiagnosticMessage(
                                 invocation_events::DiagnosticMessage {
-                                    message: diagnostic_msg.clone(),
+                                    invocation_id: diagnostic.task.invocation_id.clone(),
+                                    message: diagnostic.message.clone(),
                                 },
                             ))
                     {
@@ -832,7 +833,7 @@ mod tests {
                         executor: executor_id.clone(),
                     }],
                     reduction_tasks: ReductionTasks::default(),
-                    diagnostic_msgs: vec![],
+                    placement_diagnostics: vec![],
                 }),
                 state_changes_processed: vec![],
             })
@@ -882,7 +883,7 @@ mod tests {
                 executor: executor_id.clone(),
             }],
             reduction_tasks: ReductionTasks::default(),
-            diagnostic_msgs: vec![],
+            placement_diagnostics: vec![],
         };
 
         indexify_state

--- a/server/state_store/src/requests.rs
+++ b/server/state_store/src/requests.rs
@@ -116,6 +116,12 @@ pub struct TaskPlacement {
     pub executor: ExecutorId,
 }
 
+#[derive(Debug)]
+pub struct TaskPlacementDiagnostic {
+    pub task: Task,
+    pub message: String,
+}
+
 #[derive(Default, Debug)]
 pub struct ReductionTasks {
     pub new_reduction_tasks: Vec<ReduceTask>,
@@ -126,7 +132,7 @@ pub struct SchedulerUpdateRequest {
     pub task_requests: Vec<CreateTasksRequest>,
     pub allocations: Vec<TaskPlacement>,
     pub reduction_tasks: ReductionTasks,
-    pub diagnostic_msgs: Vec<String>,
+    pub placement_diagnostics: Vec<TaskPlacementDiagnostic>,
 }
 
 pub struct DeleteInvocationRequest {


### PR DESCRIPTION
## Context

<!--
In a few sentences or less, please explain the context behind this change to help answer why this change is needed.

If this is a bug fix, make sure to include "fixes #xxxx", or
"closes #xxxx".

Screenshots, logs, code or other visual aids are greatly appreciated.
 -->

If lots of invocations / tasks are being placed at the same time by the scheduler, it will broadcast placement issues for all invocations to all callers using block_until_done.

This results in leaking data about other tasks and can also result in lots of bandwidth being spent across all clients and tasks.

For example: a simple task can easily get megabytes of data.

## What

<!--
In a few sentences, please summarize the change to help reviewers.

Consider providing screenshots, logs, code or other visual aids to help the reviewer understand the approach taken.
-->

Only returning diagnostic data related to the current invocation.
In the future, we should consider adding a way to toggle diagnostic messages in the server config.

## Testing

<!--
Please include steps used to verify the change.

Consider providing screenshots, logs, code or other visual aids to help the reviewer in their testing.
-->

Using:

```
image = (
    Image()
    .base_image("tensorlake/default-base-image")
    .name("tensorlake/WRONG!")
)


@indexify_function(input_encoder="json", output_encoder="json", image=image)
def smoke_test_node(text: str) -> str:
    return text
 ```
 
 I invoke the graph multiple times from multiple terminals to confirm each terminal was getting the scheduler diagnostic only once instead of once per pending tasks:
 
 ```
 scheduler diagnostic: executor mJ2RNNR5VSpTJhEBoQoBL, image name: tensorlake/indexify-executor-default does not match function image name tensorlake/WRONG!. Make sure the executor is running the latest
image
```

## Contribution Checklist

- [x] If the python-sdk was changed, please run `make fmt` in `python-sdk/`.
- [x] If the server was changed, please run `make fmt` in `server/`.
- [x] Make sure all PR Checks are passing.
<!--
You can run the tests manually:

Notes:

- Tests can be run manually: start the server and executor, `cd python-sdk`,
  run `make test`.
- To test if changes to the server are backward compatible with the latest
  release, label the PR with `ci_compat_test`. This might report failures
  unrelated to your change if previous incompatible changes were pushed without
  being released yet -->
