### PR TITLE
update semantics for returning dicts

### DIFF
--- a/python-sdk/indexify/functions_sdk/indexify_functions.py
+++ b/python-sdk/indexify/functions_sdk/indexify_functions.py
@@ -267,6 +267,8 @@ class IndexifyFunctionWrapper:
             # with json encoding which won't deserialize in tuple.
             if isinstance(input, tuple) or isinstance(input, list):
                 args += input
+            elif isinstance(input, dict):
+                kwargs.update(input)
             else:
                 args.append(input)
             extracted_data = self.indexify_function._call_run(*args, **kwargs)
@@ -292,6 +294,8 @@ class IndexifyFunctionWrapper:
         # with json encoding which won't deserialize in tuple.
         if isinstance(input, tuple) or isinstance(input, list):
             args += input
+        elif isinstance(input, dict):
+            kwargs.update(input)
         else:
             args.append(input)
 

--- a/python-sdk/pyproject.toml
+++ b/python-sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "indexify"
-version = "0.2.46"
+version = "0.2.47"
 description = "Python Client for Indexify"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 license = "Apache 2.0"

--- a/python-sdk/tests/test_graph_behaviours.py
+++ b/python-sdk/tests/test_graph_behaviours.py
@@ -422,7 +422,7 @@ class TestGraphBehaviors(unittest.TestCase):
     def test_return_dict_as_args(self, is_remote):
         @indexify_function()
         def my_func(x: int) -> dict:
-            return dict(x=1, y=2, z=3)
+            return {"input": dict(x=1, y=2, z=3)}
 
         @indexify_function()
         def my_func_2(input: dict) -> int:
@@ -444,7 +444,7 @@ class TestGraphBehaviors(unittest.TestCase):
     def test_return_multiple_dict_as_args(self, is_remote):
         @indexify_function()
         def my_func(x: int) -> dict:
-            return dict(x=1, y=2, z=3), dict(x=1, y=2, z=3)
+            return {"input1": dict(x=1, y=2, z=3), "input2": dict(x=1, y=2, z=3)}
 
         @indexify_function()
         def my_func_2(input1: dict, input2: dict) -> int:
@@ -516,8 +516,8 @@ class TestGraphBehaviors(unittest.TestCase):
     @parameterized.expand([(False), (True)])
     def test_return_dict_args_json(self, is_remote):
         @indexify_function(input_encoder="json", output_encoder="json")
-        def my_func(x: int) -> tuple:
-            return dict(x=1, y=2, z=3)
+        def my_func(x: int) -> dict:
+            return {"input": dict(x=1, y=2, z=3)}
 
         @indexify_function(input_encoder="json", output_encoder="json")
         def my_func_2(input: dict) -> int:
@@ -537,7 +537,7 @@ class TestGraphBehaviors(unittest.TestCase):
 
         output1 = graph.output(invocation_id, my_func.name)
         self.assertEqual(len(output1), 1)
-        self.assertEqual(output1[0], {"x": 1, "y": 2, "z": 3})
+        self.assertEqual(output1[0], {"input": {"x": 1, "y": 2, "z": 3}})
 
     @parameterized.expand([(False), (True)])
     def test_return_dict_args_as_kwargs_in_list(self, is_remote):
@@ -567,7 +567,7 @@ class TestGraphBehaviors(unittest.TestCase):
     def test_return_dict_args_as_dict_in_list(self, is_remote):
         @indexify_function()
         def my_func(text: str) -> List[dict]:
-            return [dict(index=index, char=char) for index, char in enumerate(text)]
+            return [{"data": {"index":index, "char":char}} for index, char in enumerate(text)]
 
         @indexify_function()
         def my_func_2(data: dict) -> str:
@@ -807,7 +807,7 @@ class TestGraphBehaviors(unittest.TestCase):
 
         @indexify_function(input_encoder="json", output_encoder="json")
         def my_func1(x: int) -> dict:
-            return P1(a=x).model_dump()
+            return {"input": P1(a=x).model_dump()}
 
         @indexify_function(input_encoder="json", output_encoder="json")
         def my_func_2(input: dict) -> int:


### PR DESCRIPTION
Changed the Graph semantics to be more uniform when functions are invoked with dictionaries 


- top level keys of dictionary always map to positional arguments 
- works the same way when functions are start node or if they are downstream to start functions 