### PR TITLE
removing dynamodb from the project

### DIFF
--- a/server/src/gc.rs
+++ b/server/src/gc.rs
@@ -94,10 +94,8 @@ mod tests {
         let state = IndexifyState::new(temp_dir.path().join("state"))
             .await
             .unwrap();
-        let config = blob_store::BlobStorageConfig::new(
-            temp_dir.path().join("blob").to_str().unwrap(),
-            None,
-        );
+        let config =
+            blob_store::BlobStorageConfig::new(temp_dir.path().join("blob").to_str().unwrap());
         let storage = Arc::new(BlobStorage::new(config)?);
         let (tx, rx) = watch::channel(());
         let mut gc = Gc::new(state.clone(), storage.clone(), rx);


### PR DESCRIPTION
Slatedb doesn't need DynamoDB anymore, thanks to the new ETAG based conditional puts in S3. We can remove DynamoDB from here.