### PR TITLE
Avoid log spam if we can't deser the graph

### DIFF
--- a/python-sdk/indexify/function_executor/function_executor_service.py
+++ b/python-sdk/indexify/function_executor/function_executor_service.py
@@ -56,7 +56,13 @@ class FunctionExecutorService(FunctionExecutorServicer):
         # share the model's file descriptor between all tasks or download function configuration
         # only once.
         graph_serializer = get_serializer(request.graph.content_type)
-        graph = graph_serializer.deserialize(request.graph.bytes)
+
+        try:
+            graph = graph_serializer.deserialize(request.graph.bytes)
+        except Exception as e:
+            self._logger.error(f"Caught exception {e}")
+            return InitializeResponse(success=False)
+
         self._function = graph_serializer.deserialize(graph[request.function_name])
 
         self._logger = self._logger.bind(

--- a/python-sdk/tests/broken_graph_module_error_test/extractors.py
+++ b/python-sdk/tests/broken_graph_module_error_test/extractors.py
@@ -1,12 +1,13 @@
 import sys
 import unittest
 
+from first_p_dep import return_x
+
 from indexify import RemoteGraph
 from indexify.functions_sdk.data_objects import File
 from indexify.functions_sdk.graph import Graph
 from indexify.functions_sdk.indexify_functions import indexify_function
 
-from first_p_dep import return_x
 
 @indexify_function()
 def extractor_a(a: int) -> int:

--- a/python-sdk/tests/broken_graph_module_error_test/test_graph.py
+++ b/python-sdk/tests/broken_graph_module_error_test/test_graph.py
@@ -1,12 +1,12 @@
 import sys
 import unittest
 
+from extractors import extractor_a, extractor_c
+
 from indexify import RemoteGraph
 from indexify.functions_sdk.data_objects import File
 from indexify.functions_sdk.graph import Graph
 from indexify.functions_sdk.indexify_functions import indexify_function
-
-from extractors import extractor_a, extractor_c
 
 
 def create_broken_graph():


### PR DESCRIPTION
## Context
Before this change, if we can't deser a graph correctly it spams the log with the entire binary of the application (from grpc).

## What
Catch the error and make it a debug log. Return unsuccessful task outcome as well.

## Testing

Added a test in a previous push to main.

## Contribution Checklist

- [x] If the python-sdk was changed, please run `make fmt` in `python-sdk/`.
- [ ] If the server was changed, please run `make fmt` in `server/`.
- [ ] Make sure all PR Checks are passing.
<!--
You can run the tests manually:

Notes:

- Tests can be run manually: start the server and executor, `cd python-sdk`,
  run `make test`.
- To test if changes to the server are backward compatible with the latest
  release, label the PR with `ci_compat_test`. This might report failures
  unrelated to your change if previous incompatible changes were pushed without
  being released yet -->
