### PR TITLE
Fix error handling and log spams in Executor

### DIFF
--- a/python-sdk/indexify/executor/task_runner.py
+++ b/python-sdk/indexify/executor/task_runner.py
@@ -33,8 +33,8 @@ class TaskRunner:
             return await self._run(task_input, logger)
         except Exception as e:
             logger.error(
-                f"failed running the task: {e.details()}",
-                # exc_info=e.debug_error_string(),
+                "failed running the task:",
+                exc_info=e,
             )
             return TaskOutput.internal_error(task_input.task)
 

--- a/python-sdk/indexify/function_executor/proto/function_executor.proto
+++ b/python-sdk/indexify/function_executor/proto/function_executor.proto
@@ -31,6 +31,7 @@ message InitializeRequest {
 
 message InitializeResponse {
     optional bool success = 1;
+    optional string customer_error = 2;
 }
 
 message SetInvocationStateRequest {

--- a/python-sdk/indexify/function_executor/proto/function_executor_pb2.py
+++ b/python-sdk/indexify/function_executor/proto/function_executor_pb2.py
@@ -24,7 +24,7 @@ _sym_db = _symbol_database.Default()
 
 
 DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(
-    b'\n8indexify/function_executor/proto/function_executor.proto\x12\x19\x66unction_executor_service"i\n\x10SerializedObject\x12\x0f\n\x05\x62ytes\x18\x01 \x01(\x0cH\x00\x12\x10\n\x06string\x18\x02 \x01(\tH\x00\x12\x19\n\x0c\x63ontent_type\x18\x03 \x01(\tH\x01\x88\x01\x01\x42\x06\n\x04\x64\x61taB\x0f\n\r_content_type"\x88\x02\n\x11InitializeRequest\x12\x16\n\tnamespace\x18\x01 \x01(\tH\x00\x88\x01\x01\x12\x17\n\ngraph_name\x18\x02 \x01(\tH\x01\x88\x01\x01\x12\x1a\n\rgraph_version\x18\x03 \x01(\x05H\x02\x88\x01\x01\x12\x1a\n\rfunction_name\x18\x05 \x01(\tH\x03\x88\x01\x01\x12?\n\x05graph\x18\x07 \x01(\x0b\x32+.function_executor_service.SerializedObjectH\x04\x88\x01\x01\x42\x0c\n\n_namespaceB\r\n\x0b_graph_nameB\x10\n\x0e_graph_versionB\x10\n\x0e_function_nameB\x08\n\x06_graph"6\n\x12InitializeResponse\x12\x14\n\x07success\x18\x01 \x01(\x08H\x00\x88\x01\x01\x42\n\n\x08_success"\x80\x01\n\x19SetInvocationStateRequest\x12\x10\n\x03key\x18\x01 \x01(\tH\x00\x88\x01\x01\x12?\n\x05value\x18\x02 \x01(\x0b\x32+.function_executor_service.SerializedObjectH\x01\x88\x01\x01\x42\x06\n\x04_keyB\x08\n\x06_value"\x1c\n\x1aSetInvocationStateResponse"5\n\x19GetInvocationStateRequest\x12\x10\n\x03key\x18\x01 \x01(\tH\x00\x88\x01\x01\x42\x06\n\x04_key"\x81\x01\n\x1aGetInvocationStateResponse\x12\x10\n\x03key\x18\x01 \x01(\tH\x00\x88\x01\x01\x12?\n\x05value\x18\x02 \x01(\x0b\x32+.function_executor_service.SerializedObjectH\x01\x88\x01\x01\x42\x06\n\x04_keyB\x08\n\x06_value"\xf7\x01\n\x16InvocationStateRequest\x12\x17\n\nrequest_id\x18\x01 \x01(\tH\x01\x88\x01\x01\x12\x14\n\x07task_id\x18\x02 \x01(\tH\x02\x88\x01\x01\x12\x43\n\x03set\x18\x03 \x01(\x0b\x32\x34.function_executor_service.SetInvocationStateRequestH\x00\x12\x43\n\x03get\x18\x04 \x01(\x0b\x32\x34.function_executor_service.GetInvocationStateRequestH\x00\x42\t\n\x07requestB\r\n\x0b_request_idB\n\n\x08_task_id"\xfb\x01\n\x17InvocationStateResponse\x12\x17\n\nrequest_id\x18\x01 \x01(\tH\x01\x88\x01\x01\x12\x14\n\x07success\x18\x02 \x01(\x08H\x02\x88\x01\x01\x12\x44\n\x03set\x18\x03 \x01(\x0b\x32\x35.function_executor_service.SetInvocationStateResponseH\x00\x12\x44\n\x03get\x18\x04 \x01(\x0b\x32\x35.function_executor_service.GetInvocationStateResponseH\x00\x42\n\n\x08responseB\r\n\x0b_request_idB\n\n\x08_success"N\n\x0e\x46unctionOutput\x12<\n\x07outputs\x18\x01 \x03(\x0b\x32+.function_executor_service.SerializedObject"\x1d\n\x0cRouterOutput\x12\r\n\x05\x65\x64ges\x18\x01 \x03(\t"\xb0\x02\n\x0eRunTaskRequest\x12 \n\x13graph_invocation_id\x18\x04 \x01(\tH\x00\x88\x01\x01\x12\x14\n\x07task_id\x18\x06 \x01(\tH\x01\x88\x01\x01\x12H\n\x0e\x66unction_input\x18\t \x01(\x0b\x32+.function_executor_service.SerializedObjectH\x02\x88\x01\x01\x12M\n\x13\x66unction_init_value\x18\n \x01(\x0b\x32+.function_executor_service.SerializedObjectH\x03\x88\x01\x01\x42\x16\n\x14_graph_invocation_idB\n\n\x08_task_idB\x11\n\x0f_function_inputB\x16\n\x14_function_init_value"\xf1\x02\n\x0fRunTaskResponse\x12\x14\n\x07task_id\x18\x01 \x01(\tH\x00\x88\x01\x01\x12G\n\x0f\x66unction_output\x18\x02 \x01(\x0b\x32).function_executor_service.FunctionOutputH\x01\x88\x01\x01\x12\x43\n\rrouter_output\x18\x03 \x01(\x0b\x32\'.function_executor_service.RouterOutputH\x02\x88\x01\x01\x12\x13\n\x06stdout\x18\x04 \x01(\tH\x03\x88\x01\x01\x12\x13\n\x06stderr\x18\x05 \x01(\tH\x04\x88\x01\x01\x12\x17\n\nis_reducer\x18\x06 \x01(\x08H\x05\x88\x01\x01\x12\x14\n\x07success\x18\x07 \x01(\x08H\x06\x88\x01\x01\x42\n\n\x08_task_idB\x12\n\x10_function_outputB\x10\n\x0e_router_outputB\t\n\x07_stdoutB\t\n\x07_stderrB\r\n\x0b_is_reducerB\n\n\x08_success2\xf2\x02\n\x10\x46unctionExecutor\x12i\n\ninitialize\x12,.function_executor_service.InitializeRequest\x1a-.function_executor_service.InitializeResponse\x12\x8f\x01\n"initialize_invocation_state_server\x12\x32.function_executor_service.InvocationStateResponse\x1a\x31.function_executor_service.InvocationStateRequest(\x01\x30\x01\x12\x61\n\x08run_task\x12).function_executor_service.RunTaskRequest\x1a*.function_executor_service.RunTaskResponseb\x06proto3'
+    b'\n8indexify/function_executor/proto/function_executor.proto\x12\x19\x66unction_executor_service"i\n\x10SerializedObject\x12\x0f\n\x05\x62ytes\x18\x01 \x01(\x0cH\x00\x12\x10\n\x06string\x18\x02 \x01(\tH\x00\x12\x19\n\x0c\x63ontent_type\x18\x03 \x01(\tH\x01\x88\x01\x01\x42\x06\n\x04\x64\x61taB\x0f\n\r_content_type"\x88\x02\n\x11InitializeRequest\x12\x16\n\tnamespace\x18\x01 \x01(\tH\x00\x88\x01\x01\x12\x17\n\ngraph_name\x18\x02 \x01(\tH\x01\x88\x01\x01\x12\x1a\n\rgraph_version\x18\x03 \x01(\x05H\x02\x88\x01\x01\x12\x1a\n\rfunction_name\x18\x05 \x01(\tH\x03\x88\x01\x01\x12?\n\x05graph\x18\x07 \x01(\x0b\x32+.function_executor_service.SerializedObjectH\x04\x88\x01\x01\x42\x0c\n\n_namespaceB\r\n\x0b_graph_nameB\x10\n\x0e_graph_versionB\x10\n\x0e_function_nameB\x08\n\x06_graph"f\n\x12InitializeResponse\x12\x14\n\x07success\x18\x01 \x01(\x08H\x00\x88\x01\x01\x12\x1b\n\x0e\x63ustomer_error\x18\x02 \x01(\tH\x01\x88\x01\x01\x42\n\n\x08_successB\x11\n\x0f_customer_error"\x80\x01\n\x19SetInvocationStateRequest\x12\x10\n\x03key\x18\x01 \x01(\tH\x00\x88\x01\x01\x12?\n\x05value\x18\x02 \x01(\x0b\x32+.function_executor_service.SerializedObjectH\x01\x88\x01\x01\x42\x06\n\x04_keyB\x08\n\x06_value"\x1c\n\x1aSetInvocationStateResponse"5\n\x19GetInvocationStateRequest\x12\x10\n\x03key\x18\x01 \x01(\tH\x00\x88\x01\x01\x42\x06\n\x04_key"\x81\x01\n\x1aGetInvocationStateResponse\x12\x10\n\x03key\x18\x01 \x01(\tH\x00\x88\x01\x01\x12?\n\x05value\x18\x02 \x01(\x0b\x32+.function_executor_service.SerializedObjectH\x01\x88\x01\x01\x42\x06\n\x04_keyB\x08\n\x06_value"\xf7\x01\n\x16InvocationStateRequest\x12\x17\n\nrequest_id\x18\x01 \x01(\tH\x01\x88\x01\x01\x12\x14\n\x07task_id\x18\x02 \x01(\tH\x02\x88\x01\x01\x12\x43\n\x03set\x18\x03 \x01(\x0b\x32\x34.function_executor_service.SetInvocationStateRequestH\x00\x12\x43\n\x03get\x18\x04 \x01(\x0b\x32\x34.function_executor_service.GetInvocationStateRequestH\x00\x42\t\n\x07requestB\r\n\x0b_request_idB\n\n\x08_task_id"\xfb\x01\n\x17InvocationStateResponse\x12\x17\n\nrequest_id\x18\x01 \x01(\tH\x01\x88\x01\x01\x12\x14\n\x07success\x18\x02 \x01(\x08H\x02\x88\x01\x01\x12\x44\n\x03set\x18\x03 \x01(\x0b\x32\x35.function_executor_service.SetInvocationStateResponseH\x00\x12\x44\n\x03get\x18\x04 \x01(\x0b\x32\x35.function_executor_service.GetInvocationStateResponseH\x00\x42\n\n\x08responseB\r\n\x0b_request_idB\n\n\x08_success"N\n\x0e\x46unctionOutput\x12<\n\x07outputs\x18\x01 \x03(\x0b\x32+.function_executor_service.SerializedObject"\x1d\n\x0cRouterOutput\x12\r\n\x05\x65\x64ges\x18\x01 \x03(\t"\xb0\x02\n\x0eRunTaskRequest\x12 \n\x13graph_invocation_id\x18\x04 \x01(\tH\x00\x88\x01\x01\x12\x14\n\x07task_id\x18\x06 \x01(\tH\x01\x88\x01\x01\x12H\n\x0e\x66unction_input\x18\t \x01(\x0b\x32+.function_executor_service.SerializedObjectH\x02\x88\x01\x01\x12M\n\x13\x66unction_init_value\x18\n \x01(\x0b\x32+.function_executor_service.SerializedObjectH\x03\x88\x01\x01\x42\x16\n\x14_graph_invocation_idB\n\n\x08_task_idB\x11\n\x0f_function_inputB\x16\n\x14_function_init_value"\xf1\x02\n\x0fRunTaskResponse\x12\x14\n\x07task_id\x18\x01 \x01(\tH\x00\x88\x01\x01\x12G\n\x0f\x66unction_output\x18\x02 \x01(\x0b\x32).function_executor_service.FunctionOutputH\x01\x88\x01\x01\x12\x43\n\rrouter_output\x18\x03 \x01(\x0b\x32\'.function_executor_service.RouterOutputH\x02\x88\x01\x01\x12\x13\n\x06stdout\x18\x04 \x01(\tH\x03\x88\x01\x01\x12\x13\n\x06stderr\x18\x05 \x01(\tH\x04\x88\x01\x01\x12\x17\n\nis_reducer\x18\x06 \x01(\x08H\x05\x88\x01\x01\x12\x14\n\x07success\x18\x07 \x01(\x08H\x06\x88\x01\x01\x42\n\n\x08_task_idB\x12\n\x10_function_outputB\x10\n\x0e_router_outputB\t\n\x07_stdoutB\t\n\x07_stderrB\r\n\x0b_is_reducerB\n\n\x08_success2\xf2\x02\n\x10\x46unctionExecutor\x12i\n\ninitialize\x12,.function_executor_service.InitializeRequest\x1a-.function_executor_service.InitializeResponse\x12\x8f\x01\n"initialize_invocation_state_server\x12\x32.function_executor_service.InvocationStateResponse\x1a\x31.function_executor_service.InvocationStateRequest(\x01\x30\x01\x12\x61\n\x08run_task\x12).function_executor_service.RunTaskRequest\x1a*.function_executor_service.RunTaskResponseb\x06proto3'
 )
 
 _globals = globals()
@@ -39,27 +39,27 @@ if not _descriptor._USE_C_DESCRIPTORS:
     _globals["_INITIALIZEREQUEST"]._serialized_start = 195
     _globals["_INITIALIZEREQUEST"]._serialized_end = 459
     _globals["_INITIALIZERESPONSE"]._serialized_start = 461
-    _globals["_INITIALIZERESPONSE"]._serialized_end = 515
-    _globals["_SETINVOCATIONSTATEREQUEST"]._serialized_start = 518
-    _globals["_SETINVOCATIONSTATEREQUEST"]._serialized_end = 646
-    _globals["_SETINVOCATIONSTATERESPONSE"]._serialized_start = 648
-    _globals["_SETINVOCATIONSTATERESPONSE"]._serialized_end = 676
-    _globals["_GETINVOCATIONSTATEREQUEST"]._serialized_start = 678
-    _globals["_GETINVOCATIONSTATEREQUEST"]._serialized_end = 731
-    _globals["_GETINVOCATIONSTATERESPONSE"]._serialized_start = 734
-    _globals["_GETINVOCATIONSTATERESPONSE"]._serialized_end = 863
-    _globals["_INVOCATIONSTATEREQUEST"]._serialized_start = 866
-    _globals["_INVOCATIONSTATEREQUEST"]._serialized_end = 1113
-    _globals["_INVOCATIONSTATERESPONSE"]._serialized_start = 1116
-    _globals["_INVOCATIONSTATERESPONSE"]._serialized_end = 1367
-    _globals["_FUNCTIONOUTPUT"]._serialized_start = 1369
-    _globals["_FUNCTIONOUTPUT"]._serialized_end = 1447
-    _globals["_ROUTEROUTPUT"]._serialized_start = 1449
-    _globals["_ROUTEROUTPUT"]._serialized_end = 1478
-    _globals["_RUNTASKREQUEST"]._serialized_start = 1481
-    _globals["_RUNTASKREQUEST"]._serialized_end = 1785
-    _globals["_RUNTASKRESPONSE"]._serialized_start = 1788
-    _globals["_RUNTASKRESPONSE"]._serialized_end = 2157
-    _globals["_FUNCTIONEXECUTOR"]._serialized_start = 2160
-    _globals["_FUNCTIONEXECUTOR"]._serialized_end = 2530
+    _globals["_INITIALIZERESPONSE"]._serialized_end = 563
+    _globals["_SETINVOCATIONSTATEREQUEST"]._serialized_start = 566
+    _globals["_SETINVOCATIONSTATEREQUEST"]._serialized_end = 694
+    _globals["_SETINVOCATIONSTATERESPONSE"]._serialized_start = 696
+    _globals["_SETINVOCATIONSTATERESPONSE"]._serialized_end = 724
+    _globals["_GETINVOCATIONSTATEREQUEST"]._serialized_start = 726
+    _globals["_GETINVOCATIONSTATEREQUEST"]._serialized_end = 779
+    _globals["_GETINVOCATIONSTATERESPONSE"]._serialized_start = 782
+    _globals["_GETINVOCATIONSTATERESPONSE"]._serialized_end = 911
+    _globals["_INVOCATIONSTATEREQUEST"]._serialized_start = 914
+    _globals["_INVOCATIONSTATEREQUEST"]._serialized_end = 1161
+    _globals["_INVOCATIONSTATERESPONSE"]._serialized_start = 1164
+    _globals["_INVOCATIONSTATERESPONSE"]._serialized_end = 1415
+    _globals["_FUNCTIONOUTPUT"]._serialized_start = 1417
+    _globals["_FUNCTIONOUTPUT"]._serialized_end = 1495
+    _globals["_ROUTEROUTPUT"]._serialized_start = 1497
+    _globals["_ROUTEROUTPUT"]._serialized_end = 1526
+    _globals["_RUNTASKREQUEST"]._serialized_start = 1529
+    _globals["_RUNTASKREQUEST"]._serialized_end = 1833
+    _globals["_RUNTASKRESPONSE"]._serialized_start = 1836
+    _globals["_RUNTASKRESPONSE"]._serialized_end = 2205
+    _globals["_FUNCTIONEXECUTOR"]._serialized_start = 2208
+    _globals["_FUNCTIONEXECUTOR"]._serialized_end = 2578
 # @@protoc_insertion_point(module_scope)

--- a/python-sdk/indexify/function_executor/proto/function_executor_pb2.pyi
+++ b/python-sdk/indexify/function_executor/proto/function_executor_pb2.pyi
@@ -47,10 +47,14 @@ class InitializeRequest(_message.Message):
     ) -> None: ...
 
 class InitializeResponse(_message.Message):
-    __slots__ = ("success",)
+    __slots__ = ("success", "customer_error")
     SUCCESS_FIELD_NUMBER: _ClassVar[int]
+    CUSTOMER_ERROR_FIELD_NUMBER: _ClassVar[int]
     success: bool
-    def __init__(self, success: bool = ...) -> None: ...
+    customer_error: str
+    def __init__(
+        self, success: bool = ..., customer_error: _Optional[str] = ...
+    ) -> None: ...
 
 class SetInvocationStateRequest(_message.Message):
     __slots__ = ("key", "value")

--- a/python-sdk/indexify/logging.py
+++ b/python-sdk/indexify/logging.py
@@ -26,7 +26,7 @@ def configure_logging_early():
 
 def configure_production_logging():
     processors = [
-        structlog.processors.dict_tracebacks,
+        structlog.processors.format_exc_info,
         structlog.processors.JSONRenderer(),
     ]
     structlog.configure(processors=processors)


### PR DESCRIPTION
* Generate "customer error" if failed to deserialize graph or function in Initialize RPC.
** These errors are not logged as they are in customer owned code.
** These errors are added to function's stderr so customer can see them.
* Fix the test for missing module. It didn't check anything because g.run never raises if function fails.
* Use short formatting for exceptions in prod (non-dev) mode so only short backtraces are present in logs without fully rendered local vars in the backtraces and etc. This reduces log spam.
* Revert previous quickfixes that suppress logging of exception details in Executor.

Testing:

make check
make test

## Contribution Checklist

- [X] If the python-sdk was changed, please run `make fmt` in `python-sdk/`.
- [n/a] If the server was changed, please run `make fmt` in `server/`.
- [X] Make sure all PR Checks are passing.