### PR TITLE
Implicit namespace create

### DIFF
--- a/python-sdk/src/indexify/functions_sdk/image.py
+++ b/python-sdk/src/indexify/functions_sdk/image.py
@@ -96,7 +96,7 @@ class Image:
         self._python_version = LOCAL_PYTHON_VERSION
         self._build_ops = []  # List of ImageOperation
         self._sdk_version = importlib.metadata.version("indexify-python-sdk")
-        self.uri = "" # For internal use
+        self.uri = ""  # For internal use
 
     def name(self, image_name):
         self._image_name = image_name
@@ -131,7 +131,7 @@ class Image:
             image_name=self._image_name,
             sdk_version=self._sdk_version,
             image_hash=self.hash(),
-            image_url=self.uri
+            image_url=self.uri,
         )
 
     def build_context(self, filename: str):

--- a/python-sdk/src/indexify/functions_sdk/image.py
+++ b/python-sdk/src/indexify/functions_sdk/image.py
@@ -96,6 +96,7 @@ class Image:
         self._python_version = LOCAL_PYTHON_VERSION
         self._build_ops = []  # List of ImageOperation
         self._sdk_version = importlib.metadata.version("indexify-python-sdk")
+        self.uri = "" # For internal use
 
     def name(self, image_name):
         self._image_name = image_name
@@ -130,6 +131,7 @@ class Image:
             image_name=self._image_name,
             sdk_version=self._sdk_version,
             image_hash=self.hash(),
+            image_url=self.uri
         )
 
     def build_context(self, filename: str):

--- a/server/src/routes.rs
+++ b/server/src/routes.rs
@@ -325,7 +325,7 @@ async fn namespace_middleware(
             route_state
                 .indexify_state
                 .write(StateMachineUpdateRequest {
-                    payload: CreateNameSpace(NamespaceRequest {
+                    payload: RequestPayload::CreateNameSpace(NamespaceRequest {
                         name: namespace.to_string(),
                     }),
                     state_changes_processed: vec![],

--- a/server/src/routes.rs
+++ b/server/src/routes.rs
@@ -33,7 +33,6 @@ use state_store::{
         DeleteInvocationRequest,
         NamespaceRequest,
         RequestPayload,
-        RequestPayload::CreateNameSpace,
         StateMachineUpdateRequest,
     },
     IndexifyState,

--- a/server/src/service.rs
+++ b/server/src/service.rs
@@ -11,10 +11,7 @@ use tracing::info;
 
 use super::{routes::RouteState, scheduler::Scheduler};
 use crate::{
-    config::ServerConfig,
-    executors::ExecutorManager,
-    gc::Gc,
-    routes::create_routes,
+    config::ServerConfig, executors::ExecutorManager, gc::Gc, routes::create_routes,
     system_tasks::SystemTasksExecutor,
 };
 
@@ -96,9 +93,6 @@ impl Service {
             shutdown_signal(handle_sh, shutdown_tx).await;
             info!("received graceful shutdown signal. Telling tasks to shutdown");
         });
-
-        // State initialization
-        //initialize_indexify_state(self.indexify_state.clone()).await?;
 
         let addr: SocketAddr = self.config.listen_addr.parse()?;
         info!("server api listening on {}", self.config.listen_addr);

--- a/server/src/service.rs
+++ b/server/src/service.rs
@@ -11,7 +11,10 @@ use tracing::info;
 
 use super::{routes::RouteState, scheduler::Scheduler};
 use crate::{
-    config::ServerConfig, executors::ExecutorManager, gc::Gc, routes::create_routes,
+    config::ServerConfig,
+    executors::ExecutorManager,
+    gc::Gc,
+    routes::create_routes,
     system_tasks::SystemTasksExecutor,
 };
 

--- a/server/src/service.rs
+++ b/server/src/service.rs
@@ -5,24 +5,15 @@ use axum_server::Handle;
 use blob_store::BlobStorage;
 use metrics::{init_provider, scheduler_stats::Metrics as SchedulerMetrics};
 use prometheus::Registry;
-use state_store::{
-    kv::KVS,
-    requests::{NamespaceRequest, RequestPayload::CreateNameSpace, StateMachineUpdateRequest},
-    IndexifyState,
-};
+use state_store::{kv::KVS, IndexifyState};
 use tokio::{self, signal, sync::watch};
 use tracing::info;
 
 use super::{routes::RouteState, scheduler::Scheduler};
 use crate::{
-    config::ServerConfig,
-    executors::ExecutorManager,
-    gc::Gc,
-    routes::create_routes,
+    config::ServerConfig, executors::ExecutorManager, gc::Gc, routes::create_routes,
     system_tasks::SystemTasksExecutor,
 };
-
-const DEFAULT_NAMESPACE: &str = "default";
 
 pub struct Service {
     pub config: ServerConfig,
@@ -104,7 +95,7 @@ impl Service {
         });
 
         // State initialization
-        initialize_indexify_state(self.indexify_state.clone()).await?;
+        //initialize_indexify_state(self.indexify_state.clone()).await?;
 
         let addr: SocketAddr = self.config.listen_addr.parse()?;
         info!("server api listening on {}", self.config.listen_addr);
@@ -115,30 +106,6 @@ impl Service {
 
         Ok(())
     }
-}
-
-async fn initialize_indexify_state(indexify_state: Arc<IndexifyState>) -> Result<()> {
-    // Create default namespace if it doesn't exist.
-    if indexify_state
-        .reader()
-        .get_namespace(DEFAULT_NAMESPACE)?
-        .is_some()
-    {
-        return Ok(());
-    }
-
-    indexify_state
-        .write(StateMachineUpdateRequest {
-            payload: CreateNameSpace(NamespaceRequest {
-                name: String::from(DEFAULT_NAMESPACE),
-            }),
-            state_changes_processed: vec![],
-        })
-        .await?;
-
-    info!("created {} namespace", DEFAULT_NAMESPACE);
-
-    Ok(())
 }
 
 async fn shutdown_signal(handle: Handle, shutdown_tx: watch::Sender<()>) {


### PR DESCRIPTION
## Context

Simplify namespace creation to support serverless deployments.

## What

Adds an implicit namespace creation to the namespace middleware, the desired effect namespaces are dynamically created as functions are deployed.

Since namespaces are dynamically created we don't need a static definition of the default namespace so that has been removed.

## Testing

Start the server with an empty store and deploy any workspace.


## Contribution Checklist

- [x] If a Python package was changed, please run `make fmt` in the package directory.
- [x] If the server was changed, please run `make fmt` in `server/`.
- [ ] Make sure all PR Checks are passing.
<!--
Notes:

Tests of a Python package can be run manually. Start a Server and an Executor then
run `make test` in the Python package directory.

To test if changes to the server are backward compatible with the latest
release, label the PR with `ci_compat_test`. This might report failures
unrelated to your change if previous incompatible changes were pushed without
being released yet
-->
