### PR TITLE
Fix: We aren't passing the image_uri back to the data model.

### DIFF
--- a/server/data_model/src/lib.rs
+++ b/server/data_model/src/lib.rs
@@ -105,6 +105,7 @@ impl ImageInformation {
     pub fn new(
         image_name: String,
         image_hash: String,
+        image_uri: Option<String>,
         tag: String,
         base_image: String,
         run_strs: Vec<String>,
@@ -127,7 +128,7 @@ impl ImageInformation {
             base_image,
             run_strs,
             image_hash: compat_image_hash,
-            image_uri: None,
+            image_uri,
             sdk_version,
         }
     }

--- a/server/src/http_objects.rs
+++ b/server/src/http_objects.rs
@@ -113,6 +113,7 @@ impl From<ImageInformation> for data_model::ImageInformation {
         data_model::ImageInformation::new(
             value.image_name,
             value.image_hash,
+            value.image_uri,
             value.tag,
             value.base_image,
             value.run_strs,


### PR DESCRIPTION
## Context

This fixes a previous feature where we can specify the image_uri for a graph_function. 

<!--
In a few sentences or less, please explain the context behind this change to help answer why this change is needed.

If this is a bug fix, make sure to include "fixes #xxxx", or
"closes #xxxx".

Screenshots, logs, code or other visual aids are greatly appreciated.
 -->

## What

Pass the image_uri from the API struct to the data model structs so they are persisted.
<!--
In a few sentences, please summarize the change to help reviewers.

Consider providing screenshots, logs, code or other visual aids to help the reviewer understand the approach taken.
-->

## Testing
POST an graph with image_uri's and are able to retrieve them with GET.
<!--
Please include steps used to verify the change.

Consider providing screenshots, logs, code or other visual aids to help the reviewer in their testing.
-->

## Contribution Checklist

- [ ] If a Python package was changed, please run `make fmt` in the package directory.
- [x] If the server was changed, please run `make fmt` in `server/`.
- [ ] Make sure all PR Checks are passing.
<!--
Notes:

Tests of a Python package can be run manually. Start a Server and an Executor then
run `make test` in the Python package directory.

To test if changes to the server are backward compatible with the latest
release, label the PR with `ci_compat_test`. This might report failures
unrelated to your change if previous incompatible changes were pushed without
being released yet
-->
