### PR TITLE
Setup Webhooks for Inkwell Events

### DIFF
--- a/server/src/http_objects.rs
+++ b/server/src/http_objects.rs
@@ -575,7 +575,7 @@ pub struct InvocationQueryParams {
 }
 
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
-pub struct InkwellWebhookQueryParams {
+pub struct InkwellWebhookParams {
     pub job_id: String,
     pub job_status: String,
 }

--- a/server/src/http_objects.rs
+++ b/server/src/http_objects.rs
@@ -574,6 +574,12 @@ pub struct InvocationQueryParams {
     pub block_until_finish: Option<bool>,
 }
 
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct InkwellWebhookQueryParams {
+    pub job_id: String,
+    pub job_status: String,
+}
+
 #[cfg(test)]
 mod tests {
     use crate::http_objects::{ComputeFn, DynamicRouter};

--- a/server/src/routes.rs
+++ b/server/src/routes.rs
@@ -83,8 +83,8 @@ use crate::{
         TaskOutcome,
         Tasks,
     },
+    routes::webhook::receive_webhook,
 };
-use crate::routes::webhook::receive_webhook;
 
 #[derive(OpenApi)]
 #[openapi(

--- a/server/src/routes.rs
+++ b/server/src/routes.rs
@@ -204,7 +204,7 @@ pub fn create_routes(route_state: RouteState) -> Router {
         .route("/ui", get(ui_index_handler))
         .route("/ui/{*rest}", get(ui_handler))
         .route("/metrics/service",get(service_metrics).with_state(route_state.clone()))
-        .route("/inkwell_webhook", get(receive_webhook).with_state(route_state.clone()))
+        .route("/inkwell_webhook", post(receive_webhook).with_state(route_state.clone()))
         .layer(cors)
         .layer(DefaultBodyLimit::disable())
 }

--- a/server/src/routes.rs
+++ b/server/src/routes.rs
@@ -47,6 +47,8 @@ mod download;
 mod internal_ingest;
 mod invoke;
 mod logs;
+mod webhook;
+
 use download::{
     download_fn_output_by_key,
     download_fn_output_payload,
@@ -82,6 +84,7 @@ use crate::{
         Tasks,
     },
 };
+use crate::routes::webhook::receive_webhook;
 
 #[derive(OpenApi)]
 #[openapi(
@@ -201,6 +204,7 @@ pub fn create_routes(route_state: RouteState) -> Router {
         .route("/ui", get(ui_index_handler))
         .route("/ui/{*rest}", get(ui_handler))
         .route("/metrics/service",get(service_metrics).with_state(route_state.clone()))
+        .route("/inkwell_webhook", get(receive_webhook).with_state(route_state.clone()))
         .layer(cors)
         .layer(DefaultBodyLimit::disable())
 }

--- a/server/src/routes/webhook.rs
+++ b/server/src/routes/webhook.rs
@@ -4,13 +4,14 @@ use axum::{
 };
 
 use crate::{
-    http_objects::{IndexifyAPIError, InkwellWebhookQueryParams},
+    http_objects::{IndexifyAPIError, InkwellWebhookParams},
     routes::RouteState,
 };
 
 #[utoipa::path(
     post,
     path = "/inkwell_webhook",
+    request_body = InkwellWebhookParams,
     tag = "operations",
     responses(
         (status = 200, description = "Post a webhook for processing"),
@@ -19,8 +20,8 @@ use crate::{
 )]
 pub async fn receive_webhook(
     State(state): State<RouteState>,
-    Query(_params): Query<InkwellWebhookQueryParams>,
+    Json(body): Json<InkwellWebhookParams>,
 ) -> Result<Json<String>, IndexifyAPIError> {
-    let value = format!("{}, {}", _params.job_id, _params.job_status);
+    let value = format!("{}, {}", body.job_id, body.job_status);
     Ok(Json(value))
 }

--- a/server/src/routes/webhook.rs
+++ b/server/src/routes/webhook.rs
@@ -1,0 +1,26 @@
+use axum::{
+    extract::{Query, State},
+    Json,
+};
+
+use crate::{
+    http_objects::{IndexifyAPIError, InkwellWebhookQueryParams},
+    routes::RouteState,
+};
+
+#[utoipa::path(
+    post,
+    path = "/inkwell_webhook",
+    tag = "operations",
+    responses(
+        (status = 200, description = "Post a webhook for processing"),
+        (status = INTERNAL_SERVER_ERROR, description = "Internal Server Error")
+    ),
+)]
+pub async fn receive_webhook(
+    State(state): State<RouteState>,
+    Query(_params): Query<InkwellWebhookQueryParams>,
+) -> Result<Json<String>, IndexifyAPIError> {
+    let value = format!("{}, {}", _params.job_id, _params.job_status);
+    Ok(Json(value))
+}


### PR DESCRIPTION
## Context
User svix to send webhooks upon inkwell job completion. The payload from the even will be used to trigger additional workflows.

## What

Setup a new test endpoint to receive webhook events.

## Testing
Tested locally on the server,
```
# hit inkwell server
curl -X POST http://localhost:8900/inkwell_webhook?job_id=10&job_status=good

# use svix cli
➜  ~ curl -X POST https://play.svix.com/in/c_2FTjg7HAjYDcWse2aZrSeyLlAUF/ \
  -H  "Accept: application/json" \
  -H  "Content-Type: application/json" \
  -H  "Authorization: Bearer testsk_wrjXDgF4W9LSYJz7nikQyP00X44nlXDq.eu" \
  -d '{"job_id": "tenten", "job_status": "okish"}'
"tenten, okish"%
```

## Contribution Checklist

- [ ] If a Python package was changed, please run `make fmt` in the package directory.
- [x] If the server was changed, please run `make fmt` in `server/`.
- [ ] Make sure all PR Checks are passing.
<!--
Notes:

Tests of a Python package can be run manually. Start a Server and an Executor then
run `make test` in the Python package directory.

To test if changes to the server are backward compatible with the latest
release, label the PR with `ci_compat_test`. This might report failures
unrelated to your change if previous incompatible changes were pushed without
being released yet
-->
