### PR TITLE
Clean and synchronized shutdown of Executor

### DIFF
--- a/function_executor/src/function_executor/main.py
+++ b/function_executor/src/function_executor/main.py
@@ -1,4 +1,8 @@
-from python_utils.logging import configure_logging_early, configure_production_logging
+from python_utils.logging import (
+    configure_development_mode_logging,
+    configure_logging_early,
+    configure_production_mode_logging,
+)
 
 configure_logging_early()
 
@@ -28,8 +32,10 @@ def main():
     )
     args = parser.parse_args()
 
-    if not args.dev:
-        configure_production_logging()
+    if args.dev:
+        configure_development_mode_logging()
+    else:
+        configure_production_mode_logging()
     validate_args(args)
 
     logger.info("starting function executor server", address=args.address)

--- a/indexify/src/cli/cli.py
+++ b/indexify/src/cli/cli.py
@@ -1,4 +1,8 @@
-from python_utils.logging import configure_logging_early, configure_production_logging
+from python_utils.logging import (
+    configure_development_mode_logging,
+    configure_logging_early,
+    configure_production_mode_logging,
+)
 
 configure_logging_early()
 
@@ -199,8 +203,10 @@ def executor(
         (50000, 51000), help="Range of localhost TCP ports to be used by the executor"
     ),
 ):
-    if not dev:
-        configure_production_logging()
+    if dev:
+        configure_development_mode_logging()
+    else:
+        configure_production_mode_logging()
         if function_uris is None:
             raise typer.BadParameter(
                 "At least one function must be specified when not running in development mode"


### PR DESCRIPTION
This address the issue where we're starting new Function Executors to run incoming tasks while shutting down existing Function Executors on Executor shutdown and as a result we don't cleanup very recently create Function Executors during Executor shutdown so when we start Executor again we were getting TCP port conflicts.