### PR TITLE
finalize and update graph ctx task analytics in the processor

### DIFF
--- a/server/metrics/src/lib.rs
+++ b/server/metrics/src/lib.rs
@@ -584,9 +584,9 @@ impl StateStoreMetrics {
         }
     }
 
-    pub fn task_unassigned(&self, tasks: Vec<Task>) {
+    pub fn task_unassigned(&self, tasks: &[Task]) {
         for task in tasks {
-            let id = FnMetricsId::from_task(&task);
+            let id = FnMetricsId::from_task(task);
             match self.unassigned_tasks.write() {
                 Ok(mut count) => *count.entry(id).or_insert(0) += 1,
                 Err(e) => tracing::error!("Failed to lock unassigned_tasks: {:?}", e),
@@ -594,7 +594,7 @@ impl StateStoreMetrics {
         }
     }
 
-    pub fn task_assigned(&self, tasks: Vec<Task>, executor_id: &str) {
+    pub fn task_assigned(&self, tasks: &[Task], executor_id: &str) {
         match self.tasks_by_executor.write() {
             Ok(mut tasks_by_executor) => {
                 tasks_by_executor
@@ -606,7 +606,7 @@ impl StateStoreMetrics {
         }
 
         for task in tasks {
-            let id = FnMetricsId::from_task(&task);
+            let id = FnMetricsId::from_task(task);
             match self.assigned_tasks.write() {
                 Ok(mut count_assigned) => *count_assigned.entry(id.clone()).or_insert(0) += 1,
                 Err(e) => tracing::error!("Failed to lock assigned_tasks: {:?}", e),

--- a/server/src/routes/internal_ingest.rs
+++ b/server/src/routes/internal_ingest.rs
@@ -14,7 +14,7 @@ use data_model::{
 };
 use futures::StreamExt;
 use serde::{Deserialize, Serialize};
-use state_store::requests::{FinalizeTaskRequest, RequestPayload, StateMachineUpdateRequest};
+use state_store::requests::{IngestTaskOutputsRequest, RequestPayload, StateMachineUpdateRequest};
 use tracing::{error, info};
 use utoipa::ToSchema;
 
@@ -224,7 +224,7 @@ pub async fn ingest_files_from_executor(
         node_outputs.push(node_output);
     }
 
-    let request = RequestPayload::FinalizeTask(FinalizeTaskRequest {
+    let request = RequestPayload::IngestTaskOuputs(IngestTaskOutputsRequest {
         namespace: task_result.namespace.to_string(),
         compute_graph: task_result.compute_graph.to_string(),
         compute_fn: task_result.compute_fn.to_string(),

--- a/server/state_store/src/invocation_events.rs
+++ b/server/state_store/src/invocation_events.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use data_model::{TaskAnalytics, TaskOutcome};
 use serde::{Deserialize, Serialize};
 
-use crate::requests::FinalizeTaskRequest;
+use crate::requests::IngestTaskOutputsRequest;
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum InvocationStateChangeEvent {
@@ -16,7 +16,7 @@ pub enum InvocationStateChangeEvent {
 }
 
 impl InvocationStateChangeEvent {
-    pub fn from_task_finished(event: FinalizeTaskRequest) -> Self {
+    pub fn from_task_finished(event: IngestTaskOutputsRequest) -> Self {
         Self::TaskCompleted(TaskCompleted {
             invocation_id: event.invocation_id,
             fn_name: event.compute_fn,

--- a/server/state_store/src/requests.rs
+++ b/server/state_store/src/requests.rs
@@ -23,6 +23,7 @@ pub enum RequestPayload {
     InvokeComputeGraph(InvokeComputeGraphRequest),
     ReplayComputeGraph(ReplayComputeGraphRequest),
     ReplayInvocations(ReplayInvocationsRequest),
+    IngestTaskOuputs(IngestTaskOutputsRequest),
     FinalizeTask(FinalizeTaskRequest),
     CreateNameSpace(NamespaceRequest),
     CreateOrUpdateComputeGraph(CreateOrUpdateComputeGraphRequest),
@@ -69,7 +70,7 @@ pub struct ReplayInvocationsRequest {
 }
 
 #[derive(Debug, Clone)]
-pub struct FinalizeTaskRequest {
+pub struct IngestTaskOutputsRequest {
     pub namespace: String,
     pub compute_graph: String,
     pub compute_fn: String,
@@ -77,8 +78,20 @@ pub struct FinalizeTaskRequest {
     pub task_id: TaskId,
     pub node_outputs: Vec<NodeOutput>,
     pub task_outcome: TaskOutcome,
-    pub executor_id: ExecutorId,
     pub diagnostics: Option<TaskDiagnostics>,
+    pub executor_id: ExecutorId,
+}
+
+#[derive(Debug, Clone)]
+pub struct FinalizeTaskRequest {
+    pub namespace: String,
+    pub compute_graph: String,
+    pub compute_fn: String,
+    pub invocation_id: String,
+    pub task_id: TaskId,
+    pub task_outcome: TaskOutcome,
+    pub diagnostics: Option<TaskDiagnostics>,
+    pub executor_id: ExecutorId,
 }
 
 #[derive(Debug, Clone)]

--- a/server/state_store/src/scanner.rs
+++ b/server/state_store/src/scanner.rs
@@ -17,7 +17,7 @@ use data_model::{
     SystemTask,
     Task,
     TaskAnalytics,
-    TaskFinishedEvent,
+    TaskFinalizedEvent,
 };
 use metrics::Timer;
 use opentelemetry::KeyValue;
@@ -422,7 +422,7 @@ impl StateReader {
     }
 
     pub fn unprocessed_state_changes(&self) -> Result<Vec<StateChange>> {
-        let kvs = &[KeyValue::new("op", "get_next_state_change")];
+        let kvs = &[KeyValue::new("op", "unprocessed_state_changes")];
         let _timer = Timer::start_with_labels(&self.metrics.state_read, kvs);
         let mut state_changes = Vec::new();
         let global_state_changes: Vec<StateChange> = self
@@ -592,7 +592,7 @@ impl StateReader {
         )
     }
 
-    pub fn get_task_from_finished_event(&self, req: &TaskFinishedEvent) -> Result<Option<Task>> {
+    pub fn get_task_from_finished_event(&self, req: &TaskFinalizedEvent) -> Result<Option<Task>> {
         return self.get_task(
             &req.namespace,
             &req.compute_graph,

--- a/server/state_store/src/test_state_store.rs
+++ b/server/state_store/src/test_state_store.rs
@@ -21,7 +21,7 @@ use data_model::{
 use crate::{
     requests::{
         CreateOrUpdateComputeGraphRequest,
-        FinalizeTaskRequest,
+        IngestTaskOutputsRequest,
         InvokeComputeGraphRequest,
         RequestPayload,
         StateMachineUpdateRequest,
@@ -184,9 +184,8 @@ pub async fn finalize_task(
                 compute_fn_for_reducer.clone(),
             )
         })
-        .into_iter()
         .collect();
-    let request = FinalizeTaskRequest {
+    let request = IngestTaskOutputsRequest {
         namespace: TEST_NAMESPACE.to_string(),
         compute_graph: task.compute_graph_name.to_string(),
         compute_fn: task.compute_fn_name.to_string(),
@@ -200,7 +199,7 @@ pub async fn finalize_task(
 
     indexify_state
         .write(StateMachineUpdateRequest {
-            payload: RequestPayload::FinalizeTask(request),
+            payload: RequestPayload::IngestTaskOuputs(request),
             processed_state_changes: vec![],
         })
         .await
@@ -211,7 +210,7 @@ pub async fn finalize_task_graph_b(
     invocation_id: &str,
     task_id: &TaskId,
 ) -> Result<()> {
-    let request = FinalizeTaskRequest {
+    let request = IngestTaskOutputsRequest {
         namespace: TEST_NAMESPACE.to_string(),
         compute_graph: "graph_B".to_string(),
         compute_fn: "fn_a".to_string(),
@@ -224,7 +223,7 @@ pub async fn finalize_task_graph_b(
     };
     indexify_state
         .write(StateMachineUpdateRequest {
-            payload: RequestPayload::FinalizeTask(request),
+            payload: RequestPayload::IngestTaskOuputs(request),
             processed_state_changes: vec![],
         })
         .await
@@ -235,7 +234,7 @@ pub async fn finalize_router_x(
     invocation_id: &str,
     task_id: &TaskId,
 ) -> Result<()> {
-    let request = FinalizeTaskRequest {
+    let request = IngestTaskOutputsRequest {
         namespace: TEST_NAMESPACE.to_string(),
         compute_graph: "graph_B".to_string(),
         compute_fn: "router_x".to_string(),
@@ -248,7 +247,7 @@ pub async fn finalize_router_x(
     };
     indexify_state
         .write(StateMachineUpdateRequest {
-            payload: RequestPayload::FinalizeTask(request),
+            payload: RequestPayload::IngestTaskOuputs(request),
             processed_state_changes: vec![],
         })
         .await


### PR DESCRIPTION
## Context

<!--
In a few sentences or less, please explain the context behind this change to help answer why this change is needed.

If this is a bug fix, make sure to include "fixes #xxxx", or
"closes #xxxx".

Screenshots, logs, code or other visual aids are greatly appreciated.
 -->

Since graph invocation context influences task creation and that task creation happens in the processor, it enabled timing issues around parallel tasks where task creation could act on a previous task finalization event with data from a new task finalization which adds more complexity to the task creation logic and has added timing issues in the past.

## What

<!--
In a few sentences, please summarize the change to help reviewers.

Consider providing screenshots, logs, code or other visual aids to help the reviewer understand the approach taken.
-->

All dependencies of a processor should be mutated by it to remove any possibly of race conditions. This PR ensures that tasks will only get completed and its analytics updated by the processor.

## Testing

- from tensorlake: `TEST_TIMEOUT=2m TEST_MAX=100 TEST_FAIL_FAST=true INDEXIFY_URL=http://localhost:8900 command_stress_test poetry run python src/test_graph_behaviours.py`
- map reduce graph: `TEST_MAX=100 TEST_FAIL_FAST=true INDEXIFY_URL=http://localhost:8900 command_stress_test poetry run python graph.py`

<!--
Please include steps used to verify the change.

Consider providing screenshots, logs, code or other visual aids to help the reviewer in their testing.
-->

## Contribution Checklist

- [x] If a Python package was changed, please run `make fmt` in the package directory.
- [x] If the server was changed, please run `make fmt` in `server/`.
- [x] Make sure all PR Checks are passing.
<!--
Notes:

Tests of a Python package can be run manually. Start a Server and an Executor then
run `make test` in the Python package directory.

To test if changes to the server are backward compatible with the latest
release, label the PR with `ci_compat_test`. This might report failures
unrelated to your change if previous incompatible changes were pushed without
being released yet
-->
