### PR TITLE
Remove direct dependency on tensorlake package

### DIFF
--- a/indexify/poetry.lock
+++ b/indexify/poetry.lock
@@ -1169,25 +1169,23 @@ name = "tensorlake"
 version = "0.1.7"
 description = "Petabyte scale data framework for unstructured data of any modality"
 optional = false
-python-versions = "^3.9"
+python-versions = "<4.0,>=3.9"
 groups = ["main"]
-files = []
-develop = true
+files = [
+    {file = "tensorlake-0.1.7-py3-none-any.whl", hash = "sha256:118fcc92a9da32f824dae626d67dbfee61589f12ea7074e912b55d8e79fccbc0"},
+    {file = "tensorlake-0.1.7.tar.gz", hash = "sha256:8eaf612b5587336ea3c5e0bcb4cfbd592c6529178dc8a98745bc192b3730a2ab"},
+]
 
 [package.dependencies]
-click = "^8.1.8"
-cloudpickle = "^3.1.0"
-docker = "^7.1.0"
-httpx = {version = "^0.28.1", extras = ["http2"]}
-httpx-sse = "^0.4.0"
-nanoid = "^2.0.0"
+click = ">=8.1.8,<9.0.0"
+cloudpickle = ">=3.1.0,<4.0.0"
+docker = ">=7.1.0,<8.0.0"
+httpx = {version = ">=0.28.1,<0.29.0", extras = ["http2"]}
+httpx-sse = ">=0.4.0,<0.5.0"
+nanoid = ">=2.0.0,<3.0.0"
 pydantic = "2.10.4"
-pyyaml = "^6.0.2"
-rich = "^13.9.4"
-
-[package.source]
-type = "directory"
-url = "../tensorlake"
+pyyaml = ">=6.0.2,<7.0.0"
+rich = ">=13.9.4,<14.0.0"
 
 [[package]]
 name = "tomli"
@@ -1378,4 +1376,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.9"
-content-hash = "8fa08e2babbfc8f50fbdc26c192272db6be07da5d15cdee380dd5d6bae951925"
+content-hash = "f05a3b67cd62fe03eefdb0d7a9d66b3b33ff05cf800bb9973053f49d6de8e1e4"

--- a/indexify/pyproject.toml
+++ b/indexify/pyproject.toml
@@ -23,7 +23,7 @@ grpcio = "1.68.1"
 
 # Function Executor only
 grpcio-tools = "1.68.1"
-tensorlake = { path = "../tensorlake", develop = true }
+tensorlake = "0.1.7"
 
 # Executor only
 pydantic = "2.10.4"


### PR DESCRIPTION
PyPi doesn't allow direct dependencies on python packages. See https://github.com/tensorlakeai/indexify/actions/runs/12808052008/job/35709918724

```
Uploading distributions to https://upload.pypi.org/legacy/
Uploading indexify-0.3.0-py3-none-any.whl
WARNING  Error during upload. Retry with the --verbose option for more details.
ERROR    HTTPError: 400 Bad Request from https://upload.pypi.org/legacy/
         Can't have direct dependency: tensorlake@
         file:///home/runner/work/indexify/indexify/tensorlake. See
         https://packaging.python.org/specifications/core-metadata for more
         information.
```

Python standards also prohibit this, see
https://peps.python.org/pep-0440/#direct-references

```
Public index servers SHOULD NOT allow the use of direct references in uploaded
distributions. Direct references are intended as a tool for software integrators
rather than publishers.
```

Not removing the tensorlake git submodule as it's required to run SDK tests in Github Actions.