### PR TITLE
Setup PDF Document Parsing example with indexify 0.3.1

### DIFF
--- a/examples/pdf_document_extraction/docker-compose.yaml
+++ b/examples/pdf_document_extraction/docker-compose.yaml
@@ -18,6 +18,8 @@ services:
       [
         "indexify-cli",
         "executor",
+        "-f",
+        "default:Extract_pages_tables_images_pdf_docling:download_pdf:0.1",
         "--server-addr",
         "indexify:8900"
       ]
@@ -28,12 +30,68 @@ services:
     deploy:
       mode: replicated
       replicas: 1
-  embedding-executor:
+  image-embedding-executor:
     image: tensorlake/pdf-blueprint-st
     command:
       [
         "indexify-cli",
         "executor",
+        "-f",
+        "default:Extract_pages_tables_images_pdf_docling:image-embedding-docling:0.1",
+        "--server-addr",
+        "indexify:8900"
+      ]
+    networks:
+      server:
+    volumes:
+      - data:/tmp/indexify-blob-storage
+    deploy:
+      mode: replicated
+      replicas: 1
+  elastic-writer:
+    image: tensorlake/pdf-blueprint-st
+    command:
+      [
+        "indexify-cli",
+        "executor",
+        "-f",
+        "default:Extract_pages_tables_images_pdf_docling:elastic_search_writer:0.1",
+        "--server-addr",
+        "indexify:8900"
+      ]
+    networks:
+      server:
+    volumes:
+      - data:/tmp/indexify-blob-storage
+    deploy:
+      mode: replicated
+      replicas: 1
+  text-embedding-executor:
+    image: tensorlake/pdf-blueprint-st
+    command:
+      [
+        "indexify-cli",
+        "executor",
+        "-f",
+        "default:Extract_pages_tables_images_pdf_docling:text-embedding-extractor:0.1",
+        "--server-addr",
+        "indexify:8900"
+      ]
+    networks:
+      server:
+    volumes:
+      - data:/tmp/indexify-blob-storage
+    deploy:
+      mode: replicated
+      replicas: 1
+  chunk-executor:
+    image: tensorlake/pdf-blueprint-st
+    command:
+      [
+        "indexify-cli",
+        "executor",
+        "-f",
+        "default:Extract_pages_tables_images_pdf_docling:chunk_text_docling:0.1",
         "--server-addr",
         "indexify:8900"
       ]
@@ -58,11 +116,13 @@ services:
     volumes:
       - data:/tmp/indexify-blob-storage
   default-executor:
-    image: tensorlake/indexify-executor-default
+    image: tensorlake/indexify-executor-default:3.13-0.3.0
     command:
       [
         "indexify-cli",
         "executor",
+        "-f",
+        "default:Extract_pages_tables_images_pdf_docling:default:0.1",
         "--server-addr",
         "indexify:8900"
       ]
@@ -78,6 +138,8 @@ services:
       [
         "indexify-cli",
         "executor",
+        "-f",
+        "default:Extract_pages_tables_images_pdf_docling:pdf-parse-docling:0.1",
         "--server-addr",
         "indexify:8900"
       ]

--- a/examples/pdf_document_extraction/workflow.py
+++ b/examples/pdf_document_extraction/workflow.py
@@ -55,7 +55,7 @@ if __name__ == "__main__":
     file = File(data=resp.content, mime_type="application/pdf")
 
     # uncomment to run locally
-    #invocation_id = graph.run(block_until_true=True, file=file)
+    #invocation_id = graph.run(file=file)
     #exit(0)
 
     import common_objects
@@ -68,7 +68,5 @@ if __name__ == "__main__":
         server_url="http://localhost:8900",
     )
 
-    invocation_id = remote_graph.run(
-        block_until_done=True, file=file,
-    )
+    invocation_id = remote_graph.run(file=file)
     print(f"Invocation ID: {invocation_id}")


### PR DESCRIPTION
This reverts commit e2f9776db50cacc56092d83f5c14e1086194ce4d.

## Context
Setup example to use the new indexify cli commands.

## What
Fix the docker compose file to setup the args correctly.

## Testing
Started containers locally and tested. We would have to publish new images and I can retest once to make sure everything is fine.

## Contribution Checklist

- [ ] If a Python package was changed, please run `make fmt` in the package directory.
- [ ] If the server was changed, please run `make fmt` in `server/`.
- [ ] Make sure all PR Checks are passing.
<!--
Notes:

Tests of a Python package can be run manually. Start a Server and an Executor then
run `make test` in the Python package directory.

To test if changes to the server are backward compatible with the latest
release, label the PR with `ci_compat_test`. This might report failures
unrelated to your change if previous incompatible changes were pushed without
being released yet
-->
