### PR TITLE
Pass Executor version in Executor constructor args

### DIFF
--- a/indexify/src/indexify/cli/cli.py
+++ b/indexify/src/indexify/cli/cli.py
@@ -219,12 +219,13 @@ def executor(
             )
 
     id = nanoid.generate()
+    executor_version = version("indexify")
     logger.info(
         "starting executor",
         server_addr=server_addr,
         config_path=config_path,
         executor_id=id,
-        executor_version=version("indexify"),
+        executor_version=executor_version,
         executor_cache=executor_cache,
         ports=ports,
         functions=function_uris,
@@ -247,7 +248,8 @@ def executor(
         exit(1)
 
     Executor(
-        id,
+        id=id,
+        version=executor_version,
         server_addr=server_addr,
         config_path=config_path,
         code_path=executor_cache,

--- a/indexify/src/indexify/executor/executor.py
+++ b/indexify/src/indexify/executor/executor.py
@@ -21,7 +21,8 @@ from .task_runner import TaskInput, TaskOutput, TaskRunner
 class Executor:
     def __init__(
         self,
-        executor_id: str,
+        id: str,
+        version: str,
         code_path: Path,
         function_allowlist: Optional[List[FunctionURI]],
         function_executor_server_factory: FunctionExecutorServerFactory,
@@ -48,15 +49,16 @@ class Executor:
             code_path=code_path, base_url=self._base_url, config_path=config_path
         )
         self._task_fetcher = TaskFetcher(
+            executor_id=id,
+            executor_version=version,
+            function_allowlist=function_allowlist,
             protocol=protocol,
             indexify_server_addr=self._server_addr,
-            executor_id=executor_id,
-            function_allowlist=function_allowlist,
             config_path=config_path,
         )
         self._task_reporter = TaskReporter(
             base_url=self._base_url,
-            executor_id=executor_id,
+            executor_id=id,
             config_path=self._config_path,
         )
 

--- a/indexify/src/indexify/executor/task_fetcher.py
+++ b/indexify/src/indexify/executor/task_fetcher.py
@@ -16,10 +16,11 @@ class TaskFetcher:
 
     def __init__(
         self,
+        executor_id: str,
+        executor_version: str,
+        function_allowlist: Optional[List[FunctionURI]],
         protocol: str,
         indexify_server_addr: str,
-        executor_id: str,
-        function_allowlist: Optional[List[FunctionURI]],
         config_path: Optional[str] = None,
     ):
         self._protocol: str = protocol
@@ -30,7 +31,7 @@ class TaskFetcher:
         probe_info: ProbeInfo = RuntimeProbes().probe()
         self._executor_metadata: ExecutorMetadata = ExecutorMetadata(
             id=executor_id,
-            executor_version=version("indexify"),
+            executor_version=executor_version,
             addr="",
             function_allowlist=function_allowlist,
             labels=probe_info.labels,

--- a/indexify/tests/executor/test_executor_behaviour.py
+++ b/indexify/tests/executor/test_executor_behaviour.py
@@ -24,7 +24,8 @@ class TestExecutor(unittest.TestCase):
     def test_tls_configuration(self, mock_async_client, mock_sync_client, mock_file):
         # Create an instance of Executor with the mock config
         executor = Executor(
-            executor_id="unit-test",
+            id="unit-test",
+            version="0.1.0",
             code_path=Path("test"),
             function_allowlist=None,
             function_executor_server_factory=None,
@@ -56,7 +57,8 @@ class TestExecutor(unittest.TestCase):
     def test_no_tls_configuration(self):
         # Create an instance of Executor without TLS
         executor = Executor(
-            executor_id="unit-test",
+            id="unit-test",
+            version="0.1.0",
             code_path=Path("test"),
             function_allowlist=None,
             function_executor_server_factory=None,


### PR DESCRIPTION
This allows to deploy an OSS based Executor using a different Python package (not Indexify).