### PR TITLE
Add image_uri field to Task HTTP object

### DIFF
--- a/indexify/src/indexify/executor/function_executor/server/subprocess_function_executor_server_factory.py
+++ b/indexify/src/indexify/executor/function_executor/server/subprocess_function_executor_server_factory.py
@@ -22,11 +22,6 @@ class SubprocessFunctionExecutorServerFactory(FunctionExecutorServerFactory):
     async def create(
         self, config: FunctionExecutorServerConfiguration, logger: Any
     ) -> SubprocessFunctionExecutorServer:
-        if config.image_uri is not None:
-            raise ValueError(
-                "SubprocessFunctionExecutorServerFactory doesn't support container images"
-            )
-
         logger = logger.bind(module=__name__)
         port: Optional[int] = None
 

--- a/server/src/http_objects.rs
+++ b/server/src/http_objects.rs
@@ -476,6 +476,7 @@ pub struct Task {
     pub outcome: TaskOutcome,
     pub reducer_output_id: Option<String>,
     pub graph_version: GraphVersion,
+    pub image_uri: Option<String>,
 }
 
 impl From<data_model::Task> for Task {
@@ -490,6 +491,7 @@ impl From<data_model::Task> for Task {
             outcome: task.outcome.into(),
             reducer_output_id: task.reducer_output_id,
             graph_version: task.graph_version.into(),
+            image_uri: task.image_uri,
         }
     }
 }


### PR DESCRIPTION
This one was missing and Executor was getting None image_uri all the time.