### PR TITLE
feat: implement endpoint for retrieving invocation's details

### DIFF
--- a/server/src/routes.rs
+++ b/server/src/routes.rs
@@ -8,7 +8,8 @@ use axum::{
     middleware::{self, Next},
     response::{sse::Event, Html, IntoResponse},
     routing::{delete, get, post},
-    Json, Router,
+    Json,
+    Router,
 };
 use axum_tracing_opentelemetry::{
     self,
@@ -26,8 +27,12 @@ use prometheus::Encoder;
 use state_store::{
     kv::{ReadContextData, WriteContextData, KVS},
     requests::{
-        CreateOrUpdateComputeGraphRequest, DeleteComputeGraphRequest, DeleteInvocationRequest,
-        NamespaceRequest, RequestPayload, StateMachineUpdateRequest,
+        CreateOrUpdateComputeGraphRequest,
+        DeleteComputeGraphRequest,
+        DeleteInvocationRequest,
+        NamespaceRequest,
+        RequestPayload,
+        StateMachineUpdateRequest,
     },
     IndexifyState,
 };
@@ -46,21 +51,43 @@ mod internal_ingest;
 mod invoke;
 mod logs;
 use download::{
-    download_fn_output_by_key, download_fn_output_payload, download_invocation_payload,
+    download_fn_output_by_key,
+    download_fn_output_payload,
+    download_invocation_payload,
 };
 use internal_ingest::ingest_files_from_executor;
 use invoke::{
-    invoke_with_file, invoke_with_object, replay_compute_graph, wait_until_invocation_completed,
+    invoke_with_file,
+    invoke_with_object,
+    replay_compute_graph,
+    wait_until_invocation_completed,
 };
 use logs::download_task_logs;
 
 use crate::{
     executors::ExecutorManager,
     http_objects::{
-        ComputeFn, ComputeGraph, ComputeGraphsList, CreateNamespace, DataObject, DynamicRouter,
-        ExecutorMetadata, FnOutputs, GraphInvocations, GraphVersion, ImageInformation,
-        IndexifyAPIError, InvocationResult, ListParams, Namespace, NamespaceList, Node,
-        RuntimeInformation, Task, TaskOutcome, Tasks,
+        ComputeFn,
+        ComputeGraph,
+        ComputeGraphsList,
+        CreateNamespace,
+        DataObject,
+        DynamicRouter,
+        ExecutorMetadata,
+        FnOutputs,
+        GraphInvocations,
+        GraphVersion,
+        ImageInformation,
+        IndexifyAPIError,
+        InvocationResult,
+        ListParams,
+        Namespace,
+        NamespaceList,
+        Node,
+        RuntimeInformation,
+        Task,
+        TaskOutcome,
+        Tasks,
     },
 };
 


### PR DESCRIPTION
## Context

Currently, there is no good way to check whether an invocation exists on a graph. This is a need because in lower environments graphs remove invocations and dependent systems are left hanging without a way to verify whether the invocation is there.

## What

GET operation to retrieve an invocation from a graph.
