### PR TITLE
Fix test_function_executor_routing

### DIFF
--- a/indexify/tests/executor/test_function_executor_routing.py
+++ b/indexify/tests/executor/test_function_executor_routing.py
@@ -1,3 +1,5 @@
+import os
+import platform
 import unittest
 
 from tensorlake import Graph, RemoteGraph, tensorlake_function
@@ -5,9 +7,9 @@ from testing import test_graph_name
 
 
 def function_executor_id() -> str:
-    # We can't use PIDs as they are reused when a process exits.
-    # Use memory address of the function instead.
-    return str(id(function_executor_id))
+    # PIDs are good for Subprocess Function Executors.
+    # Hostnames are good for Function Executors running in VMs and containers.
+    return str(os.getpid()) + str(platform.node())
 
 
 @tensorlake_function()


### PR DESCRIPTION
The test uses memory address of a function as a process ID. On some platforms these addresses are not so random so fallback to a combination of PID and hostname.