### PR TITLE
Hack (don't merge unless really needed): Overwrite task version id in manual function executor management mode

### DIFF
--- a/indexify/src/indexify/executor/function_executor/function_executor_state.py
+++ b/indexify/src/indexify/executor/function_executor/function_executor_state.py
@@ -12,11 +12,17 @@ class FunctionExecutorState:
     under the lock.
     """
 
-    def __init__(self, function_id_with_version: str, function_id_without_version: str):
+    def __init__(
+        self,
+        function_id_with_version: str,
+        function_id_without_version: str,
+        function_version: str,
+    ):
         self.function_id_with_version: str = function_id_with_version
         self.function_id_without_version: str = function_id_without_version
         # All the fields below are protected by the lock.
         self.lock: asyncio.Lock = asyncio.Lock()
+        self.function_version: str = function_version
         self.is_shutdown: bool = False
         self.function_executor: Optional[FunctionExecutor] = None
         self.running_tasks: int = 0

--- a/indexify/src/indexify/executor/task_runner.py
+++ b/indexify/src/indexify/executor/task_runner.py
@@ -61,6 +61,7 @@ class TaskRunner:
                 state = FunctionExecutorState(
                     function_id_with_version=_function_id_with_version(task),
                     function_id_without_version=id,
+                    function_version=task.graph_version,
                 )
                 self._function_executor_states[id] = state
             return self._function_executor_states[id]
@@ -76,6 +77,8 @@ class TaskRunner:
         await state.wait_running_tasks_less(1)
 
         if self._disable_automatic_function_executor_management:
+            # Hack: lie to task executor about the function version so it won't raise errors.
+            task.graph_version = state.function_version
             return  # Disable Function Executor destroy in manual management mode.
 
         if state.function_id_with_version != _function_id_with_version(task):


### PR DESCRIPTION
This is a hack that forces Function Executor to accept a task if the Function Executor was created for a different function version.