### PR TITLE
Add Executor ID to Executor logs and pass it all Function Executors

### DIFF
--- a/indexify/poetry.lock
+++ b/indexify/poetry.lock
@@ -1116,14 +1116,14 @@ typing = ["mypy (>=1.4)", "rich", "twisted"]
 
 [[package]]
 name = "tensorlake"
-version = "0.1.14"
+version = "0.1.16"
 description = "Petabyte scale data framework for unstructured data of any modality"
 optional = false
 python-versions = "<4.0,>=3.9"
 groups = ["main"]
 files = [
-    {file = "tensorlake-0.1.14-py3-none-any.whl", hash = "sha256:22cd2871a5170f2846ba292158825d3ee9b05ada086076eba8816cedcf7f4e5d"},
-    {file = "tensorlake-0.1.14.tar.gz", hash = "sha256:cd9c9773de8f5049126ecc78387a99ab16f076b72b7282631a5c51e752d60313"},
+    {file = "tensorlake-0.1.16-py3-none-any.whl", hash = "sha256:8c6263c536e1ff0b4b7e82779a3fb9d59518a768a54140d214b99b2b98fb5e2e"},
+    {file = "tensorlake-0.1.16.tar.gz", hash = "sha256:e7b01dff1899634d38b88f827e3e046ab0321098450b48e991483493c2083932"},
 ]
 
 [package.dependencies]
@@ -1247,4 +1247,4 @@ zstd = ["zstandard (>=0.18.0)"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.9"
-content-hash = "d14d5902868d233ceca5dc11395e564e272fdc6483be306ca3d5569dce66678f"
+content-hash = "064495e9c3f4680d618ca83707fe387596d571d12f52692ecddd553864459189"

--- a/indexify/pyproject.toml
+++ b/indexify/pyproject.toml
@@ -24,7 +24,7 @@ grpcio = "1.70.0"
 pydantic = "2.10.4"
 httpx-sse = "^0.4.0"
 # Adds function-executor binary and utils lib.
-tensorlake = ">=0.1.14"
+tensorlake = ">=0.1.16"
 
 # CLI only
 rich = "^13.9.2"

--- a/indexify/src/indexify/cli/cli.py
+++ b/indexify/src/indexify/cli/cli.py
@@ -223,14 +223,14 @@ def executor(
                 "At least one function must be specified when not running in development mode"
             )
 
-    logger = structlog.get_logger(module=__name__)
-    id = nanoid.generate()
     executor_version = version("indexify")
+    id = nanoid.generate()
+    logger = structlog.get_logger(module=__name__, executor_id=id)
+
     logger.info(
         "starting executor",
         server_addr=server_addr,
         config_path=config_path,
-        executor_id=id,
         executor_version=executor_version,
         executor_cache=executor_cache,
         ports=ports,

--- a/indexify/src/indexify/executor/executor.py
+++ b/indexify/src/indexify/executor/executor.py
@@ -41,6 +41,7 @@ class Executor:
         self._base_url = f"{protocol}://{self._server_addr}"
         self._code_path = code_path
         self._task_runner = TaskRunner(
+            executor_id=id,
             function_executor_server_factory=function_executor_server_factory,
             base_url=self._base_url,
             config_path=config_path,

--- a/indexify/src/indexify/executor/function_executor/server/function_executor_server_factory.py
+++ b/indexify/src/indexify/executor/function_executor/server/function_executor_server_factory.py
@@ -14,7 +14,8 @@ class FunctionExecutorServerConfiguration:
     configuration parameters or raise an exception if it can't implement
     them."""
 
-    def __init__(self, image_uri: Optional[str]):
+    def __init__(self, executor_id: str, image_uri: Optional[str]):
+        self.executor_id: str = executor_id
         # Container image URI of the Function Executor Server.
         self.image_uri: Optional[str] = image_uri
 

--- a/indexify/src/indexify/executor/function_executor/server/subprocess_function_executor_server_factory.py
+++ b/indexify/src/indexify/executor/function_executor/server/subprocess_function_executor_server_factory.py
@@ -28,6 +28,8 @@ class SubprocessFunctionExecutorServerFactory(FunctionExecutorServerFactory):
         try:
             port = self._allocate_port()
             args = [
+                "--executor-id",
+                config.executor_id,
                 "--address",
                 _server_address(port),
             ]

--- a/indexify/src/indexify/executor/function_executor/single_task_runner.py
+++ b/indexify/src/indexify/executor/function_executor/single_task_runner.py
@@ -25,6 +25,7 @@ from .task_output import TaskOutput
 class SingleTaskRunner:
     def __init__(
         self,
+        executor_id: str,
         function_executor_state: FunctionExecutorState,
         task_input: TaskInput,
         function_executor_server_factory: FunctionExecutorServerFactory,
@@ -32,6 +33,7 @@ class SingleTaskRunner:
         config_path: Optional[str],
         logger: Any,
     ):
+        self._executor_id: str = executor_id
         self._state: FunctionExecutorState = function_executor_state
         self._task_input: TaskInput = task_input
         self._factory: FunctionExecutorServerFactory = function_executor_server_factory
@@ -76,6 +78,7 @@ class SingleTaskRunner:
         )
         config: FunctionExecutorServerConfiguration = (
             FunctionExecutorServerConfiguration(
+                executor_id=self._executor_id,
                 image_uri=self._task_input.task.image_uri,
             )
         )

--- a/indexify/src/indexify/executor/task_runner.py
+++ b/indexify/src/indexify/executor/task_runner.py
@@ -18,11 +18,13 @@ class TaskRunner:
 
     def __init__(
         self,
+        executor_id: str,
         function_executor_server_factory: FunctionExecutorServerFactory,
         base_url: str,
         config_path: Optional[str],
         disable_automatic_function_executor_management: bool,
     ):
+        self._executor_id: str = executor_id
         self._factory: FunctionExecutorServerFactory = function_executor_server_factory
         self._base_url: str = base_url
         self._config_path: Optional[str] = config_path
@@ -88,6 +90,7 @@ class TaskRunner:
         self, state: FunctionExecutorState, task_input: TaskInput, logger: Any
     ) -> TaskOutput:
         runner: SingleTaskRunner = SingleTaskRunner(
+            executor_id=self._executor_id,
             function_executor_state=state,
             task_input=task_input,
             function_executor_server_factory=self._factory,


### PR DESCRIPTION
This allows us to understand easier what's going on in each Executor machine.