### PR TITLE
Generic Executor health checker that uses signals independent from deployment environment

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -130,7 +130,7 @@ jobs:
             echo $! > /tmp/indexify-executor.pid &
 
           wait-on: |
-            tcp:localhost:8900
+            tcp:localhost:7000
 
           tail: true
           wait-for: 10s
@@ -231,7 +231,7 @@ jobs:
             echo $! > /tmp/indexify-executor.pid &
 
           wait-on: |
-            tcp:localhost:8900
+            tcp:localhost:7000
 
           tail: true
           wait-for: 10s

--- a/indexify/src/indexify/cli/cli.py
+++ b/indexify/src/indexify/cli/cli.py
@@ -192,7 +192,8 @@ def executor(
     ),
     # Registred ports range ends at 49151.
     ports: Tuple[int, int] = typer.Option(
-        (50000, 51000), help="Range of localhost TCP ports to be used by the executor"
+        (50000, 51000),
+        help="Range of localhost TCP ports to be used by Function Executors",
     ),
     disable_automatic_function_executor_management: Annotated[
         bool,

--- a/indexify/src/indexify/executor/executor.py
+++ b/indexify/src/indexify/executor/executor.py
@@ -50,9 +50,7 @@ class Executor:
         self._server_addr = server_addr
         self._base_url = f"{protocol}://{self._server_addr}"
         self._code_path = code_path
-        self._startup_probe_handler: ExecutorStartupProbeHandler = (
-            ExecutorStartupProbeHandler()
-        )
+        self._startup_probe_handler = ExecutorStartupProbeHandler()
         self._api_server = APIServer(
             api_host=api_host,
             api_port=api_port,

--- a/indexify/src/indexify/executor/function_executor/function_executor_state.py
+++ b/indexify/src/indexify/executor/function_executor/function_executor_state.py
@@ -18,6 +18,8 @@ class FunctionExecutorState:
         # All the fields below are protected by the lock.
         self.lock: asyncio.Lock = asyncio.Lock()
         self.is_shutdown: bool = False
+        # Set to True if a Function Executor health check ever failed.
+        self.health_check_failed: bool = False
         self.function_executor: Optional[FunctionExecutor] = None
         self.running_tasks: int = 0
         self.running_tasks_change_notifier: asyncio.Condition = asyncio.Condition(

--- a/indexify/src/indexify/executor/health_checker/generic_health_checker.py
+++ b/indexify/src/indexify/executor/health_checker/generic_health_checker.py
@@ -5,6 +5,8 @@ from ..function_executor.function_executor_states_container import (
 )
 from .health_checker import HealthChecker, HealthCheckResult
 
+HEALTH_CHECKER_NAME = "GenericHealthChecker"
+
 
 class GenericHealthChecker(HealthChecker):
     """A generic health checker that doesn't depend on machine type and other features of the environment.
@@ -24,12 +26,33 @@ class GenericHealthChecker(HealthChecker):
         if self._function_executor_states is None:
             return HealthCheckResult(
                 is_success=False,
-                status_message="Function executor states container was not provided yet",
-                checker_name="GenericHealthChecker",
+                status_message="Function Executor states container was not provided yet",
+                checker_name=HEALTH_CHECKER_NAME,
             )
 
+        # Current health check policy and reasoning:
+        # * A Function Executor health check failure is a strong signal that something is wrong
+        #   either with:
+        #   - The Function Code (a criticial software bug).
+        #   - The Executor machine/container/VM (a software bug or malfunctioning local hardware).
+        # * Critical Function Code bugs tend to get fixed eventually by users. What doesn't get fixed eventually
+        #   is rare but recurring local Executor issues like hardware errors and software bugs in middleware like
+        #   drivers.
+        # * Such issues tend to get mitigated by automatically recreating the Executor machine/VM/container.
+        # * So we fail whole Executor health check if a Function Executor health check ever failed to hint the users
+        #   that we probably need to recreate the Executor machine/VM/container (unless there's a bug in Function
+        #   code that user can investigate themself).
+        async for state in self._function_executor_states:
+            # No need to async lock the state to read a single value.
+            if state.health_check_failed:
+                return HealthCheckResult(
+                    is_success=False,
+                    status_message="A Function Executor health check failed",
+                    checker_name=HEALTH_CHECKER_NAME,
+                )
+
         return HealthCheckResult(
-            is_success=False,
-            status_message="Not implemented",
-            checker_name="GenericHealthChecker",
+            is_success=True,
+            status_message="All Function Executors pass health checks",
+            checker_name=HEALTH_CHECKER_NAME,
         )

--- a/indexify/tests/cli/test_disable_automatic_container_management.py
+++ b/indexify/tests/cli/test_disable_automatic_container_management.py
@@ -1,7 +1,6 @@
 import os
 import platform
 import subprocess
-import time
 import unittest
 
 from tensorlake import Graph, tensorlake_function

--- a/indexify/tests/cli/test_health_probe.py
+++ b/indexify/tests/cli/test_health_probe.py
@@ -1,0 +1,83 @@
+import os
+import subprocess
+import unittest
+
+import httpx
+from tensorlake import Graph, tensorlake_function
+from tensorlake.remote_graph import RemoteGraph
+from testing import (
+    ExecutorProcessContextManager,
+    test_graph_name,
+    wait_executor_startup,
+)
+
+
+@tensorlake_function()
+def crash_function(crash: bool) -> str:
+    if crash:
+        # os.kill(getpid(), signal.SIGKILL) won't work for container init process,
+        # see https://stackoverflow.com/questions/21031537/sigkill-init-process-pid-1.
+        # sys.exit(1) hangs the function for some unknown reason,
+        # see some ideas at https://stackoverflow.com/questions/5422831/what-does-sys-exit-do-in-python.
+        os._exit(1)
+    return "success"
+
+
+class TestHealthProbe(unittest.TestCase):
+    def test_success(self):
+        # Run a new Executor to not interfere with other tests that might turn the default Executor health checks into failing.
+        with ExecutorProcessContextManager(
+            [
+                "--dev",
+                "--ports",
+                "60000",
+                "60001",
+                "--api-port",
+                "7001",
+            ]
+        ) as executor_a:
+            executor_a: subprocess.Popen
+            print(f"Started Executor A with PID: {executor_a.pid}")
+            wait_executor_startup(7001)
+
+            response = httpx.post("http://localhost:7001/probe/health")
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(
+                response.json(),
+                {
+                    "status": "ok",
+                    "message": "All Function Executors pass health checks",
+                    "checker": "GenericHealthChecker",
+                },
+            )
+
+    def test_failure_after_function_executor_process_crash(self):
+        graph = Graph(
+            name=test_graph_name(self),
+            description="test",
+            start_node=crash_function,
+        )
+        graph = RemoteGraph.deploy(graph)
+
+        # No need to verify if the default Executor health check is successful because other tests might make it fail already.
+
+        # Create and crash the Function Executor twice.
+        invocation_id = graph.run(block_until_done=True, crash=True)
+        output = graph.output(invocation_id, "crash_function")
+        self.assertEqual(len(output), 0)
+
+        # Verify that the default Executor health check fails after the Function Executor crashed.
+        response = httpx.post("http://localhost:7000/probe/health")
+        self.assertEqual(response.status_code, 503)
+        self.assertEqual(
+            response.json(),
+            {
+                "status": "nok",
+                "message": "A Function Executor health check failed",
+                "checker": "GenericHealthChecker",
+            },
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/indexify/tests/cli/test_startup_probe.py
+++ b/indexify/tests/cli/test_startup_probe.py
@@ -1,0 +1,33 @@
+import subprocess
+import unittest
+
+import httpx
+from testing import ExecutorProcessContextManager, wait_executor_startup
+
+
+class TestStartupProbe(unittest.TestCase):
+    def test_success(self):
+        with ExecutorProcessContextManager(
+            [
+                "--dev",
+                "--ports",
+                "60000",
+                "60001",
+                "--api-port",
+                "7001",
+            ]
+        ) as executor_a:
+            executor_a: subprocess.Popen
+            print(f"Started Executor A with PID: {executor_a.pid}")
+            wait_executor_startup(7001)
+            response = httpx.post(f"http://localhost:7001/probe/startup")
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response.json(), {"status": "ok"})
+
+    def test_failure(self):
+        # There's currently no way to reliably slow down Executor startup so this test is empty for now.
+        pass
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/indexify/tests/cli/testing.py
+++ b/indexify/tests/cli/testing.py
@@ -42,17 +42,17 @@ def wait_executor_startup(port: int):
 
     import httpx
 
-    print(f"Waiting 5 secs for Executors to start at port {port}")
+    print(f"Waiting 5 secs for Executor to start at port {port}")
     attempts_left: int = 5
     while attempts_left > 0:
         try:
-            response = httpx.get(f"http://localhost:{port}/probe/startup")
+            response = httpx.post(f"http://localhost:{port}/probe/startup")
             if response.status_code == 200:
                 print(f"Executor startup check successful at port {port}")
                 return
-        except httpx.RequestError as e:
+        except Exception:
             if attempts_left == 1:
                 raise
 
         attempts_left -= 1
-        time.sleep(1)
+        time.sleep(0.1)


### PR DESCRIPTION
Current Executor health check policy and reasoning:
* A Function Executor health check failure is a strong signal that something is wrong either with:
  - The Function Code (a criticial software bug).
  - The Executor machine/container/VM (a software bug or malfunctioning local hardware).
* Critical Function Code bugs tend to get fixed eventually by users. What doesn't get fixed eventually is rare but recurring local Executor issues like hardware errors and software bugs in middleware like drivers.
* Such issues tend to get mitigated by automatically recreating the Executor machine/VM/container.
* So we fail whole Executor health check if a Function Executor health check ever failed to hint the users that we probably need to recreate the Executor machine/VM/container (unless there's a bug in Function code that user can investigate themself).

Also implemented tests for both startup and health probes.