### PR TITLE
Use GET HTTP verb for Executor monitoring API

### DIFF
--- a/indexify/src/indexify/executor/monitoring/server.py
+++ b/indexify/src/indexify/executor/monitoring/server.py
@@ -16,8 +16,8 @@ class MonitoringServer:
         self._app: web.Application = web.Application()
         self._app.add_routes(
             [
-                web.post("/monitoring/startup", startup_probe_handler.handle),
-                web.post("/monitoring/health", health_probe_handler.handle),
+                web.get("/monitoring/startup", startup_probe_handler.handle),
+                web.get("/monitoring/health", health_probe_handler.handle),
             ]
         )
         self._app_runner: web.AppRunner = web.AppRunner(self._app)

--- a/indexify/tests/cli/test_health_probe.py
+++ b/indexify/tests/cli/test_health_probe.py
@@ -40,7 +40,7 @@ class TestHealthProbe(unittest.TestCase):
             print(f"Started Executor A with PID: {executor_a.pid}")
             wait_executor_startup(7001)
 
-            response = httpx.post("http://localhost:7001/monitoring/health")
+            response = httpx.get("http://localhost:7001/monitoring/health")
             self.assertEqual(response.status_code, 200)
             self.assertEqual(
                 response.json(),
@@ -67,7 +67,7 @@ class TestHealthProbe(unittest.TestCase):
         self.assertEqual(len(output), 0)
 
         # Verify that the default Executor health check fails after the Function Executor crashed.
-        response = httpx.post("http://localhost:7000/monitoring/health")
+        response = httpx.get("http://localhost:7000/monitoring/health")
         self.assertEqual(response.status_code, 503)
         self.assertEqual(
             response.json(),

--- a/indexify/tests/cli/test_startup_probe.py
+++ b/indexify/tests/cli/test_startup_probe.py
@@ -20,7 +20,7 @@ class TestStartupProbe(unittest.TestCase):
             executor_a: subprocess.Popen
             print(f"Started Executor A with PID: {executor_a.pid}")
             wait_executor_startup(7001)
-            response = httpx.post(f"http://localhost:7001/monitoring/startup")
+            response = httpx.get(f"http://localhost:7001/monitoring/startup")
             self.assertEqual(response.status_code, 200)
             self.assertEqual(response.json(), {"status": "ok"})
 

--- a/indexify/tests/cli/testing.py
+++ b/indexify/tests/cli/testing.py
@@ -46,7 +46,7 @@ def wait_executor_startup(port: int):
     attempts_left: int = 5
     while attempts_left > 0:
         try:
-            response = httpx.post(f"http://localhost:{port}/monitoring/startup")
+            response = httpx.get(f"http://localhost:{port}/monitoring/startup")
             if response.status_code == 200:
                 print(f"Executor startup check successful at port {port}")
                 return


### PR DESCRIPTION
Looks like there are no concerns wrt GET response caching by default as Prometheus uses GET verb.

curl:

```
curl http://localhost:7000/monitoring/startup
{"status": "ok"}%
curl http://localhost:7000/monitoring/health
{"status": "ok", "message": "All Function Executors pass health checks", "checker": "GenericHealthChecker"}
```