### PR TITLE
Don't publish ARM Docker images for Server

### DIFF
--- a/.github/workflows/publish_indexify_server.yaml
+++ b/.github/workflows/publish_indexify_server.yaml
@@ -156,8 +156,6 @@ jobs:
       - create-release
     steps:
       - uses: actions/checkout@v4
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Login to Docker Hub
@@ -166,7 +164,7 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - run: |
-          docker buildx build --platform=linux/amd64,linux/arm64 --push . -t tensorlake/indexify-server:latest -f dockerfiles/Dockerfile.release_server;
+          docker buildx build --platform=linux/amd64 --push . -t tensorlake/indexify-server:latest -f dockerfiles/Dockerfile.release_server;
 
           tag="";
           for i in $(echo ${{ needs.extract-version.outputs.version }} | tr '.' '\n')
@@ -176,5 +174,5 @@ jobs:
             else
               tag="$tag.$i";
             fi
-            docker buildx build --platform=linux/amd64,linux/arm64 --push . -t tensorlake/indexify-server:$tag -f dockerfiles/Dockerfile.release_server;
+            docker buildx build --platform=linux/amd64 --push . -t tensorlake/indexify-server:$tag -f dockerfiles/Dockerfile.release_server;
           done


### PR DESCRIPTION
We're not currently running Server on ARM, so we don't really need this. This also allows to workaround QEMU segfaulting on ARM see https://github.com/docker/setup-qemu-action/issues/198.