### PR TITLE
Remove import of default Executor image

### DIFF
--- a/indexify/src/indexify/cli/cli.py
+++ b/indexify/src/indexify/cli/cli.py
@@ -25,7 +25,7 @@ import typer
 from rich.console import Console
 from rich.text import Text
 from rich.theme import Theme
-from tensorlake.functions_sdk.image import GetDefaultPythonImage, Image
+from tensorlake.functions_sdk.image import Image
 
 from indexify.executor.api_objects import FunctionURI
 from indexify.executor.executor import Executor


### PR DESCRIPTION
The default Executor image is not updated anymore so it shoudn't be used.
