### PR TITLE
Pass Function Executor --executor-id argument using =

### DIFF
--- a/indexify/src/indexify/executor/function_executor/server/subprocess_function_executor_server_factory.py
+++ b/indexify/src/indexify/executor/function_executor/server/subprocess_function_executor_server_factory.py
@@ -28,8 +28,7 @@ class SubprocessFunctionExecutorServerFactory(FunctionExecutorServerFactory):
         try:
             port = self._allocate_port()
             args = [
-                "--executor-id",
-                config.executor_id,
+                f"--executor-id={config.executor_id}",  # use = as executor_id can start with -
                 "--address",
                 _server_address(port),
             ]


### PR DESCRIPTION
This is needed because if executor id starts with - then argparse in Function Executor treats this id as a different command line argument parameter instead of --executor-id value.