### PR TITLE
Bump Server and Executor version and update submodule commit

### DIFF
--- a/indexify/pyproject.toml
+++ b/indexify/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "indexify"
 # Incremented if any of the components provided in this packages are updated.
-version = "0.3.10"
+version = "0.3.11"
 description = "Open Source Indexify components and helper tools"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 license = "Apache 2.0"

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -1512,7 +1512,7 @@ dependencies = [
 
 [[package]]
 name = "indexify-server"
-version = "0.2.27"
+version = "0.2.28"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "indexify-server"
-version = "0.2.27"
+version = "0.2.28"
 edition = "2021"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 license = "Apache-2.0"


### PR DESCRIPTION
* Bump Server version so we can run GH action to release it as the previous version release 0.2.27 failed.
* Bump Executor version to release the --executor-id Function Executor CLI parameter bugfix.
* Update tensorlake submodule commit to latest main branch to keep things in sync.