### PR TITLE
Add task_completion_latency_seconds Executor metric

### DIFF
--- a/indexify/src/indexify/executor/metrics/executor.py
+++ b/indexify/src/indexify/executor/metrics/executor.py
@@ -1,6 +1,9 @@
 import prometheus_client
 
-from ..monitoring.metrics import latency_metric_for_fast_operation
+from ..monitoring.metrics import (
+    latency_metric_for_customer_controlled_operation,
+    latency_metric_for_fast_operation,
+)
 
 # This file contains all metrics used by Executor.
 
@@ -31,6 +34,12 @@ metric_tasks_completed.labels(
     outcome=METRIC_TASKS_COMPLETED_OUTCOME_ERROR_CUSTOMER_CODE
 )
 metric_tasks_completed.labels(outcome=METRIC_TASKS_COMPLETED_OUTCOME_ERROR_PLATFORM)
+metric_task_completion_latency: prometheus_client.Histogram = (
+    latency_metric_for_customer_controlled_operation(
+        "task_completion",
+        "task completion from the moment it got fetched until its outcome got reported",
+    )
+)
 
 # Task outcome reporting metrics.
 metric_task_outcome_reports: prometheus_client.Counter = prometheus_client.Counter(

--- a/indexify/tests/executor/test_metrics.py
+++ b/indexify/tests/executor/test_metrics.py
@@ -180,6 +180,8 @@ class TestMetrics(unittest.TestCase):
             # Task lifecycle steps
             "tasks_fetched_total",
             "tasks_completed_total",
+            "task_completion_latency_seconds_count",
+            "task_completion_latency_seconds_sum",
             # Task outcome reporting
             "task_outcome_reports_total",
             "tasks_reporting_outcome",
@@ -375,6 +377,7 @@ class TestMetrics(unittest.TestCase):
             SampleDiff(
                 "tasks_completed_total", {"outcome": "error_customer_code"}, 0.0
             ),
+            SampleDiff("task_completion_latency_seconds_count", {}, 1.0),
             # Task outcome reporting
             SampleDiff("task_outcome_reports_total", {}, 1.0),
             SampleDiff("tasks_reporting_outcome", {}, 0.0),

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -1512,7 +1512,7 @@ dependencies = [
 
 [[package]]
 name = "indexify-server"
-version = "0.2.28"
+version = "0.2.29"
 dependencies = [
  "anyhow",
  "async-stream",


### PR DESCRIPTION
This metric measures duration of task execution from the moment it got fetched until its result got reported to Server. Might be useful to understand general trends of how much time it takes to executor tasks in the Indexify deployment.