### PR TITLE
Remove py-inkwell package from examples

### DIFF
--- a/docs/packaging-dependencies.mdx
+++ b/docs/packaging-dependencies.mdx
@@ -26,7 +26,6 @@ image = (
     .run("pip install git+https://github.com/facebookresearch/detectron2.git@v0.6")
     .run("apt install -y tesseract-ocr")
     .run("apt install -y libtesseract-dev")
-    .run("pip install py-inkwell")
 )
 ```
 

--- a/examples/pdf_document_extraction/images.py
+++ b/examples/pdf_document_extraction/images.py
@@ -15,7 +15,6 @@ st_image = (
     .run("pip install sentence-transformers")
     .run("pip install langchain")
     .run("pip install pillow")
-    .run("pip install py-inkwell")
     .run("pip install opentelemetry-api")
     .run("pip install elasticsearch")
     .run("pip install elastic-transport")

--- a/examples/pdf_structured_extraction/workflow.py
+++ b/examples/pdf_structured_extraction/workflow.py
@@ -19,7 +19,6 @@ image = (
     .run("pip install git+https://github.com/facebookresearch/detectron2.git@v0.6")
     .run("apt install -y tesseract-ocr")
     .run("apt install -y libtesseract-dev")
-    .run('pip install "py-inkwell[inference]"')
 )
 class BillSchema(BaseModel):
     account_no: str = Field(..., description="Account number of the customer")


### PR DESCRIPTION
This package is not available anymore and it's not needed in the examples.