### PR TITLE
Emit Function Executor info metrics

### DIFF
--- a/indexify/src/indexify/executor/function_executor/metrics/function_executor.py
+++ b/indexify/src/indexify/executor/function_executor/metrics/function_executor.py
@@ -78,6 +78,22 @@ metric_destroy_channel_errors: prometheus_client.Counter = prometheus_client.Cou
     "Number of Function Executor channel destruction errors",
 )
 
+# FE get_info RPC metrics.
+metric_get_info_rpc_latency: prometheus_client.Histogram = (
+    latency_metric_for_fast_operation(
+        "function_executor_get_info_rpc", "Function Executor get_info RPC"
+    )
+)
+metric_get_info_rpc_errors: prometheus_client.Counter = prometheus_client.Counter(
+    "function_executor_get_info_rpc_errors",
+    "Number of Function Executor get_info RPC errors",
+)
+metric_function_executor_infos: prometheus_client.Counter = prometheus_client.Counter(
+    "function_executor_infos",
+    "Number of Function Executors with particular info",
+    ["version", "sdk_version", "sdk_language", "sdk_language_version"],
+)
+
 # FE initialization RPC metrics.
 metric_initialize_rpc_latency: prometheus_client.Histogram = (
     latency_metric_for_customer_controlled_operation(

--- a/indexify/tests/executor/test_metrics.py
+++ b/indexify/tests/executor/test_metrics.py
@@ -1,3 +1,5 @@
+import importlib.metadata
+import sys
 import unittest
 from typing import Dict, List, Optional
 
@@ -146,6 +148,11 @@ class TestMetrics(unittest.TestCase):
             "function_executor_destroy_channel_latency_seconds_count",
             "function_executor_destroy_channel_latency_seconds_sum",
             "function_executor_destroy_channel_errors_total",
+            #
+            "function_executor_get_info_rpc_latency_seconds_count",
+            "function_executor_get_info_rpc_latency_seconds_sum",
+            "function_executor_get_info_rpc_errors_total",
+            "function_executor_infos_total",
             #
             "function_executor_initialize_rpc_latency_seconds_count",
             "function_executor_initialize_rpc_latency_seconds_sum",
@@ -329,6 +336,19 @@ class TestMetrics(unittest.TestCase):
             SampleDiff("function_executor_establish_channel_errors_total", {}, 0.0),
             #
             SampleDiff("function_executor_destroy_channel_errors_total", {}, 0.0),
+            #
+            SampleDiff("function_executor_get_info_rpc_errors_total", {}, 0.0),
+            SampleDiff("function_executor_get_info_rpc_latency_seconds_count", {}, 1.0),
+            SampleDiff(
+                "function_executor_infos_total",
+                {
+                    "version": "0.1.0",
+                    "sdk_version": importlib.metadata.version("tensorlake"),
+                    "sdk_language": "python",
+                    "sdk_language_version": f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}",
+                },
+                1.0,
+            ),
             #
             SampleDiff(
                 "function_executor_initialize_rpc_latency_seconds_count", {}, 1.0


### PR DESCRIPTION
Example metric sample:

```
function_executor_infos_total{sdk_language="python",sdk_language_version="3.9.21",sdk_version="0.1.22",version="0.1.0"} 2.0
```

This will allow us to know info about Function Executors that we're running not from a local file system e.g. if they are from a container or a VM image.