### PR TITLE
Tests for distribution of invocations between Executors by Server

### DIFF
--- a/indexify/tests/cli/test_disable_automatic_container_management.py
+++ b/indexify/tests/cli/test_disable_automatic_container_management.py
@@ -1,21 +1,15 @@
-import os
-import platform
 import subprocess
 import unittest
 
+import testing
 from tensorlake import Graph, tensorlake_function
 from tensorlake.remote_graph import RemoteGraph
 from testing import (
     ExecutorProcessContextManager,
+    function_executor_id,
     test_graph_name,
     wait_executor_startup,
 )
-
-
-def function_executor_id() -> str:
-    # PIDs are good for Subprocess Function Executors.
-    # Hostnames are good for Function Executors running in VMs and containers.
-    return str(os.getpid()) + str(platform.node())
 
 
 @tensorlake_function()
@@ -31,7 +25,7 @@ class TestDisabledAutomaticContainerManagement(unittest.TestCase):
             start_node=get_function_executor_id,
             version="1.0",
         )
-        graph_v1 = RemoteGraph.deploy(graph_v1)
+        graph_v1 = RemoteGraph.deploy(graph_v1, additional_modules=[testing])
 
         invocation_id = graph_v1.run(block_until_done=True)
         output = graph_v1.output(invocation_id, "get_function_executor_id")
@@ -71,7 +65,7 @@ class TestDisabledAutomaticContainerManagement(unittest.TestCase):
                 start_node=get_function_executor_id,
                 version="2.0",
             )
-            graph_v2 = RemoteGraph.deploy(graph_v2)
+            graph_v2 = RemoteGraph.deploy(graph_v2, additional_modules=[testing])
 
             success_fe_ids_v2 = []
             for _ in range(10):

--- a/indexify/tests/cli/test_server.py
+++ b/indexify/tests/cli/test_server.py
@@ -1,0 +1,188 @@
+import subprocess
+import time
+import unittest
+from typing import List
+
+import testing
+from tensorlake import Graph, tensorlake_function
+from tensorlake.remote_graph import RemoteGraph
+from testing import (
+    ExecutorProcessContextManager,
+    executor_pid,
+    test_graph_name,
+    wait_executor_startup,
+)
+
+
+@tensorlake_function()
+def get_executor_pid(sleep_secs: float) -> str:
+    time.sleep(sleep_secs)
+    return executor_pid()
+
+
+@tensorlake_function()
+def success_func(sleep_secs: float) -> str:
+    time.sleep(sleep_secs)
+    return "success"
+
+
+class TestServer(unittest.TestCase):
+    def test_server_distributes_invocations_fairly_between_two_executors(self):
+        print(
+            "Waiting for 10 seconds for Server to notice that any previously existing Executors exited."
+        )
+        time.sleep(10)
+
+        with ExecutorProcessContextManager(
+            [
+                "--dev",
+                "--ports",
+                "60000",
+                "60001",
+                "--monitoring-server-port",
+                "7001",
+            ],
+            keep_std_outputs=False,
+        ) as executor_a:
+            executor_a: subprocess.Popen
+            print(f"Started Executor A with PID: {executor_a.pid}")
+            wait_executor_startup(7001)
+
+            graph = Graph(
+                name=test_graph_name(self),
+                description="test",
+                start_node=get_executor_pid,
+            )
+            graph = RemoteGraph.deploy(graph, additional_modules=[testing])
+
+            invocations_per_pid = {}
+            invocation_ids: List[str] = []
+            # Run many invokes to collect enough samples.
+            for _ in range(200):
+                invocation_id = graph.run(block_until_done=False, sleep_secs=0)
+                invocation_ids.append(invocation_id)
+
+            # Let all the invocations finish in at least (0.02 sec * 200) = 4 seconds + 1 sec
+            # for any overheads.
+            print("Waiting 5 secs for all invocations to finish.")
+            time.sleep(5)
+
+            for invocation_id in invocation_ids:
+                output = graph.output(invocation_id, "get_executor_pid")
+                self.assertEqual(len(output), 1)
+                executor_pid = output[0]
+                if executor_pid not in invocations_per_pid:
+                    invocations_per_pid[executor_pid] = 0
+                invocations_per_pid[executor_pid] += 1
+
+            for pid, invocations_count in invocations_per_pid.items():
+                print(f"Executor PID: {pid}, invocations count:{invocations_count}")
+
+            for _, invocations_count in invocations_per_pid.items():
+                # Allow +-25 invocations difference between the executors.
+                self.assertGreater(invocations_count, 75)
+                self.assertLess(invocations_count, 125)
+
+    def test_server_redistributes_invocations_when_new_executor_joins(self):
+        print(
+            "Waiting for 10 seconds for Server to notice that any previously existing Executors exited."
+        )
+        time.sleep(10)
+
+        graph = Graph(
+            name=test_graph_name(self),
+            description="test",
+            start_node=get_executor_pid,
+        )
+        graph = RemoteGraph.deploy(graph, additional_modules=[testing])
+
+        invocations_per_pid = {}
+        invocation_ids: List[str] = []
+        # Run many invokes to collect enough samples.
+        for _ in range(200):
+            invocation_id = graph.run(block_until_done=False, sleep_secs=0.1)
+            invocation_ids.append(invocation_id)
+
+        with ExecutorProcessContextManager(
+            [
+                "--dev",
+                "--ports",
+                "60000",
+                "60001",
+                "--monitoring-server-port",
+                "7001",
+            ],
+            keep_std_outputs=False,
+        ) as executor_a:
+            executor_a: subprocess.Popen
+            print(f"Started Executor A with PID: {executor_a.pid}")
+            wait_executor_startup(7001)
+
+            # Let all the invocations finish in at least (0.1 sec * 200) = 20 seconds + 10 sec
+            # for any overheads.
+            print("Waiting 30 secs for all invocations to finish.")
+            time.sleep(30)
+
+            for invocation_id in invocation_ids:
+                output = graph.output(invocation_id, "get_executor_pid")
+                self.assertEqual(len(output), 1)
+                executor_pid = output[0]
+                if executor_pid not in invocations_per_pid:
+                    invocations_per_pid[executor_pid] = 0
+                invocations_per_pid[executor_pid] += 1
+
+            for pid, invocations_count in invocations_per_pid.items():
+                print(f"Executor PID: {pid}, invocations count:{invocations_count}")
+
+            for _, invocations_count in invocations_per_pid.items():
+                # At least 25% to 75% of all tasks should go to each executor after the new executor joins.
+                self.assertGreater(invocations_count, 50)
+                self.assertLess(invocations_count, 150)
+
+    def test_all_tasks_succeed_when_executor_exits(self):
+        print(
+            "Waiting for 10 seconds for Server to notice that any previously existing Executors exited."
+        )
+        time.sleep(10)
+
+        with ExecutorProcessContextManager(
+            [
+                "--dev",
+                "--ports",
+                "60000",
+                "60001",
+                "--monitoring-server-port",
+                "7001",
+            ],
+            keep_std_outputs=False,
+        ) as executor_a:
+            executor_a: subprocess.Popen
+            print(f"Started Executor A with PID: {executor_a.pid}")
+            wait_executor_startup(7001)
+
+            graph = Graph(
+                name=test_graph_name(self),
+                description="test",
+                start_node=success_func,
+            )
+            graph = RemoteGraph.deploy(graph, additional_modules=[testing])
+
+            invocation_ids: List[str] = []
+            # Run many invokes to collect enough samples.
+            for _ in range(200):
+                invocation_id = graph.run(block_until_done=False, sleep_secs=0.1)
+                invocation_ids.append(invocation_id)
+
+        # Let all the invocations finish in at least (0.1 sec * 200) = 20 seconds + 10 sec
+        # for any overheads.
+        print("Waiting 30 secs for all invocations to finish.")
+        time.sleep(30)
+
+        for invocation_id in invocation_ids:
+            output = graph.output(invocation_id, "success_func")
+            self.assertEqual(len(output), 1)
+            self.assertEqual(output[0], "success")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/indexify/tests/cli/testing.py
+++ b/indexify/tests/cli/testing.py
@@ -1,3 +1,4 @@
+import os
 import subprocess
 import unittest
 from typing import List, Optional
@@ -22,13 +23,18 @@ def function_uri(namespace: str, graph: str, function: str, version: str) -> str
 
 
 class ExecutorProcessContextManager:
-    def __init__(self, args: List[str]):
+    def __init__(self, args: List[str], keep_std_outputs: bool = True):
         self._args = ["indexify-cli", "executor"]
         self._args.extend(args)
+        self._keep_std_outputs = keep_std_outputs
         self._process: Optional[subprocess.Popen] = None
 
     def __enter__(self) -> subprocess.Popen:
-        self._process = subprocess.Popen(self._args)
+        kwargs = {}
+        if not self._keep_std_outputs:
+            kwargs["stdout"] = subprocess.DEVNULL
+            kwargs["stderr"] = subprocess.DEVNULL
+        self._process = subprocess.Popen(self._args, **kwargs)
         return self._process
 
     def __exit__(self, exc_type, exc_value, traceback):
@@ -56,3 +62,13 @@ def wait_executor_startup(port: int):
 
         attempts_left -= 1
         time.sleep(1)
+
+
+def executor_pid() -> int:
+    # Assuming Subprocess Function Executors are used in Open Source.
+    return os.getppid()
+
+
+def function_executor_id() -> str:
+    # PIDs are good for Subprocess Function Executors.
+    return os.getpid()


### PR DESCRIPTION
Testing a few typical scenarios that happen in production.

The tests depend on timings quite a lot. We'd delete them if they end up being flaky.
It's better to rewrite them in the future as deterministic server unit tests.

The test fails currently due to the known issue:

```
======================================================================
FAIL: test_server_redistributes_invocations_when_new_executor_joins (__main__.TestServer)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/runner/work/indexify/indexify/indexify/tests/./cli/test_server.py", line 140, in test_server_redistributes_invocations_when_new_executor_joins
    self.assertLess(invocations_count, 150)
AssertionError: 200 not less than 150
----------------------------------------------------------------------
Ran 3 tests in 127.851s
FAILED (failures=1)
```
