### PR TITLE
Exit with tests exit code in run_tests.sh

### DIFF
--- a/indexify/tests/run_tests.sh
+++ b/indexify/tests/run_tests.sh
@@ -42,3 +42,5 @@ if [ $tests_exit_code -eq 0 ]; then
 else
   echo "One or more tests failed. Please check output log for details."
 fi
+
+exit $tests_exit_code


### PR DESCRIPTION
I somehow dropped this line when I moved Function Executor into SDK.
