### PR TITLE
Wait for Executor startup for up to 5 secs

### DIFF
--- a/indexify/tests/cli/testing.py
+++ b/indexify/tests/cli/testing.py
@@ -55,4 +55,4 @@ def wait_executor_startup(port: int):
                 raise
 
         attempts_left -= 1
-        time.sleep(0.1)
+        time.sleep(1)


### PR DESCRIPTION
Looks like the tests are failing now because Executor startups got slower. It's okay for Executors to startup in 5 secs.
