### PR TITLE
prepare patch release 0.2.31

### DIFF
--- a/.github/workflows/publish_indexify_server.yaml
+++ b/.github/workflows/publish_indexify_server.yaml
@@ -22,7 +22,6 @@ permissions:
   contents: write
   actions: write
   packages: write
-  
 
 env:
   CARGO_TERM_COLOR: always
@@ -34,6 +33,8 @@ defaults:
 jobs:
   build-release-packages:
     uses: ./.github/workflows/wf_build_indexify_server_release_packages.yaml
+    with:
+      ref: ${{ inputs.ref }}
 
   extract-version:
     name: Extract Version Number
@@ -43,7 +44,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - id: version_extraction
-        run: echo "version=$(cargo metadata --format-version 1 | jq '.packages[] | select(.name == "indexify-server") | .version' | xargs)" >> "$GITHUB_OUTPUT"
+        run:
+          echo "version=$(cargo metadata --format-version 1 | jq '.packages[] |
+          select(.name == "indexify-server") | .version' | xargs)" >>
+          "$GITHUB_OUTPUT"
 
   create-release:
     name: Create GitHub Release
@@ -72,8 +76,9 @@ jobs:
         id: create_release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: "v${{ needs.extract-version.outputs.version }}"
+          tag_name: 'v${{ needs.extract-version.outputs.version }}'
           prerelease: ${{ github.event.inputs.prerelease }}
+          target_commitish: ${{ inputs.ref }}
 
       #- name: Upload Windows Binary
       #  uses: actions/upload-release-asset@v1
@@ -88,8 +93,12 @@ jobs:
         uses: actions/upload-release-asset@v1
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: /tmp/release/indexify-server-${{ needs.extract-version.outputs.version }}-linux-amd64
-          asset_name: indexify-server-${{ needs.extract-version.outputs.version }}-linux-amd64
+          asset_path:
+            /tmp/release/indexify-server-${{
+            needs.extract-version.outputs.version }}-linux-amd64
+          asset_name:
+            indexify-server-${{ needs.extract-version.outputs.version
+            }}-linux-amd64
           asset_content_type: application/octet-stream
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -97,8 +106,12 @@ jobs:
         uses: actions/upload-release-asset@v1
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: /tmp/release/indexify-server-${{ needs.extract-version.outputs.version }}-darwin-arm64
-          asset_name: indexify-server-${{ needs.extract-version.outputs.version }}-darwin-arm64
+          asset_path:
+            /tmp/release/indexify-server-${{
+            needs.extract-version.outputs.version }}-darwin-arm64
+          asset_name:
+            indexify-server-${{ needs.extract-version.outputs.version
+            }}-darwin-arm64
           asset_content_type: application/octet-stream
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -115,8 +128,12 @@ jobs:
         uses: actions/upload-release-asset@v1
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: /tmp/release/indexify-server-${{ needs.extract-version.outputs.version }}-linux-amd64.deb
-          asset_name: indexify-server-${{ needs.extract-version.outputs.version }}-linux-amd64.deb
+          asset_path:
+            /tmp/release/indexify-server-${{
+            needs.extract-version.outputs.version }}-linux-amd64.deb
+          asset_name:
+            indexify-server-${{ needs.extract-version.outputs.version
+            }}-linux-amd64.deb
           asset_content_type: application/octet-stream
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -124,8 +141,12 @@ jobs:
         uses: actions/upload-release-asset@v1
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: /tmp/release/indexify-server-${{ needs.extract-version.outputs.version }}-linux-arm64.deb
-          asset_name: indexify-server-${{ needs.extract-version.outputs.version }}-linux-arm64.deb
+          asset_path:
+            /tmp/release/indexify-server-${{
+            needs.extract-version.outputs.version }}-linux-arm64.deb
+          asset_name:
+            indexify-server-${{ needs.extract-version.outputs.version
+            }}-linux-arm64.deb
           asset_content_type: application/octet-stream
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -156,6 +177,8 @@ jobs:
       - create-release
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Login to Docker Hub

--- a/.github/workflows/wf_build_indexify_server_release_packages.yaml
+++ b/.github/workflows/wf_build_indexify_server_release_packages.yaml
@@ -2,6 +2,12 @@ name: Build Indexify Server Release Packages
 
 on:
   workflow_call:
+    inputs:
+      ref:
+        type: string
+        description: The ref to checkout before running the workflow
+        required: false
+        default: main
 
 env:
   CARGO_TERM_COLOR: always
@@ -16,6 +22,8 @@ jobs:
     runs-on: ubuntu-latest-xlarge
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
       - run: rustup toolchain install nightly --component rustfmt
       - run: cargo +nightly fmt --check
       - run: cargo install cargo-deb
@@ -37,6 +45,8 @@ jobs:
     runs-on: ubuntu-latest-xlarge
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
       - run: rustup toolchain install nightly --component rustfmt
       - run: cargo +nightly fmt --check
       - run: make build-release-aarch64
@@ -58,6 +68,8 @@ jobs:
     runs-on: macos-14-xlarge
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
       - run: rustup update
       - run: rustup toolchain install nightly --component rustfmt
       - run: rustup target add aarch64-apple-darwin
@@ -75,6 +87,8 @@ jobs:
   #   runs-on: macos-12
   #   steps:
   #     - uses: actions/checkout@v4
+  #       with:
+  #         ref: ${{ inputs.ref }}
   #     - run: rustup update
   #     - run: rustup toolchain install nightly --component rustfmt
   #     - run: cargo +nightly fmt --check
@@ -91,6 +105,8 @@ jobs:
   #   runs-on: windows-latest-large
   #   steps:
   #     - uses: actions/checkout@v4
+  #       with:
+  #         ref: ${{ inputs.ref }}
   #     - uses: ilammy/setup-nasm@v1
   #     - run: rustup toolchain install nightly --component rustfmt
   #     - run: cargo +nightly fmt --check

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -1512,7 +1512,7 @@ dependencies = [
 
 [[package]]
 name = "indexify-server"
-version = "0.2.30"
+version = "0.2.31"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "indexify-server"
-version = "0.2.30"
+version = "0.2.31"
 edition = "2021"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 license = "Apache-2.0"
@@ -45,7 +45,9 @@ axum-server = "0.7.1"
 tempfile = "3.16.0"
 utoipa = { version = "5.3.1", features = ["axum_extras"] }
 utoipa-swagger-ui = { version = "9.0.0", features = ["axum"] }
-object_store = {git = "https://github.com/tensorlakeai/arrow-rs", branch="remove-obj-store-log", features=["aws"]}
+object_store = { git = "https://github.com/tensorlakeai/arrow-rs", branch = "remove-obj-store-log", features = [
+    "aws",
+] }
 futures = "0.3.31"
 bytes = "1.9.0"
 pin-project-lite = "0.2.16"

--- a/server/processor/src/graph_processor.rs
+++ b/server/processor/src/graph_processor.rs
@@ -86,11 +86,10 @@ impl GraphProcessor {
         // 1. First load 100 state changes. Process the `global` state changes first
         // and then the `ns_` state changes
         if cached_state_changes.is_empty() {
-            let unprocessed_state_changes =
-                self.indexify_state.reader().unprocessed_state_changes(
-                    &last_global_state_change_cursor,
-                    &last_namespace_state_change_cursor,
-                )?;
+            let unprocessed_state_changes = self
+                .indexify_state
+                .reader()
+                .unprocessed_state_changes(&None, &None)?;
             let _ = match unprocessed_state_changes.last_global_state_change_cursor {
                 Some(cursor) => {
                     last_global_state_change_cursor.replace(cursor);


### PR DESCRIPTION
A scaling bug in 0.2.30 requires a patch release for it.

We have 2 bugs with processing state changes: when dealing with namespaces, it is possible for a given namespace to never have its state changes processed. It is possible for some state changes to be never processed because of rocksdb lexicographic ordering of keys.

This fix removes the pagination optimization which will fix these issues until we bring it back soon.