### PR TITLE
Update tensorlake SDK version to fix test failures

### DIFF
--- a/indexify/poetry.lock
+++ b/indexify/poetry.lock
@@ -1673,14 +1673,14 @@ typing = ["mypy (>=1.4)", "rich", "twisted"]
 
 [[package]]
 name = "tensorlake"
-version = "0.1.23"
+version = "0.1.27"
 description = "Tensorlake SDK for Document Ingestion API and Serverless Workflows"
 optional = false
 python-versions = "<4.0,>=3.9"
 groups = ["main"]
 files = [
-    {file = "tensorlake-0.1.23-py3-none-any.whl", hash = "sha256:b9318b37148fd41b997e12472eb41b9d23119b58dee63cbd8b64237ea3d6c84f"},
-    {file = "tensorlake-0.1.23.tar.gz", hash = "sha256:45b736347a2bc142d9f5ab59a85e9899d77c4e54f270ee514a116e2082fc590b"},
+    {file = "tensorlake-0.1.27-py3-none-any.whl", hash = "sha256:cce10ff4223de27f0187b73a04a2a80cfc3f10008ea6ec6f084894fd1b03ec3c"},
+    {file = "tensorlake-0.1.27.tar.gz", hash = "sha256:cd16519a48fa0498d1dbc29e248f6829c085fe87a68d5d81e7d831c50e02eb25"},
 ]
 
 [package.dependencies]


### PR DESCRIPTION
The newest SDK has a bugfix that makes it work with the latest Server