### PR TITLE
Remove use ::from_env() instead of explicitly copying config. 

### DIFF
--- a/server/blob_store/src/lib.rs
+++ b/server/blob_store/src/lib.rs
@@ -82,28 +82,12 @@ impl BlobStorage {
             ObjectStoreScheme::AmazonS3 => {
                 // inject AWS environment variables to prioritize keys over instance metadata
                 // credentials.
-                let opts: Vec<(AmazonS3ConfigKey, String)> = std::env::vars_os()
-                    .filter_map(|(os_key, os_value)| {
-                        if let (Some(key), Some(value)) = (os_key.to_str(), os_value.to_str()) {
-                            if key.starts_with("AWS_") {
-                                if let Ok(config_key) = key.to_ascii_lowercase().parse() {
-                                    return Some((config_key, String::from(value)));
-                                }
-                            }
-                        }
-                        None
-                    })
-                    .collect();
-
-                let mut s3_builder = AmazonS3Builder::new().with_url(url_str);
-                for (key, value) in opts.iter() {
-                    s3_builder = s3_builder.with_config(*key, value.clone());
-                }
-                let s3_builder = s3_builder
+                let s3_builder = AmazonS3Builder::from_env()
+                    .with_url(url_str)
                     .with_conditional_put(S3ConditionalPut::ETagMatch)
                     .build()
                     .expect("failed to create object store");
-                let (_, path) = parse_url_opts(url, opts)?;
+                let (_, path) = parse_url(url)?;
                 Ok((Box::new(s3_builder), path))
             }
             _ => Ok(parse_url(url)?),

--- a/server/blob_store/src/lib.rs
+++ b/server/blob_store/src/lib.rs
@@ -5,9 +5,8 @@ use bytes::{Bytes, BytesMut};
 use futures::{stream::BoxStream, StreamExt};
 use metrics::{blob_storage, Timer};
 use object_store::{
-    aws::{AmazonS3Builder, AmazonS3ConfigKey, S3ConditionalPut},
+    aws::{AmazonS3Builder, S3ConditionalPut},
     parse_url,
-    parse_url_opts,
     path::Path,
     ObjectStore,
     ObjectStoreScheme,


### PR DESCRIPTION
## Context

This is part of an effort to get indexify-server to use AWS roles. As it turns out there doesn't need to be any code changes and the library [supports using roles.](https://github.com/apache/arrow-rs/blob/main/object_store/src/aws/credential.rs#L616). 

The proper env vars are set when using the IRSA OIDC provider in EKS. See [AWS's guidance](https://docs.aws.amazon.com/eks/latest/userguide/associate-service-account-role.html) on how to do this. Also an example of how to accomplish it via terraform is [here](https://surajblog.medium.com/aws-iam-roles-for-service-accounts-irsa-with-terraform-a870765def0e)


<!--
In a few sentences or less, please explain the context behind this change to help answer why this change is needed.

If this is a bug fix, make sure to include "fixes #xxxx", or
"closes #xxxx".

Screenshots, logs, code or other visual aids are greatly appreciated.
 -->

## What

This cleans up object_storage initialization by letting the builder configure from the environment. 

<!--
In a few sentences, please summarize the change to help reviewers.

Consider providing screenshots, logs, code or other visual aids to help the reviewer understand the approach taken.
-->

## Testing

<!--
Please include steps used to verify the change.

Consider providing screenshots, logs, code or other visual aids to help the reviewer in their testing.
-->

## Contribution Checklist

- [ ] If a Python package was changed, please run `make fmt` in the package directory.
- [ ] If the server was changed, please run `make fmt` in `server/`.
- [ ] Make sure all PR Checks are passing.
<!--
Notes:

Tests of a Python package can be run manually. Start a Server and an Executor then
run `make test` in the Python package directory.

To test if changes to the server are backward compatible with the latest
release, label the PR with `ci_compat_test`. This might report failures
unrelated to your change if previous incompatible changes were pushed without
being released yet
-->
