### PR TITLE
Fix graph deletion

### DIFF
--- a/server/data_model/src/lib.rs
+++ b/server/data_model/src/lib.rs
@@ -1289,6 +1289,19 @@ impl StateChange {
     }
 }
 
+impl Display for StateChange {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "StateChange: namespace:{},  id: {}, change_type: {}, created_at: {}",
+            self.namespace.as_ref().unwrap_or(&"global".to_string()),
+            self.id,
+            self.change_type,
+            self.created_at,
+        )
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Namespace {
     pub name: String,

--- a/server/processor/src/graph_processor.rs
+++ b/server/processor/src/graph_processor.rs
@@ -161,7 +161,7 @@ impl GraphProcessor {
         &self,
         state_change: &StateChange,
     ) -> Result<StateMachineUpdateRequest> {
-        info!("processing state change: {}", state_change.change_type);
+        info!("processing state change: {}", state_change);
         let mut indexes = self.indexify_state.in_memory_state.read().await.clone();
         match &state_change.change_type {
             ChangeType::InvokeComputeGraph(_) | ChangeType::TaskOutputsIngested(_) => {

--- a/server/state_store/src/in_memory_state.rs
+++ b/server/state_store/src/in_memory_state.rs
@@ -288,16 +288,16 @@ impl InMemoryState {
             }
             RequestPayload::DeleteInvocationRequest(req) => {
                 // Remove tasks
-                let key = Task::key_prefix_for_invocation(
+                let key_prefix = Task::key_prefix_for_invocation(
                     &req.namespace,
                     &req.compute_graph,
                     &req.invocation_id,
                 );
                 let mut tasks_to_remove = Vec::new();
                 self.tasks
-                    .range(key.clone()..)
+                    .range(key_prefix.clone()..)
                     .into_iter()
-                    .take_while(|(k, _v)| k.starts_with(&key))
+                    .take_while(|(k, _v)| k.starts_with(&key_prefix))
                     .for_each(|(k, _v)| {
                         tasks_to_remove.push(k.clone());
                     });
@@ -306,7 +306,7 @@ impl InMemoryState {
                 }
 
                 // Remove invocation ctx
-                self.invocation_ctx.remove(&key);
+                self.invocation_ctx.remove(&key_prefix);
 
                 // Remove allocations
                 let mut allocations_to_remove = Vec::new();
@@ -324,7 +324,7 @@ impl InMemoryState {
                 // Remove unallocated tasks
                 let mut unallocated_tasks_to_remove = Vec::new();
                 for (k, _v) in self.unallocated_tasks.iter() {
-                    if k.starts_with(&key) {
+                    if k.starts_with(&key_prefix) {
                         unallocated_tasks_to_remove.push(k.clone());
                     }
                 }
@@ -335,7 +335,7 @@ impl InMemoryState {
                 // Remove queued reduction tasks
                 let mut queued_reduction_tasks_to_remove = Vec::new();
                 for (k, _v) in self.queued_reduction_tasks.iter() {
-                    if k.starts_with(&key) {
+                    if k.starts_with(&key_prefix) {
                         queued_reduction_tasks_to_remove.push(k.clone());
                     }
                 }

--- a/server/state_store/src/in_memory_state.rs
+++ b/server/state_store/src/in_memory_state.rs
@@ -287,62 +287,8 @@ impl InMemoryState {
                 }
             }
             RequestPayload::DeleteInvocationRequest(req) => {
-                // Remove tasks
-                let key_prefix = Task::key_prefix_for_invocation(
-                    &req.namespace,
-                    &req.compute_graph,
-                    &req.invocation_id,
-                );
-                let mut tasks_to_remove = Vec::new();
-                self.tasks
-                    .range(key_prefix.clone()..)
-                    .into_iter()
-                    .take_while(|(k, _v)| k.starts_with(&key_prefix))
-                    .for_each(|(k, _v)| {
-                        tasks_to_remove.push(k.clone());
-                    });
-                for task in tasks_to_remove {
-                    self.tasks.remove(&task);
-                }
-
-                // Remove invocation ctx
-                self.invocation_ctx.remove(&key_prefix);
-
-                // Remove allocations
-                let mut allocations_to_remove = Vec::new();
-                for (_executor, allocations) in self.allocations_by_executor.iter() {
-                    allocations.iter().for_each(|allocation| {
-                        if allocation.invocation_id == req.invocation_id {
-                            allocations_to_remove.push(allocation.id.clone());
-                        }
-                    });
-                }
-                for allocation in allocations_to_remove {
-                    self.allocations_by_executor.remove(&allocation);
-                }
-
-                // Remove unallocated tasks
-                let mut unallocated_tasks_to_remove = Vec::new();
-                for (k, _v) in self.unallocated_tasks.iter() {
-                    if k.starts_with(&key_prefix) {
-                        unallocated_tasks_to_remove.push(k.clone());
-                    }
-                }
-                for k in unallocated_tasks_to_remove {
-                    self.unallocated_tasks.remove(&k);
-                }
-
-                // Remove queued reduction tasks
-                let mut queued_reduction_tasks_to_remove = Vec::new();
-                for (k, _v) in self.queued_reduction_tasks.iter() {
-                    if k.starts_with(&key_prefix) {
-                        queued_reduction_tasks_to_remove.push(k.clone());
-                    }
-                }
-                for k in queued_reduction_tasks_to_remove {
-                    self.queued_reduction_tasks.remove(&k);
-                }
-            }
+                self.delete_invocation(&req.namespace, &req.compute_graph, &req.invocation_id);
+           }
             RequestPayload::DeleteComputeGraphRequest(req) => {
                 let key = ComputeGraph::key_from(&req.namespace, &req.name);
                 self.compute_graphs.remove(&key);
@@ -363,8 +309,12 @@ impl InMemoryState {
                     .take_while(|(k, _v)| k.starts_with(&key))
                     .map(|(k, _v)| k.clone())
                     .collect::<Vec<String>>();
+                let mut invocations_to_remove = Vec::new();
                 for k in keys_to_remove {
-                    self.invocation_ctx.remove(&k);
+                    invocations_to_remove.push(k);
+                }
+                for k in invocations_to_remove {
+                    self.delete_invocation(&req.namespace, &req.name, &k);
                 }
             }
             RequestPayload::SchedulerUpdate(req) => {
@@ -471,6 +421,65 @@ impl InMemoryState {
                 &[KeyValue::new("executor_id", executor_id.to_string())],
             );
         }
+    }
+
+    pub fn delete_invocation(&mut self, namespace: &str, compute_graph: &str, invocation_id: &str) {
+                // Remove tasks
+                let key_prefix = Task::key_prefix_for_invocation(
+                    &namespace,
+                    &compute_graph,
+                    &invocation_id,
+                );
+                let mut tasks_to_remove = Vec::new();
+                self.tasks
+                    .range(key_prefix.clone()..)
+                    .into_iter()
+                    .take_while(|(k, _v)| k.starts_with(&key_prefix))
+                    .for_each(|(k, _v)| {
+                        tasks_to_remove.push(k.clone());
+                    });
+                for task in tasks_to_remove {
+                    self.tasks.remove(&task);
+                }
+
+                // Remove invocation ctx
+                self.invocation_ctx.remove(&key_prefix);
+
+                // Remove allocations
+                let mut allocations_to_remove = Vec::new();
+                for (_executor, allocations) in self.allocations_by_executor.iter() {
+                    allocations.iter().for_each(|allocation| {
+                        if allocation.invocation_id == invocation_id {
+                            allocations_to_remove.push(allocation.id.clone());
+                        }
+                    });
+                }
+                for allocation in allocations_to_remove {
+                    self.allocations_by_executor.remove(&allocation);
+                }
+
+                // Remove unallocated tasks
+                let mut unallocated_tasks_to_remove = Vec::new();
+                for (k, _v) in self.unallocated_tasks.iter() {
+                    if k.starts_with(&key_prefix) {
+                        unallocated_tasks_to_remove.push(k.clone());
+                    }
+                }
+                for k in unallocated_tasks_to_remove {
+                    self.unallocated_tasks.remove(&k);
+                }
+
+                // Remove queued reduction tasks
+                let mut queued_reduction_tasks_to_remove = Vec::new();
+                for (k, _v) in self.queued_reduction_tasks.iter() {
+                    if k.starts_with(&key_prefix) {
+                        queued_reduction_tasks_to_remove.push(k.clone());
+                    }
+                }
+                for k in queued_reduction_tasks_to_remove {
+                    self.queued_reduction_tasks.remove(&k);
+                }
+ 
     }
 
     pub fn clone(&self) -> Box<Self> {

--- a/server/state_store/src/in_memory_state.rs
+++ b/server/state_store/src/in_memory_state.rs
@@ -288,7 +288,7 @@ impl InMemoryState {
             }
             RequestPayload::DeleteInvocationRequest(req) => {
                 self.delete_invocation(&req.namespace, &req.compute_graph, &req.invocation_id);
-           }
+            }
             RequestPayload::DeleteComputeGraphRequest(req) => {
                 let key = ComputeGraph::key_from(&req.namespace, &req.name);
                 self.compute_graphs.remove(&key);
@@ -424,62 +424,58 @@ impl InMemoryState {
     }
 
     pub fn delete_invocation(&mut self, namespace: &str, compute_graph: &str, invocation_id: &str) {
-                // Remove tasks
-                let key_prefix = Task::key_prefix_for_invocation(
-                    &namespace,
-                    &compute_graph,
-                    &invocation_id,
-                );
-                let mut tasks_to_remove = Vec::new();
-                self.tasks
-                    .range(key_prefix.clone()..)
-                    .into_iter()
-                    .take_while(|(k, _v)| k.starts_with(&key_prefix))
-                    .for_each(|(k, _v)| {
-                        tasks_to_remove.push(k.clone());
-                    });
-                for task in tasks_to_remove {
-                    self.tasks.remove(&task);
-                }
+        // Remove tasks
+        let key_prefix =
+            Task::key_prefix_for_invocation(&namespace, &compute_graph, &invocation_id);
+        let mut tasks_to_remove = Vec::new();
+        self.tasks
+            .range(key_prefix.clone()..)
+            .into_iter()
+            .take_while(|(k, _v)| k.starts_with(&key_prefix))
+            .for_each(|(k, _v)| {
+                tasks_to_remove.push(k.clone());
+            });
+        for task in tasks_to_remove {
+            self.tasks.remove(&task);
+        }
 
-                // Remove invocation ctx
-                self.invocation_ctx.remove(&key_prefix);
+        // Remove invocation ctx
+        self.invocation_ctx.remove(&key_prefix);
 
-                // Remove allocations
-                let mut allocations_to_remove = Vec::new();
-                for (_executor, allocations) in self.allocations_by_executor.iter() {
-                    allocations.iter().for_each(|allocation| {
-                        if allocation.invocation_id == invocation_id {
-                            allocations_to_remove.push(allocation.id.clone());
-                        }
-                    });
+        // Remove allocations
+        let mut allocations_to_remove = Vec::new();
+        for (_executor, allocations) in self.allocations_by_executor.iter() {
+            allocations.iter().for_each(|allocation| {
+                if allocation.invocation_id == invocation_id {
+                    allocations_to_remove.push(allocation.id.clone());
                 }
-                for allocation in allocations_to_remove {
-                    self.allocations_by_executor.remove(&allocation);
-                }
+            });
+        }
+        for allocation in allocations_to_remove {
+            self.allocations_by_executor.remove(&allocation);
+        }
 
-                // Remove unallocated tasks
-                let mut unallocated_tasks_to_remove = Vec::new();
-                for (k, _v) in self.unallocated_tasks.iter() {
-                    if k.starts_with(&key_prefix) {
-                        unallocated_tasks_to_remove.push(k.clone());
-                    }
-                }
-                for k in unallocated_tasks_to_remove {
-                    self.unallocated_tasks.remove(&k);
-                }
+        // Remove unallocated tasks
+        let mut unallocated_tasks_to_remove = Vec::new();
+        for (k, _v) in self.unallocated_tasks.iter() {
+            if k.starts_with(&key_prefix) {
+                unallocated_tasks_to_remove.push(k.clone());
+            }
+        }
+        for k in unallocated_tasks_to_remove {
+            self.unallocated_tasks.remove(&k);
+        }
 
-                // Remove queued reduction tasks
-                let mut queued_reduction_tasks_to_remove = Vec::new();
-                for (k, _v) in self.queued_reduction_tasks.iter() {
-                    if k.starts_with(&key_prefix) {
-                        queued_reduction_tasks_to_remove.push(k.clone());
-                    }
-                }
-                for k in queued_reduction_tasks_to_remove {
-                    self.queued_reduction_tasks.remove(&k);
-                }
- 
+        // Remove queued reduction tasks
+        let mut queued_reduction_tasks_to_remove = Vec::new();
+        for (k, _v) in self.queued_reduction_tasks.iter() {
+            if k.starts_with(&key_prefix) {
+                queued_reduction_tasks_to_remove.push(k.clone());
+            }
+        }
+        for k in queued_reduction_tasks_to_remove {
+            self.queued_reduction_tasks.remove(&k);
+        }
     }
 
     pub fn clone(&self) -> Box<Self> {


### PR DESCRIPTION
Fixing graph deletion, and using invocation deletion under the hood wherever possible.

Test - 

Ran a graph which runs a function for 5 seconds, deleted the graph, when the task is reported, the internal ingest simply ignores it. 

```
{"timestamp":"2025-02-27T00:56:25.048692Z","level":"INFO","message":"deleting compute graph: namespace: default, name: __main___TestGraphUpdate_test_running_invocation_gets_its_graph_version_updated","namespace":"default","graph":"__main___TestGraphUpdate_test_running_invocation_gets_its_graph_version_updated","target":"state_store::state_machine","span":{"request_type":"DeleteComputeGraphRequest","name":"write"}}
{"timestamp":"2025-02-27T00:56:25.054198Z","level":"INFO","message":"Returning unprocessed state changes","total":0,"global":0,"ns":0,"target":"state_store::scanner"}

{"timestamp":"2025-02-27T00:56:35.977418Z","level":"WARN","message":"task not found in state store, task_id = c691e165-da81-4226-a1ab-65a0ea0bbbe1","target":"indexify_server::routes::internal_ingest","span":{"http.request.method":"POST","http.route":"/internal/ingest_files","network.protocol.version":"1.1","otel.kind":"Server","otel.name":"POST /internal/ingest_files","server.address":"localhost:8900","span.type":"web","url.path":"/internal/ingest_files","url.scheme":"","user_agent.original":"python-httpx/0.27.2","name":"HTTP request"}}
```