### PR TITLE
ensure all invocation ctx have a created_at

### DIFF
--- a/server/processor/src/graph_processor.rs
+++ b/server/processor/src/graph_processor.rs
@@ -98,15 +98,18 @@ impl GraphProcessor {
             state_changes.reverse();
             cached_state_changes.extend(state_changes);
         }
+
         // 2. If there are no state changes to process, return
         // and wait for the scheduler to wake us up again when there are state changes
         if cached_state_changes.is_empty() {
             return Ok(());
         }
 
-        // 3. Fire a notification to wake ourselves up to see if there are more than 100
-        //    state changes
-        notify.notify_one();
+        // 3. Fire a notification when caching multiple
+        // state changes in order to process them.
+        if cached_state_changes.len() > 1 {
+            notify.notify_one();
+        }
 
         // 4. Process the next state change from the queue
         let state_change = cached_state_changes.pop().unwrap();

--- a/server/state_store/src/migrations.rs
+++ b/server/state_store/src/migrations.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, sync::Arc};
+use std::sync::Arc;
 
 use anyhow::{Context, Result};
 use data_model::StateMachineMetadata;


### PR DESCRIPTION
## Context

<!--
In a few sentences or less, please explain the context behind this change to help answer why this change is needed.

If this is a bug fix, make sure to include "fixes #xxxx", or
"closes #xxxx".

Screenshots, logs, code or other visual aids are greatly appreciated.
 -->

As part of improving APIs we change list invocations to return invocation ctx data. Unfortunately, that meant adding a created at to graph invocation context that was not backported. This resulted in random order of invocations.

## What

Set the invocation ct date from the invocation payload.

<!--
In a few sentences, please summarize the change to help reviewers.

Consider providing screenshots, logs, code or other visual aids to help the reviewer understand the approach taken.
-->

## Testing

<!--
Please include steps used to verify the change.

Consider providing screenshots, logs, code or other visual aids to help the reviewer in their testing.
-->

- [ ] Test using prod data

## Contribution Checklist

- [ ] If a Python package was changed, please run `make fmt` in the package directory.
- [ ] If the server was changed, please run `make fmt` in `server/`.
- [ ] Make sure all PR Checks are passing.
<!--
Notes:

Tests of a Python package can be run manually. Start a Server and an Executor then
run `make test` in the Python package directory.

To test if changes to the server are backward compatible with the latest
release, label the PR with `ci_compat_test`. This might report failures
unrelated to your change if previous incompatible changes were pushed without
being released yet
-->
