### PR TITLE
feat: limit allocations per executor to spread load

### DIFF
--- a/server/processor/src/graph_processor.rs
+++ b/server/processor/src/graph_processor.rs
@@ -105,9 +105,13 @@ impl GraphProcessor {
             return Ok(());
         }
 
-        // 3. Fire a notification when caching multiple
-        // state changes in order to process them.
-        if cached_state_changes.len() > 1 {
+        // 3. Fire a notification when handling multiple
+        // state changes in order to fill in the cache when
+        // the next state change is processed.
+        //
+        // 0 = we fetched all current state changes
+        // > 1 = we are processing cached state changes, we need to fetch more when done
+        if cached_state_changes.len() > 0 {
             notify.notify_one();
         }
 

--- a/server/processor/src/graph_processor.rs
+++ b/server/processor/src/graph_processor.rs
@@ -177,10 +177,6 @@ impl GraphProcessor {
                     .invoke(&state_change.change_type, &mut indexes)
                     .await;
                 if let Ok(mut result) = scheduler_update {
-                    result.updated_tasks.iter().for_each(|t| {
-                        indexes.tasks.insert(t.key(), Box::new(t.clone()));
-                        indexes.unallocated_tasks.insert(t.key(), [0; 0]);
-                    });
                     let placement_result = self.task_allocator.allocate(&mut indexes)?;
                     result
                         .new_allocations

--- a/server/processor/src/task_allocator.rs
+++ b/server/processor/src/task_allocator.rs
@@ -155,7 +155,6 @@ impl TaskAllocationProcessor {
                 .filter(|(k, _)| {
                     let allocations = indexes.allocations_by_executor.get(*k);
                     let allocation_count = allocations.map_or(0, |allocs| allocs.len());
-                    info!("executor {} has {} allocations", k, allocation_count);
                     allocation_count < MAX_ALLOCATIONS_PER_EXECUTOR
                 })
                 .map(|(_, v)| v)

--- a/server/processor/src/task_creator.rs
+++ b/server/processor/src/task_creator.rs
@@ -621,7 +621,6 @@ impl TaskCreator {
             }
         }
 
-        trace!("tasks: {:?}", new_tasks.len());
         invocation_ctx.create_tasks(&new_tasks);
         Ok(TaskCreationResult {
             namespace: task.namespace.clone(),

--- a/server/processor/src/task_creator.rs
+++ b/server/processor/src/task_creator.rs
@@ -70,6 +70,13 @@ impl TaskCreator {
         match change {
             ChangeType::TaskOutputsIngested(ev) => {
                 let result = self.handle_task_finished_inner(ev, indexes).await?;
+                result.tasks.iter().for_each(|t| {
+                    indexes.tasks.insert(t.key(), Box::new(t.clone()));
+                    indexes.unallocated_tasks.insert(t.key(), [0; 0]);
+                });
+                if let Some(ctx) = result.invocation_ctx.clone() {
+                    indexes.invocation_ctx.insert(ctx.key(), Box::new(ctx));
+                }
                 return Ok(SchedulerUpdateRequest {
                     new_allocations: vec![],
                     remove_allocations: vec![],
@@ -90,6 +97,13 @@ impl TaskCreator {
                 let result = self
                     .handle_invoke_compute_graph(ev.clone(), indexes)
                     .await?;
+                result.tasks.iter().for_each(|t| {
+                    indexes.tasks.insert(t.key(), Box::new(t.clone()));
+                    indexes.unallocated_tasks.insert(t.key(), [0; 0]);
+                });
+                if let Some(ctx) = result.invocation_ctx.clone() {
+                    indexes.invocation_ctx.insert(ctx.key(), Box::new(ctx));
+                }
                 return Ok(SchedulerUpdateRequest {
                     new_allocations: vec![],
                     remove_allocations: vec![],

--- a/server/src/integration_test.rs
+++ b/server/src/integration_test.rs
@@ -7,6 +7,9 @@ mod tests {
         test_objects::tests::{
             mock_executor,
             mock_executor_id,
+            mock_graph_a,
+            mock_invocation_ctx,
+            mock_invocation_payload,
             mock_invocation_payload_graph_b,
             mock_node_fn_output,
             TEST_EXECUTOR_ID,
@@ -20,8 +23,10 @@ mod tests {
     use futures::StreamExt;
     use state_store::{
         requests::{
+            CreateOrUpdateComputeGraphRequest,
             DeleteComputeGraphRequest,
             IngestTaskOutputsRequest,
+            InvokeComputeGraphRequest,
             RegisterExecutorRequest,
             RequestPayload,
             StateMachineUpdateRequest,
@@ -155,6 +160,94 @@ mod tests {
 
             assert!(invocation.completed);
         }
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_max_allocation_per_executor() -> Result<()> {
+        let test_srv = testing::TestService::new().await?;
+        let Service { indexify_state, .. } = test_srv.service.clone();
+
+        // invoke the graph
+        {
+            let cg_request = CreateOrUpdateComputeGraphRequest {
+                namespace: TEST_NAMESPACE.to_string(),
+                compute_graph: mock_graph_a("image_hash".to_string()),
+                upgrade_tasks_to_current_version: true,
+            };
+            indexify_state
+                .write(StateMachineUpdateRequest {
+                    payload: RequestPayload::CreateOrUpdateComputeGraph(cg_request),
+                    processed_state_changes: vec![],
+                })
+                .await
+                .unwrap();
+
+            for i in 0..30 {
+                let mut invocation_payload = mock_invocation_payload();
+                invocation_payload.id = format!("invocation-{}", i);
+
+                let ctx = mock_invocation_ctx(
+                    TEST_NAMESPACE,
+                    &mock_graph_a("image_hash".to_string()),
+                    &invocation_payload,
+                );
+                let request = InvokeComputeGraphRequest {
+                    namespace: TEST_NAMESPACE.to_string(),
+                    compute_graph_name: "graph_A".to_string(),
+                    invocation_payload: invocation_payload.clone(),
+                    ctx,
+                };
+                indexify_state
+                    .write(StateMachineUpdateRequest {
+                        payload: RequestPayload::InvokeComputeGraph(request),
+                        processed_state_changes: vec![],
+                    })
+                    .await
+                    .unwrap();
+            }
+
+            test_srv.process_all_state_changes().await?;
+
+            test_srv.assert_task_states(30, 0, 30, 0).await?;
+        };
+
+        // register executor1
+        {
+            let executor = test_srv.register_executor(mock_executor_id()).await?;
+
+            test_srv.process_all_state_changes().await?;
+
+            test_srv.assert_task_states(30, 20, 10, 0).await?;
+
+            let executor_tasks = executor.get_tasks().await?;
+            assert_eq!(
+                executor_tasks.len(),
+                20,
+                "Executor tasks: {:#?}",
+                executor_tasks
+            );
+        };
+
+        // register executor2
+        {
+            let executor = test_srv
+                .register_executor(ExecutorId::new("executor_2".to_string()))
+                .await?;
+
+            test_srv.process_all_state_changes().await?;
+
+            test_srv.assert_task_states(30, 30, 0, 0).await?;
+
+            let executor_tasks = executor.get_tasks().await?;
+            assert_eq!(
+                executor_tasks.len(),
+                10,
+                "Executor tasks: {:#?}",
+                executor_tasks
+            );
+        };
 
         Ok(())
     }

--- a/server/state_store/src/in_memory_state.rs
+++ b/server/state_store/src/in_memory_state.rs
@@ -35,7 +35,7 @@ pub struct InMemoryState {
     // Executor Id -> List of Task IDs
     pub allocations_by_executor: im::HashMap<String, im::Vector<Box<Allocation>>>,
 
-    // NS|CG|Fn|Inv -> Task
+    // TaskKey -> Task
     pub unallocated_tasks: im::OrdMap<String, [u8; 0]>,
 
     // Task Key -> Task
@@ -372,6 +372,8 @@ impl InMemoryState {
                 }
                 for executor_id in &req.remove_executors {
                     self.executors.remove(executor_id.get());
+                    self.allocations_by_executor
+                        .remove(&executor_id.get().to_string());
                 }
             }
             RequestPayload::RegisterExecutor(req) => {

--- a/server/state_store/src/in_memory_state.rs
+++ b/server/state_store/src/in_memory_state.rs
@@ -110,6 +110,19 @@ impl InMemoryState {
             }
         }
 
+        let mut invocation_ctx = im::OrdMap::new();
+        {
+            let all_graph_invocation_ctx: Vec<(String, GraphInvocationCtx)> =
+                reader.get_all_rows_from_cf(IndexifyObjectsColumns::GraphInvocationCtx)?;
+            for (_id, ctx) in all_graph_invocation_ctx {
+                // Do not cache completed invocations
+                if ctx.completed {
+                    continue;
+                }
+                invocation_ctx.insert(ctx.key(), Box::new(ctx));
+            }
+        }
+
         // Creating Tasks
         let mut tasks = im::OrdMap::new();
         let mut unallocated_tasks = im::OrdMap::new();
@@ -117,6 +130,18 @@ impl InMemoryState {
             let all_tasks: Vec<(String, Task)> =
                 reader.get_all_rows_from_cf(IndexifyObjectsColumns::Tasks)?;
             for (_id, task) in all_tasks {
+                // Do not cache tasks for completed invocations
+                if invocation_ctx
+                    .get(&GraphInvocationCtx::key_from(
+                        &task.namespace,
+                        &task.compute_graph_name,
+                        &task.invocation_id,
+                    ))
+                    .is_none()
+                {
+                    continue;
+                }
+
                 if task.is_terminal() {
                     continue;
                 }
@@ -127,23 +152,22 @@ impl InMemoryState {
             }
         }
 
-        let mut invocation_ctx = im::OrdMap::new();
-        {
-            let all_graph_invocation_ctx: Vec<(String, GraphInvocationCtx)> =
-                reader.get_all_rows_from_cf(IndexifyObjectsColumns::GraphInvocationCtx)?;
-            for (_id, ctx) in all_graph_invocation_ctx {
-                if ctx.completed {
-                    continue;
-                }
-                invocation_ctx.insert(ctx.key(), Box::new(ctx));
-            }
-        }
-
         let mut queued_reduction_tasks = im::OrdMap::new();
         {
             let all_reduction_tasks: Vec<(String, ReduceTask)> =
                 reader.get_all_rows_from_cf(IndexifyObjectsColumns::ReductionTasks)?;
             for (_id, task) in all_reduction_tasks {
+                // Do not cache reduction tasks for completed invocations
+                if invocation_ctx
+                    .get(&GraphInvocationCtx::key_from(
+                        &task.namespace,
+                        &task.compute_graph_name,
+                        &task.invocation_id,
+                    ))
+                    .is_none()
+                {
+                    continue;
+                }
                 queued_reduction_tasks.insert(task.key(), Box::new(task));
             }
         }
@@ -344,16 +368,16 @@ impl InMemoryState {
                             &invocation_ctx.invocation_id,
                         );
                         self.invocation_ctx.remove(&key);
-                        let keys_to_remove = self
+                        let tasks_to_remove = self
                             .tasks
                             .range(key.clone()..)
                             .into_iter()
                             .take_while(|(k, _v)| k.starts_with(&key))
-                            .map(|(k, _v)| k.clone())
-                            .collect::<Vec<String>>();
-                        for k in keys_to_remove {
-                            self.tasks.remove(&k);
-                        }
+                            .map(|(_k, v)| v.clone())
+                            .collect::<Vec<_>>();
+
+                        self.delete_tasks(tasks_to_remove);
+                        // TODO: delete cached queued reduction tasks
                     }
                 }
                 for allocation in &req.new_allocations {
@@ -425,6 +449,17 @@ impl InMemoryState {
         }
     }
 
+    pub fn delete_tasks(&mut self, tasks: Vec<Box<Task>>) {
+        for task in tasks.iter() {
+            self.tasks.remove(&task.key());
+            self.unallocated_tasks.remove(&task.key());
+        }
+
+        for (_executor, allocations) in self.allocations_by_executor.iter_mut() {
+            allocations.retain(|allocation| !tasks.iter().any(|t| t.id == allocation.task_id));
+        }
+    }
+
     pub fn delete_invocation(&mut self, namespace: &str, compute_graph: &str, invocation_id: &str) {
         // Remove tasks
         let key_prefix =
@@ -445,16 +480,8 @@ impl InMemoryState {
         self.invocation_ctx.remove(&key_prefix);
 
         // Remove allocations
-        let mut allocations_to_remove = Vec::new();
-        for (_executor, allocations) in self.allocations_by_executor.iter() {
-            allocations.iter().for_each(|allocation| {
-                if allocation.invocation_id == invocation_id {
-                    allocations_to_remove.push(allocation.id.clone());
-                }
-            });
-        }
-        for allocation in allocations_to_remove {
-            self.allocations_by_executor.remove(&allocation);
+        for (_executor, allocations) in self.allocations_by_executor.iter_mut() {
+            allocations.retain(|allocation| allocation.invocation_id != invocation_id);
         }
 
         // Remove unallocated tasks


### PR DESCRIPTION
## Context

<!--
In a few sentences or less, please explain the context behind this change to help answer why this change is needed.

If this is a bug fix, make sure to include "fixes #xxxx", or
"closes #xxxx".

Screenshots, logs, code or other visual aids are greatly appreciated.
 -->

On a busy server, adding new executors would have very little to no impact on the P90 of the tasks's time-to-executor latency. This is because it only start being used to allocate new tasks but would not be used to place already allocated tasks. All the previous tasks would have already been allocated to the executor already present on the system without any limits.

## What

This PR limits the number of tasks that are allocated per executor at a time in order for the server to be able to take advantage of new executors joining the cluster.

The current limit is set to 20 which is double the number of tasks we queue (send via the task stream) on an executor at once.

<!--
In a few sentences, please summarize the change to help reviewers.

Consider providing screenshots, logs, code or other visual aids to help the reviewer understand the approach taken.
-->

## Testing

<!--
Please include steps used to verify the change.

Consider providing screenshots, logs, code or other visual aids to help the reviewer in their testing.
-->

- Start server
- Queue up 30 invocations of many 1000 reducer graph
- Start executor 1
- Start executor 2
- Open /internal/allocations
- Notice allocations are spread very evenlly

## Contribution Checklist

- [x] If a Python package was changed, please run `make fmt` in the package directory.
- [x] If the server was changed, please run `make fmt` in `server/`.
- [x] Make sure all PR Checks are passing.
<!--
Notes:

Tests of a Python package can be run manually. Start a Server and an Executor then
run `make test` in the Python package directory.

To test if changes to the server are backward compatible with the latest
release, label the PR with `ci_compat_test`. This might report failures
unrelated to your change if previous incompatible changes were pushed without
being released yet
-->
