### PR TITLE
Secondary index for invocations

### DIFF
--- a/examples/pdf_document_extraction/README.md
+++ b/examples/pdf_document_extraction/README.md
@@ -73,6 +73,9 @@ The name of the databases used in the example are `text_embeddings` and `image_e
 
 There code to retrieve from ChromaDB is [here](https://github.com/tensorlakeai/indexify/blob/main/examples/pdf_document_extraction/chromadb_retreive.py)
 
+#### Swapping OCR Engines
+You could swap out Docling for another open source or propretiery engine. The code [here](https://github.com/tensorlakeai/indexify/blob/c7b6c5929b6fdd58993e8187f5d546f056950289/examples/pdf_document_extraction/pdf_parser_docling.py#L18) needs to be updated to use another library. 
+
 ## Using GPU
 
 You have to make a couple of changes to use GPUs for PDF parsing.

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -1542,6 +1542,7 @@ dependencies = [
  "axum 0.8.1",
  "axum-server",
  "axum-tracing-opentelemetry",
+ "base64",
  "blob_store",
  "bytes",
  "ciborium",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -88,6 +88,7 @@ tracing-opentelemetry = "0.29.0"
 dashmap = "6.1.0"
 tower-otel-http-metrics = "0.13.0"
 im = {version="15.1.0"}
+base64 = "0.22.1"
 
 [dependencies]
 async-stream = { workspace = true }
@@ -132,6 +133,7 @@ axum-tracing-opentelemetry = { version = "0.26.1", features = [
     "tracing_level_info",
 ] }
 tower-otel-http-metrics = { workspace = true }
+base64 = {workspace=true}
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/server/data_model/src/lib.rs
+++ b/server/data_model/src/lib.rs
@@ -773,6 +773,24 @@ impl GraphInvocationCtx {
         )
     }
 
+    pub fn secondary_index_key(&self) -> Vec<u8> {
+        let mut key = Vec::new();
+        key.extend_from_slice(self.namespace.as_bytes());
+        key.push(b'|');
+        key.extend_from_slice(self.compute_graph_name.as_bytes());
+        key.push(b'|');
+        key.extend_from_slice(&self.created_at.to_be_bytes());
+        key.push(b'|');
+        key.extend_from_slice(self.invocation_id.as_bytes());
+        key
+    }
+
+    pub fn get_invocation_id_from_secondary_index_key(key: &[u8]) -> Option<String> {
+        key.split(|&b| b == b'|')
+            .nth(3)
+            .map(|s| String::from_utf8_lossy(s).into_owned())
+    }
+
     pub fn key_from(ns: &str, cg: &str, id: &str) -> String {
         format!("{}|{}|{}", ns, cg, id)
     }

--- a/server/src/http_objects.rs
+++ b/server/src/http_objects.rs
@@ -59,10 +59,19 @@ impl From<serde_json::Error> for IndexifyAPIError {
     }
 }
 
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub enum CursorDirection {
+    #[serde(rename = "forward")]
+    Forward,
+    #[serde(rename = "backward")]
+    Backward,
+}
+
 #[derive(Debug, Serialize, Deserialize, ToSchema, IntoParams)]
 pub struct ListParams {
     pub limit: Option<usize>,
     pub cursor: Option<String>,
+    pub direction: Option<CursorDirection>,
 }
 
 #[derive(Debug, Serialize, Deserialize, ToSchema)]

--- a/server/src/http_objects.rs
+++ b/server/src/http_objects.rs
@@ -8,7 +8,7 @@ use data_model::{ComputeGraphCode, GraphInvocationCtx, GraphInvocationOutcome};
 use indexify_utils::get_epoch_time_in_ms;
 use serde::{Deserialize, Serialize};
 use tracing::error;
-use utoipa::ToSchema;
+use utoipa::{IntoParams, ToSchema};
 
 #[derive(Debug, ToSchema, Serialize, Deserialize)]
 pub struct IndexifyAPIError {
@@ -59,10 +59,10 @@ impl From<serde_json::Error> for IndexifyAPIError {
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, ToSchema)]
+#[derive(Debug, Serialize, Deserialize, ToSchema, IntoParams)]
 pub struct ListParams {
     pub limit: Option<usize>,
-    pub cursor: Option<Vec<u8>>,
+    pub cursor: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
@@ -377,7 +377,7 @@ pub struct CreateNamespace {
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
 pub struct ComputeGraphsList {
     pub compute_graphs: Vec<ComputeGraph>,
-    pub cursor: Option<Vec<u8>>,
+    pub cursor: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -401,7 +401,7 @@ pub struct CreateNamespaceResponse {
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
 pub struct GraphInvocations {
     pub invocations: Vec<Invocation>,
-    pub cursor: Option<Vec<u8>>,
+    pub cursor: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
@@ -504,7 +504,7 @@ impl From<data_model::Task> for Task {
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
 pub struct Tasks {
     pub tasks: Vec<Task>,
-    pub cursor: Option<Vec<u8>>,
+    pub cursor: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
@@ -553,7 +553,7 @@ pub struct FnOutputs {
     pub status: InvocationStatus,
     pub outcome: InvocationOutcome,
     pub outputs: Vec<FnOutput>,
-    pub cursor: Option<Vec<u8>>,
+    pub cursor: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, ToSchema)]

--- a/server/src/routes.rs
+++ b/server/src/routes.rs
@@ -74,6 +74,7 @@ use crate::{
         ComputeGraph,
         ComputeGraphsList,
         CreateNamespace,
+        CursorDirection,
         DynamicRouter,
         ExecutorMetadata,
         ExecutorsAllocations,
@@ -628,6 +629,11 @@ async fn graph_invocations(
     let cursor = params
         .cursor
         .map(|c| BASE64_STANDARD.decode(c).unwrap_or(vec![]));
+    let direction = match params.direction {
+        Some(CursorDirection::Forward) => Some(state_store::scanner::CursorDirection::Forward),
+        Some(CursorDirection::Backward) => Some(state_store::scanner::CursorDirection::Backward),
+        None => None,
+    };
     let (invocation_ctxs, cursor) = state
         .indexify_state
         .reader()
@@ -636,6 +642,7 @@ async fn graph_invocations(
             &compute_graph,
             cursor.as_deref(),
             params.limit.unwrap_or(100),
+            direction,
         )
         .map_err(IndexifyAPIError::internal_error)?;
     let mut invocations = vec![];

--- a/server/src/routes.rs
+++ b/server/src/routes.rs
@@ -15,6 +15,7 @@ use axum_tracing_opentelemetry::{
     self,
     middleware::{OtelAxumLayer, OtelInResponseLayer},
 };
+use base64::prelude::*;
 use blob_store::PutResult;
 use data_model::{ComputeGraphError, ExecutorId};
 use futures::StreamExt;
@@ -124,6 +125,7 @@ use crate::{
                 Node,
                 DynamicRouter,
                 ComputeFn,
+                ListParams,
                 ComputeGraphCreateType,
                 ComputeGraphsList,
                 ImageInformation,
@@ -552,6 +554,9 @@ async fn delete_compute_graph(
     get,
     path = "/namespaces/{namespace}/compute_graphs",
     tag = "operations",
+    params(
+        ListParams
+    ),
     responses(
         (status = 200, description = "Lists Compute Graph", body = ComputeGraphsList),
         (status = INTERNAL_SERVER_ERROR, description = "Internal Server Error")
@@ -562,11 +567,15 @@ async fn list_compute_graphs(
     Query(params): Query<ListParams>,
     State(state): State<RouteState>,
 ) -> Result<Json<ComputeGraphsList>, IndexifyAPIError> {
+    let cursor = params
+        .cursor
+        .map(|c| BASE64_STANDARD.decode(c).unwrap_or(vec![]));
     let (compute_graphs, cursor) = state
         .indexify_state
         .reader()
-        .list_compute_graphs(&namespace, params.cursor.as_deref(), params.limit)
+        .list_compute_graphs(&namespace, cursor.as_deref(), params.limit)
         .map_err(IndexifyAPIError::internal_error)?;
+    let cursor = cursor.map(|c| BASE64_STANDARD.encode(c));
     Ok(Json(ComputeGraphsList {
         compute_graphs: compute_graphs.into_iter().map(|c| c.into()).collect(),
         cursor,
@@ -603,8 +612,11 @@ async fn get_compute_graph(
     get,
     path = "/namespaces/{namespace}/compute_graphs/{compute_graph}/invocations",
     tag = "ingestion",
+    params(
+        ListParams
+    ),
     responses(
-        (status = 200, description = "Compute Graph Definition", body = GraphInvocations),
+        (status = 200, description = "List Graph Invocations", body = GraphInvocations),
         (status = INTERNAL_SERVER_ERROR, description = "Internal Server Error")
     ),
 )]
@@ -613,20 +625,25 @@ async fn graph_invocations(
     Query(params): Query<ListParams>,
     State(state): State<RouteState>,
 ) -> Result<Json<GraphInvocations>, IndexifyAPIError> {
+    let cursor = params
+        .cursor
+        .map(|c| BASE64_STANDARD.decode(c).unwrap_or(vec![]));
     let (invocation_ctxs, cursor) = state
         .indexify_state
         .reader()
         .list_invocations(
             &namespace,
             &compute_graph,
-            params.cursor.as_deref(),
-            params.limit,
+            cursor.as_deref(),
+            params.limit.unwrap_or(100),
         )
         .map_err(IndexifyAPIError::internal_error)?;
     let mut invocations = vec![];
     for invocation_ctx in invocation_ctxs {
         invocations.push(invocation_ctx.into());
     }
+    let cursor = cursor.map(|c| BASE64_STANDARD.encode(c));
+
     Ok(Json(GraphInvocations {
         invocations,
         cursor,
@@ -821,6 +838,9 @@ async fn executor_tasks(
     get,
     path = "/namespaces/{namespace}/compute_graphs/{compute_graph}/invocations/{invocation_id}/tasks",
     tag = "operations",
+    params(
+        ListParams
+    ),
     responses(
         (status = 200, description = "List tasks for a given invocation id", body = Tasks),
         (status = INTERNAL_SERVER_ERROR, description = "Internal Server Error")
@@ -832,6 +852,9 @@ async fn list_tasks(
     Query(params): Query<ListParams>,
     State(state): State<RouteState>,
 ) -> Result<Json<Tasks>, IndexifyAPIError> {
+    let cursor = params
+        .cursor
+        .map(|c| BASE64_STANDARD.decode(c).unwrap_or(vec![]));
     let (tasks, cursor) = state
         .indexify_state
         .reader()
@@ -839,11 +862,12 @@ async fn list_tasks(
             &namespace,
             &compute_graph,
             &invocation_id,
-            params.cursor.as_deref(),
+            cursor.as_deref(),
             params.limit,
         )
         .map_err(IndexifyAPIError::internal_error)?;
     let tasks = tasks.into_iter().map(Into::into).collect();
+    let cursor = cursor.map(|c| BASE64_STANDARD.encode(c));
     Ok(Json(Tasks { tasks, cursor }))
 }
 
@@ -885,6 +909,9 @@ async fn list_outputs(
     Query(params): Query<ListParams>,
     State(state): State<RouteState>,
 ) -> Result<Json<FnOutputs>, IndexifyAPIError> {
+    let cursor = params
+        .cursor
+        .map(|c| BASE64_STANDARD.decode(c).unwrap_or(vec![]));
     let invocation_ctx = state
         .indexify_state
         .reader()
@@ -899,7 +926,7 @@ async fn list_outputs(
             &namespace,
             &compute_graph,
             &invocation_id,
-            params.cursor.as_deref(),
+            cursor.as_deref(),
             params.limit,
         )
         .map_err(IndexifyAPIError::internal_error)?;
@@ -912,6 +939,7 @@ async fn list_outputs(
     } else {
         InvocationStatus::Pending
     };
+    let cursor = cursor.map(|c| BASE64_STANDARD.encode(c));
 
     // We return the outputs of finalized and pending invocations to allow getting
     // partial results.

--- a/server/state_store/src/lib.rs
+++ b/server/state_store/src/lib.rs
@@ -102,7 +102,8 @@ pub struct IndexifyState {
 
 impl IndexifyState {
     pub async fn new(path: PathBuf) -> Result<Arc<Self>> {
-        fs::create_dir_all(path.clone())?;
+        fs::create_dir_all(path.clone())
+            .map_err(|e| anyhow!("failed to create state store dir: {}", e))?;
         let sm_column_families = IndexifyObjectsColumns::iter()
             .map(|cf| ColumnFamilyDescriptor::new(cf.to_string(), Options::default()));
         let mut db_opts = Options::default();

--- a/server/ui/src/index.tsx
+++ b/server/ui/src/index.tsx
@@ -60,6 +60,11 @@ const router = createBrowserRouter(
       loader: rootLoader,
       children: [
         {
+          index: true,
+          element: <Navigate to="/default/compute-graphs" replace />,
+          errorElement: <ErrorPage />
+        },
+        {
           path: "/:namespace",
           element: <RedirectToComputeGraphs />,
           errorElement: <ErrorPage />

--- a/server/ui/src/routes/Namespace/IndividualComputeGraphPage.tsx
+++ b/server/ui/src/routes/Namespace/IndividualComputeGraphPage.tsx
@@ -1,34 +1,26 @@
-import { Box, Breadcrumbs, Typography, Stack, Chip, Button } from '@mui/material'
+import { Box, Breadcrumbs, Typography, Stack, Chip, Button, CircularProgress } from '@mui/material'
 import { TableDocument } from 'iconsax-react'
 import NavigateNextIcon from '@mui/icons-material/NavigateNext'
-import { Link, useLoaderData, useNavigate } from 'react-router-dom'
-import { useState, useCallback, useEffect } from 'react'
+import NavigateBeforeIcon from '@mui/icons-material/NavigateBefore'
+import { Link, useLoaderData } from 'react-router-dom'
+import { useState, useCallback } from 'react'
 import type { Invocation } from '../../types'
 import type { IndividualComputeGraphLoaderData } from './types'
 import ComputeGraphTable from '../../components/tables/ComputeGraphTable'
 import CopyText from '../../components/CopyText'
 import InvocationsTable from '../../components/tables/InvocationsTable'
 import CopyTextPopover from '../../components/CopyTextPopover'
+import axios from 'axios'
+import { getIndexifyServiceURL } from '../../utils/helpers'
 
 const IndividualComputeGraphPage = () => {
-  const { invocationsList, computeGraph, namespace, nextCursor, currentCursor } =
-    useLoaderData() as IndividualComputeGraphLoaderData
-  
-  const navigate = useNavigate()
+  const { invocationsList, computeGraph, namespace, cursor } = useLoaderData() as IndividualComputeGraphLoaderData
 
-  const [invocations, setInvocations] = useState<Invocation[]>(
-    [...invocationsList].sort(
-      (a, b) => (b.created_at ?? 0) - (a.created_at ?? 0)
-    )
-  )
-
-  useEffect(() => {
-    setInvocations(
-      [...invocationsList].sort(
-        (a, b) => (b.created_at ?? 0) - (a.created_at ?? 0)
-      )
-    )
-  }, [invocationsList])
+  const [invocations, setInvocations] = useState<Invocation[]>(invocationsList)
+  const [isLoading, setIsLoading] = useState(false)
+  const [currentCursor, setCurrentCursor] = useState<string | null>(null)
+  const [nextCursor, setNextCursor] = useState<string | null>(cursor)
+  const [cursorHistory, setCursorHistory] = useState<string[]>([])
 
   const handleDelete = useCallback((updatedList: Invocation[]) => {
     const sortedList = [...updatedList].sort(
@@ -37,15 +29,55 @@ const IndividualComputeGraphPage = () => {
     setInvocations(sortedList)
   }, [])
 
-  const handleNextPage = () => {
-    if (nextCursor) {
-      navigate(`/${namespace}/compute-graphs/${computeGraph.name}?cursor=${nextCursor}`)
+  const fetchInvocations = useCallback(async (cursor: string | null, direction: 'forward' | 'backward') => {
+    setIsLoading(true)
+    try {
+      const serviceURL = getIndexifyServiceURL()
+      const limit = 20
+      const url = `${serviceURL}/namespaces/${namespace}/compute_graphs/${computeGraph.name}/invocations?limit=${limit}${
+        cursor ? `&cursor=${cursor}` : ''
+      }&direction=${direction}`
+      
+      const response = await axios.get(url)
+      const data = response.data
+      
+      setInvocations([...data.invocations].sort(
+        (a, b) => (b.created_at ?? 0) - (a.created_at ?? 0)
+      ))
+      
+      if (direction === 'forward') {
+        if (cursor) {
+          setCursorHistory(prev => [...prev, cursor])
+        }
+        setCurrentCursor(cursor)
+        setNextCursor(data.cursor || null)
+      } else {
+        if (cursorHistory.length > 0) {
+          setCursorHistory(prev => prev.slice(0, -1))
+        }
+        setCurrentCursor(cursorHistory.length > 1 ? cursorHistory[cursorHistory.length - 2] : null)
+        setNextCursor(data.cursor || null)
+      }
+    } catch (error) {
+      console.error("Error fetching invocations:", error)
+    } finally {
+      setIsLoading(false)
     }
-  }
+  }, [namespace, computeGraph.name, cursorHistory])
 
-  const handlePreviousPage = () => {
-    navigate(`/${namespace}/compute-graphs/${computeGraph.name}`)
-  }
+  const handleNextPage = useCallback(() => {
+    const cursor = nextCursor || currentCursor
+    if (cursor) {
+      fetchInvocations(cursor, 'forward')
+    }
+  }, [nextCursor, currentCursor, fetchInvocations])
+
+  const handlePreviousPage = useCallback(() => {
+    if (cursorHistory.length > 0) {
+      const prevCursor = cursorHistory[cursorHistory.length - 1]
+      fetchInvocations(prevCursor, 'backward')
+    }
+  }, [cursorHistory, fetchInvocations])
 
   return (
     <Stack direction="column" spacing={3}>
@@ -99,16 +131,31 @@ const IndividualComputeGraphPage = () => {
           computeGraph={computeGraph.name}
           onDelete={handleDelete}
         />
-        <Box sx={{ display: 'flex', justifyContent: 'space-between', mt: 2 }}>
-          <Button 
+
+        <Box 
+          sx={{ 
+            display: 'flex', 
+            justifyContent: 'space-between', 
+            mt: 2,
+            alignItems: 'center'
+          }}
+        >
+          <Button
+            startIcon={<NavigateBeforeIcon />}
             onClick={handlePreviousPage}
-            disabled={!currentCursor}
+            disabled={cursorHistory.length === 0 || isLoading}
+            variant="outlined"
           >
             Previous
           </Button>
-          <Button 
+          
+          {isLoading && <CircularProgress size={24} />}
+          
+          <Button
+            endIcon={<NavigateNextIcon />}
             onClick={handleNextPage}
-            disabled={!nextCursor}
+            disabled={isLoading}
+            variant="outlined"
           >
             Next
           </Button>

--- a/server/ui/src/routes/Namespace/IndividualComputeGraphPage.tsx
+++ b/server/ui/src/routes/Namespace/IndividualComputeGraphPage.tsx
@@ -1,4 +1,4 @@
-import { Box, Breadcrumbs, Typography, Stack, Chip, Button, ButtonGroup } from '@mui/material'
+import { Box, Breadcrumbs, Typography, Stack, Chip, Button } from '@mui/material'
 import { TableDocument } from 'iconsax-react'
 import NavigateNextIcon from '@mui/icons-material/NavigateNext'
 import { Link, useLoaderData, useNavigate } from 'react-router-dom'
@@ -101,17 +101,17 @@ const IndividualComputeGraphPage = () => {
         />
         <Box sx={{ display: 'flex', justifyContent: 'space-between', mt: 2 }}>
           <Button 
-              onClick={handlePreviousPage}
-              disabled={!currentCursor}
-            >
-              Previous
-            </Button>
+            onClick={handlePreviousPage}
+            disabled={!currentCursor}
+          >
+            Previous
+          </Button>
           <Button 
-              onClick={handleNextPage}
-              disabled={!nextCursor}
-            >
-              Next
-            </Button>
+            onClick={handleNextPage}
+            disabled={!nextCursor}
+          >
+            Next
+          </Button>
         </Box>
       </Box>
     </Stack>

--- a/server/ui/src/routes/Namespace/IndividualComputeGraphPage.tsx
+++ b/server/ui/src/routes/Namespace/IndividualComputeGraphPage.tsx
@@ -1,8 +1,8 @@
-import { Box, Breadcrumbs, Typography, Stack, Chip } from '@mui/material'
+import { Box, Breadcrumbs, Typography, Stack, Chip, Button, ButtonGroup } from '@mui/material'
 import { TableDocument } from 'iconsax-react'
 import NavigateNextIcon from '@mui/icons-material/NavigateNext'
-import { Link, useLoaderData } from 'react-router-dom'
-import { useState, useCallback } from 'react'
+import { Link, useLoaderData, useNavigate } from 'react-router-dom'
+import { useState, useCallback, useEffect } from 'react'
 import type { Invocation } from '../../types'
 import type { IndividualComputeGraphLoaderData } from './types'
 import ComputeGraphTable from '../../components/tables/ComputeGraphTable'
@@ -11,8 +11,10 @@ import InvocationsTable from '../../components/tables/InvocationsTable'
 import CopyTextPopover from '../../components/CopyTextPopover'
 
 const IndividualComputeGraphPage = () => {
-  const { invocationsList, computeGraph, namespace } =
+  const { invocationsList, computeGraph, namespace, nextCursor, currentCursor } =
     useLoaderData() as IndividualComputeGraphLoaderData
+  
+  const navigate = useNavigate()
 
   const [invocations, setInvocations] = useState<Invocation[]>(
     [...invocationsList].sort(
@@ -20,12 +22,30 @@ const IndividualComputeGraphPage = () => {
     )
   )
 
+  useEffect(() => {
+    setInvocations(
+      [...invocationsList].sort(
+        (a, b) => (b.created_at ?? 0) - (a.created_at ?? 0)
+      )
+    )
+  }, [invocationsList])
+
   const handleDelete = useCallback((updatedList: Invocation[]) => {
     const sortedList = [...updatedList].sort(
       (a, b) => (b.created_at ?? 0) - (a.created_at ?? 0)
     )
     setInvocations(sortedList)
   }, [])
+
+  const handleNextPage = () => {
+    if (nextCursor) {
+      navigate(`/${namespace}/compute-graphs/${computeGraph.name}?cursor=${nextCursor}`)
+    }
+  }
+
+  const handlePreviousPage = () => {
+    navigate(`/${namespace}/compute-graphs/${computeGraph.name}`)
+  }
 
   return (
     <Stack direction="column" spacing={3}>
@@ -79,6 +99,20 @@ const IndividualComputeGraphPage = () => {
           computeGraph={computeGraph.name}
           onDelete={handleDelete}
         />
+        <Box sx={{ display: 'flex', justifyContent: 'space-between', mt: 2 }}>
+          <Button 
+              onClick={handlePreviousPage}
+              disabled={!currentCursor}
+            >
+              Previous
+            </Button>
+          <Button 
+              onClick={handleNextPage}
+              disabled={!nextCursor}
+            >
+              Next
+            </Button>
+        </Box>
       </Box>
     </Stack>
   )

--- a/server/ui/src/routes/Namespace/types.ts
+++ b/server/ui/src/routes/Namespace/types.ts
@@ -19,6 +19,8 @@ export interface ComputeGraphLoaderData extends NamespaceLoaderData {
 export interface IndividualComputeGraphLoaderData extends NamespaceLoaderData {
   invocationsList: Invocation[]
   computeGraph: ComputeGraph
+  nextCursor?: string
+  currentCursor?: string
 }
 
 export interface IndividualInvocationLoaderData extends NamespaceLoaderData {

--- a/server/ui/src/routes/Namespace/types.ts
+++ b/server/ui/src/routes/Namespace/types.ts
@@ -19,8 +19,8 @@ export interface ComputeGraphLoaderData extends NamespaceLoaderData {
 export interface IndividualComputeGraphLoaderData extends NamespaceLoaderData {
   invocationsList: Invocation[]
   computeGraph: ComputeGraph
-  nextCursor?: string
-  currentCursor?: string
+  cursor: string | null;
+  direction?: string
 }
 
 export interface IndividualInvocationLoaderData extends NamespaceLoaderData {


### PR DESCRIPTION
Added secondary index for invocations because when we ingest 10s of 1000s of files, the UI becomes unresponsive. 

The list_invocations api returns the results in descending order of created_at attribute to give us what we need for the UI. It needs to be more configurable 

There is a bug here. The cursor should be null if we at the last page and iteration direction is backward, and on the first page if the iteration direction is forward.