### PR TITLE
fix: fix unallocated task ordering

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -2308,6 +2308,7 @@ dependencies = [
  "blob_store",
  "dashmap",
  "data_model",
+ "indexify_utils",
  "itertools 0.14.0",
  "metrics",
  "opentelemetry",

--- a/server/data_model/src/lib.rs
+++ b/server/data_model/src/lib.rs
@@ -906,21 +906,6 @@ impl Default for TaskStatus {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct UnallocatedTaskId {
-    pub creation_time_ns: u128,
-    pub task_key: String,
-}
-
-impl UnallocatedTaskId {
-    pub fn new(task: &Task) -> Self {
-        Self {
-            creation_time_ns: task.creation_time_ns,
-            task_key: task.key(),
-        }
-    }
-}
-
 #[derive(Serialize, Debug, Deserialize, Clone, PartialEq, Builder)]
 #[builder(build_fn(skip))]
 pub struct Task {
@@ -1007,10 +992,6 @@ impl Task {
 
     pub fn key_output(&self, output_id: &str) -> String {
         format!("{}|{}|{}", self.namespace, self.id, output_id)
-    }
-
-    pub fn unallocated_task_id(&self) -> UnallocatedTaskId {
-        UnallocatedTaskId::new(self)
     }
 }
 
@@ -1338,7 +1319,6 @@ mod tests {
         GraphVersion,
         Node,
         RuntimeInformation,
-        UnallocatedTaskId,
     };
 
     #[test]
@@ -1825,85 +1805,5 @@ mod tests {
                 ]);
             },
         );
-    }
-
-    #[test]
-    fn test_unallocated_task_id_ordering() {
-        {
-            let task1 = UnallocatedTaskId {
-                creation_time_ns: 100,
-                task_key: "task1".to_string(),
-            };
-            let task2 = UnallocatedTaskId {
-                creation_time_ns: 200,
-                task_key: "task1".to_string(),
-            };
-            let task3 = UnallocatedTaskId {
-                creation_time_ns: 300,
-                task_key: "task1".to_string(),
-            };
-            let task4 = UnallocatedTaskId {
-                creation_time_ns: 400,
-                task_key: "task1".to_string(),
-            };
-            let task5 = UnallocatedTaskId {
-                creation_time_ns: 1000,
-                task_key: "task1".to_string(),
-            };
-
-            assert!(task1 < task2);
-            assert!(task2 < task3);
-            assert!(task3 < task4);
-            assert!(task3 < task5);
-        }
-
-        {
-            let task1 = UnallocatedTaskId {
-                creation_time_ns: 100,
-                task_key: "task1".to_string(),
-            };
-            let task2 = UnallocatedTaskId {
-                creation_time_ns: 100,
-                task_key: "task2".to_string(),
-            };
-            let task3 = UnallocatedTaskId {
-                creation_time_ns: 100,
-                task_key: "task3".to_string(),
-            };
-            let task4 = UnallocatedTaskId {
-                creation_time_ns: 100,
-                task_key: "task4".to_string(),
-            };
-
-            assert!(task1 < task2);
-            assert!(task2 < task3);
-            assert!(task3 < task4);
-        }
-
-        // test that task key is ONLY used as a tie breaker
-        // this depends on the field ordering in the struct
-        // where creation_time_ns needs to be first.
-        {
-            let task1 = UnallocatedTaskId {
-                creation_time_ns: 400,
-                task_key: "task1".to_string(),
-            };
-            let task2 = UnallocatedTaskId {
-                creation_time_ns: 300,
-                task_key: "task2".to_string(),
-            };
-            let task3 = UnallocatedTaskId {
-                creation_time_ns: 200,
-                task_key: "task3".to_string(),
-            };
-            let task4 = UnallocatedTaskId {
-                creation_time_ns: 100,
-                task_key: "task4".to_string(),
-            };
-
-            assert!(task4 < task3);
-            assert!(task3 < task2);
-            assert!(task2 < task1);
-        }
     }
 }

--- a/server/processor/Cargo.toml
+++ b/server/processor/Cargo.toml
@@ -18,3 +18,4 @@ blob_store.workspace = true
 opentelemetry.workspace = true
 async-trait.workspace = true
 itertools.workspace = true
+indexify_utils.workspace = true

--- a/server/processor/src/task_allocator.rs
+++ b/server/processor/src/task_allocator.rs
@@ -18,7 +18,7 @@ use metrics::low_latency_boundaries;
 use opentelemetry::metrics::Histogram;
 use rand::seq::SliceRandom;
 use state_store::{
-    in_memory_state::InMemoryState,
+    in_memory_state::{InMemoryState, UnallocatedTaskId},
     requests::{ReductionTasks, SchedulerUpdateRequest},
 };
 use tracing::{debug, error, info, span};
@@ -214,7 +214,7 @@ impl TaskAllocationProcessor {
                     indexes.tasks.insert(task.key(), task.clone());
                     indexes
                         .unallocated_tasks
-                        .remove(&task.unallocated_task_id());
+                        .remove(&UnallocatedTaskId::new(&task));
                     updated_tasks.push(*task);
                 }
                 Ok(None) => {

--- a/server/processor/src/task_creator.rs
+++ b/server/processor/src/task_creator.rs
@@ -15,7 +15,7 @@ use data_model::{
     TaskOutputsIngestedEvent,
 };
 use state_store::{
-    in_memory_state::InMemoryState,
+    in_memory_state::{InMemoryState, UnallocatedTaskId},
     requests::{ReductionTasks, SchedulerUpdateRequest},
     IndexifyState,
 };
@@ -72,7 +72,7 @@ impl TaskCreator {
                 let result = self.handle_task_finished_inner(ev, indexes).await?;
                 result.tasks.iter().for_each(|t| {
                     indexes.tasks.insert(t.key(), Box::new(t.clone()));
-                    indexes.unallocated_tasks.insert(t.unallocated_task_id());
+                    indexes.unallocated_tasks.insert(UnallocatedTaskId::new(&t));
                 });
                 if let Some(ctx) = result.invocation_ctx.clone() {
                     indexes.invocation_ctx.insert(ctx.key(), Box::new(ctx));
@@ -99,7 +99,7 @@ impl TaskCreator {
                     .await?;
                 result.tasks.iter().for_each(|t| {
                     indexes.tasks.insert(t.key(), Box::new(t.clone()));
-                    indexes.unallocated_tasks.insert(t.unallocated_task_id());
+                    indexes.unallocated_tasks.insert(UnallocatedTaskId::new(&t));
                 });
                 if let Some(ctx) = result.invocation_ctx.clone() {
                     indexes.invocation_ctx.insert(ctx.key(), Box::new(ctx));

--- a/server/processor/src/task_creator.rs
+++ b/server/processor/src/task_creator.rs
@@ -72,7 +72,7 @@ impl TaskCreator {
                 let result = self.handle_task_finished_inner(ev, indexes).await?;
                 result.tasks.iter().for_each(|t| {
                     indexes.tasks.insert(t.key(), Box::new(t.clone()));
-                    indexes.unallocated_tasks.insert(t.key(), [0; 0]);
+                    indexes.unallocated_tasks.insert(t.unallocated_task_id());
                 });
                 if let Some(ctx) = result.invocation_ctx.clone() {
                     indexes.invocation_ctx.insert(ctx.key(), Box::new(ctx));
@@ -99,7 +99,7 @@ impl TaskCreator {
                     .await?;
                 result.tasks.iter().for_each(|t| {
                     indexes.tasks.insert(t.key(), Box::new(t.clone()));
-                    indexes.unallocated_tasks.insert(t.key(), [0; 0]);
+                    indexes.unallocated_tasks.insert(t.unallocated_task_id());
                 });
                 if let Some(ctx) = result.invocation_ctx.clone() {
                     indexes.invocation_ctx.insert(ctx.key(), Box::new(ctx));

--- a/server/src/routes.rs
+++ b/server/src/routes.rs
@@ -778,7 +778,7 @@ async fn list_unallocated_tasks(
         .unallocated_tasks
         .clone()
         .iter()
-        .filter_map(|(task_id, _)| state.tasks.get(task_id))
+        .filter_map(|unallocated_task_id| state.tasks.get(&unallocated_task_id.task_key))
         .map(|t| (**t).clone().into())
         .collect();
 

--- a/server/state_store/src/in_memory_state.rs
+++ b/server/state_store/src/in_memory_state.rs
@@ -406,6 +406,8 @@ impl InMemoryState {
                         .retain(|a| a.task_id != allocation.task_id);
                 }
                 for executor_id in &req.remove_executors {
+                    self.active_allocations_gauge
+                        .record(0, &[KeyValue::new("executor_id", executor_id.to_string())]);
                     self.executors.remove(executor_id.get());
                     self.allocations_by_executor
                         .remove(&executor_id.get().to_string());


### PR DESCRIPTION
## Context

<!--
In a few sentences or less, please explain the context behind this change to help answer why this change is needed.

If this is a bug fix, make sure to include "fixes #xxxx", or
"closes #xxxx".

Screenshots, logs, code or other visual aids are greatly appreciated.
 -->

We rely on Task Key ordering when iterating on unallocated tasks which is `<namespace>_<compute_graph_name>_<invocation_id>_<fn_name>_<task_id>`

This means that we allocate tasks from the lowest namespace first. Within a given namespace, we would favor lower invocation id and lower task id as well.
Task IDs are uuid v4 is random and do not incorporate a timestamp like uuid v7 does. Which would not prioritize older tasks.

Fixes https://github.com/tensorlakeai/compute-engine-internal/issues/66

## What

This PR introduces an `UnallocatedTaskId` which allows defining an ordering for unallocated tasks. From the `UnallocatedTaskId`, it is possible to get the Task Key to retrieve a task.

Note that since unallocated tasks never get saved in rocksdb, we do not have to make it a key. It is only used in memory in an am::OrdSet.

Since tasks are indexed by TaskKey and that task key require the whole `<namespace>_<compute_graph_name>_<invocation_id>_<fn_name>_<task_id>` fields to be present since we do range queries, we did not change how task are indexed in memory.

This PR also adds new metrics:

```
# HELP task_queuing_latency_seconds Time tasks wait in queue before allocation in seconds
# TYPE task_queuing_latency_seconds histogram
...
# HELP processor_processing_latency_seconds processor task processing latency in seconds
# TYPE processor_processing_latency_seconds histogram
...
# HELP state_transition_latency_seconds Latency of state transitions before processing in seconds
# TYPE state_transition_latency_seconds histogram
```

<!--
In a few sentences, please summarize the change to help reviewers.

Consider providing screenshots, logs, code or other visual aids to help the reviewer understand the approach taken.
-->

## Testing

- [x] Testing triggering a lot of distributed map invocations and expecting invocations to finish one by one as opposed to have them finish almost at the same time.

<!--
Please include steps used to verify the change.

Consider providing screenshots, logs, code or other visual aids to help the reviewer in their testing.
-->

## Contribution Checklist

- [x] If a Python package was changed, please run `make fmt` in the package directory.
- [x] If the server was changed, please run `make fmt` in `server/`.
- [x] Make sure all PR Checks are passing.
<!--
Notes:

Tests of a Python package can be run manually. Start a Server and an Executor then
run `make test` in the Python package directory.

To test if changes to the server are backward compatible with the latest
release, label the PR with `ci_compat_test`. This might report failures
unrelated to your change if previous incompatible changes were pushed without
being released yet
-->
