### PR TITLE
feat: add latency metrics for all task states

### DIFF
--- a/server/data_model/src/lib.rs
+++ b/server/data_model/src/lib.rs
@@ -890,7 +890,18 @@ impl TaskOutcome {
     }
 }
 
-#[derive(Serialize, Debug, Deserialize, Clone, PartialEq)]
+impl Display for TaskOutcome {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let str_val = match self {
+            TaskOutcome::Success => "Success",
+            TaskOutcome::Failure => "Failure",
+            TaskOutcome::Unknown => "Unknown",
+        };
+        write!(f, "{}", str_val)
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub enum TaskStatus {
     /// Task is waiting for execution
     Pending,
@@ -903,6 +914,17 @@ pub enum TaskStatus {
 impl Default for TaskStatus {
     fn default() -> Self {
         Self::Completed
+    }
+}
+
+impl Display for TaskStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let str_val = match self {
+            TaskStatus::Pending => "Pending",
+            TaskStatus::Running => "Running",
+            TaskStatus::Completed => "Completed",
+        };
+        write!(f, "{}", str_val)
     }
 }
 
@@ -1034,9 +1056,7 @@ impl TaskBuilder {
         let reducer_output_id = self.reducer_output_id.clone().flatten();
         let current_time = SystemTime::now();
         let duration = current_time.duration_since(UNIX_EPOCH).unwrap();
-        let secs = duration.as_secs() as u128;
-        let nsecs = duration.subsec_nanos() as u128;
-        let creation_time_ns = secs * 1_000_000_000 + nsecs;
+        let creation_time_ns = duration.as_nanos();
         let id = uuid::Uuid::new_v4().to_string();
         let task = Task {
             id: TaskId(id),

--- a/server/processor/src/task_allocator.rs
+++ b/server/processor/src/task_allocator.rs
@@ -12,10 +12,7 @@ use data_model::{
     Task,
     TaskStatus,
 };
-use indexify_utils::get_elapsed_time;
 use itertools::Itertools;
-use metrics::low_latency_boundaries;
-use opentelemetry::metrics::Histogram;
 use rand::seq::SliceRandom;
 use state_store::{
     in_memory_state::{InMemoryState, UnallocatedTaskId},
@@ -41,23 +38,11 @@ pub struct TaskPlacementResult {
 // - compute node timeout configuration
 const MAX_ALLOCATIONS_PER_EXECUTOR: usize = 20;
 
-pub struct TaskAllocationProcessor {
-    pub task_queuing_latency: Histogram<f64>,
-}
+pub struct TaskAllocationProcessor {}
 
 impl TaskAllocationProcessor {
     pub fn new() -> Self {
-        let meter = opentelemetry::global::meter("task_allocator");
-        let task_queuing_latency = meter
-            .f64_histogram("task_queuing_latency")
-            .with_unit("s")
-            .with_boundaries(low_latency_boundaries())
-            .with_description("Time tasks wait in queue before allocation in seconds")
-            .build();
-
-        Self {
-            task_queuing_latency,
-        }
+        Self {}
     }
 }
 impl TaskAllocationProcessor {
@@ -202,8 +187,6 @@ impl TaskAllocationProcessor {
                         invocation_id = &task.invocation_id,
                         "allocated task"
                     );
-                    self.task_queuing_latency
-                        .record(get_elapsed_time(task.creation_time_ns), &[]);
                     allocations.push(allocation.clone());
                     task.status = TaskStatus::Running;
                     indexes


### PR DESCRIPTION
## Context

<!--
In a few sentences or less, please explain the context behind this change to help answer why this change is needed.

If this is a bug fix, make sure to include "fixes #xxxx", or
"closes #xxxx".

Screenshots, logs, code or other visual aids are greatly appreciated.
 -->

We were missing server visibility into how long tasks took to run and how long they took end to end to complete.
We also had a bug in how the metric task_pending_latency was reported.

## What

<!--
In a few sentences, please summarize the change to help reviewers.

Consider providing screenshots, logs, code or other visual aids to help the reviewer understand the approach taken.
-->

New metrics:
```
# HELP task_completion_latency_seconds Time tasks spend from creation to completion
# TYPE task_completion_latency_seconds histogram
...
# HELP task_pending_latency_seconds Time tasks spend from creation to running
# TYPE task_pending_latency_seconds histogram
...
# HELP task_running_latency_seconds Time tasks spend from running to completion
# TYPE task_running_latency_seconds histogram
```

Metrics emitting was also moved within the in-memory state.

## Testing

<!--
Please include steps used to verify the change.

Consider providing screenshots, logs, code or other visual aids to help the reviewer in their testing.
-->

## Contribution Checklist

- [x] If a Python package was changed, please run `make fmt` in the package directory.
- [x] If the server was changed, please run `make fmt` in `server/`.
- [x] Make sure all PR Checks are passing.
<!--
Notes:

Tests of a Python package can be run manually. Start a Server and an Executor then
run `make test` in the Python package directory.

To test if changes to the server are backward compatible with the latest
release, label the PR with `ci_compat_test`. This might report failures
unrelated to your change if previous incompatible changes were pushed without
being released yet
-->
