### PR TITLE
fix allocation algo

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -2308,6 +2308,7 @@ dependencies = [
  "blob_store",
  "dashmap",
  "data_model",
+ "im",
  "indexify_utils",
  "itertools 0.14.0",
  "metrics",

--- a/server/data_model/src/lib.rs
+++ b/server/data_model/src/lib.rs
@@ -139,6 +139,13 @@ impl Allocation {
             &self.task_id.to_string(),
         )
     }
+
+    pub fn fn_uri(&self) -> String {
+        format!(
+            "{}|{}|{}",
+            self.namespace, self.compute_graph, self.compute_fn
+        )
+    }
 }
 
 impl AllocationBuilder {
@@ -964,6 +971,13 @@ impl Task {
         format!(
             "{}|{}|{}",
             self.namespace, self.compute_graph_name, self.graph_version.0,
+        )
+    }
+
+    pub fn fn_uri(&self) -> String {
+        format!(
+            "{}|{}|{}",
+            self.namespace, self.compute_graph_name, self.compute_fn_name
         )
     }
 

--- a/server/processor/Cargo.toml
+++ b/server/processor/Cargo.toml
@@ -19,3 +19,4 @@ opentelemetry.workspace = true
 async-trait.workspace = true
 itertools.workspace = true
 indexify_utils.workspace = true
+im.workspace = true

--- a/server/processor/src/task_allocator.rs
+++ b/server/processor/src/task_allocator.rs
@@ -37,7 +37,7 @@ pub struct TaskPlacementResult {
 // - compute node concurrency configuration
 // - compute node batching configuration
 // - compute node timeout configuration
-const MAX_ALLOCATIONS_PER_EXECUTOR: usize = 20;
+const MAX_ALLOCATIONS_PER_FN_EXECUTOR: usize = 20;
 
 pub struct TaskAllocationProcessor {}
 
@@ -165,10 +165,10 @@ impl TaskAllocationProcessor {
                 .iter()
                 .filter(|(k, _)| {
                     let all_allocations = indexes.allocations_by_fn.get(*k);
-                    let allocations_for_task = all_allocations.map_or(0, |allocs| {
+                    let allocations_for_fn = all_allocations.map_or(0, |allocs| {
                         allocs.get(&task.fn_uri()).unwrap_or(&Vector::new()).len()
                     });
-                    allocations_for_task < MAX_ALLOCATIONS_PER_EXECUTOR
+                    allocations_for_fn < MAX_ALLOCATIONS_PER_FN_EXECUTOR
                 })
                 .map(|(_, v)| v)
                 .collect_vec();

--- a/server/processor/src/task_allocator.rs
+++ b/server/processor/src/task_allocator.rs
@@ -12,6 +12,7 @@ use data_model::{
     Task,
     TaskStatus,
 };
+use im::Vector;
 use itertools::Itertools;
 use rand::seq::SliceRandom;
 use state_store::{
@@ -163,9 +164,11 @@ impl TaskAllocationProcessor {
                 .executors
                 .iter()
                 .filter(|(k, _)| {
-                    let allocations = indexes.allocations_by_executor.get(*k);
-                    let allocation_count = allocations.map_or(0, |allocs| allocs.len());
-                    allocation_count < MAX_ALLOCATIONS_PER_EXECUTOR
+                    let all_allocations = indexes.allocations_by_fn.get(*k);
+                    let allocations_for_task = all_allocations.map_or(0, |allocs| {
+                        allocs.get(&task.fn_uri()).unwrap_or(&Vector::new()).len()
+                    });
+                    allocations_for_task < MAX_ALLOCATIONS_PER_EXECUTOR
                 })
                 .map(|(_, v)| v)
                 .collect_vec();
@@ -189,6 +192,13 @@ impl TaskAllocationProcessor {
                     );
                     allocations.push(allocation.clone());
                     task.status = TaskStatus::Running;
+                    indexes
+                        .allocations_by_fn
+                        .entry(allocation.executor_id.to_string())
+                        .or_default()
+                        .entry(task.fn_uri())
+                        .or_default()
+                        .push_back(allocation.id.to_string());
                     indexes
                         .allocations_by_executor
                         .entry(allocation.executor_id.to_string())

--- a/server/state_store/src/in_memory_state.rs
+++ b/server/state_store/src/in_memory_state.rs
@@ -372,6 +372,13 @@ impl InMemoryState {
                     get_elapsed_time(req.task.creation_time_ns, TimeUnit::Nanoseconds),
                     &[KeyValue::new("outcome", req.task.outcome.to_string())],
                 );
+
+                self.allocations_by_fn
+                    .entry(req.executor_id.get().to_string())
+                    .or_default()
+                    .entry(req.task.fn_uri())
+                    .or_default()
+                    .retain(|a| a != &allocation_id);
             }
             RequestPayload::CreateNameSpace(req) => {
                 self.namespaces.insert(req.name.clone(), [0; 0]);


### PR DESCRIPTION
Instead of allocating 20 tasks per executor, we allocate 20 per function executor allowed to run on a host. This prevents starvation when a exeuctor is used to run functions from a bunch of different graphs.