### PR TITLE
feat: support secrets metadata in server

### DIFF
--- a/server/data_model/src/lib.rs
+++ b/server/data_model/src/lib.rs
@@ -251,6 +251,7 @@ pub struct DynamicEdgeRouter {
     #[serde(default = "default_data_encoder")]
     pub output_encoder: String,
     pub image_information: ImageInformation,
+    pub secret_names: Option<Vec<String>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
@@ -265,6 +266,7 @@ pub struct ComputeFn {
     #[serde(default = "default_data_encoder")]
     pub output_encoder: String,
     pub image_information: ImageInformation,
+    pub secret_names: Option<Vec<String>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -308,6 +310,13 @@ impl Node {
             Node::Compute(compute) => compute.reducer,
         }
     }
+
+    pub fn secret_names(&self) -> Option<Vec<String>> {
+        match self {
+            Node::Router(router) => router.secret_names.clone(),
+            Node::Compute(compute) => compute.secret_names.clone(),
+        }
+    }
 }
 
 impl Node {
@@ -333,6 +342,7 @@ impl Node {
             .reducer_output_id(reducer_output_id)
             .graph_version(graph_version.clone())
             .image_uri(self.image_uri())
+            .secret_names(self.secret_names())
             .build()?;
         Ok(task)
     }
@@ -956,6 +966,7 @@ pub struct Task {
     pub reducer_output_id: Option<String>,
     pub graph_version: GraphVersion,
     pub image_uri: Option<String>,
+    pub secret_names: Option<Vec<String>>,
 }
 
 impl Task {
@@ -1088,6 +1099,10 @@ impl TaskBuilder {
             graph_version,
             image_uri: self.image_uri.clone().flatten(),
             creation_time_ns,
+            secret_names: self
+                .secret_names
+                .clone()
+                .ok_or(anyhow!("secret_names is required"))?,
         };
         Ok(task)
     }

--- a/server/data_model/src/test_objects.rs
+++ b/server/data_model/src/test_objects.rs
@@ -46,6 +46,7 @@ pub mod tests {
             .invocation_id(inv_id.to_string())
             .reducer_output_id(None)
             .graph_version(Default::default())
+            .secret_names(None)
             .build()
             .unwrap()
     }
@@ -228,6 +229,7 @@ pub mod tests {
                 image_uri: Some("1234567890.dkr.ecr.us-east-1.amazonaws.com/test".to_string()),
                 sdk_version: Some("1.2.3".to_string()),
             },
+            ..Default::default()
         };
         let fn_b = test_compute_fn("fn_b", "image_hash".to_string());
         let fn_c = test_compute_fn("fn_c", "image_hash".to_string());

--- a/server/src/http_objects.rs
+++ b/server/src/http_objects.rs
@@ -160,6 +160,8 @@ pub struct ComputeFn {
     #[serde(default = "default_encoder")]
     pub output_encoder: String,
     pub image_information: ImageInformation,
+    #[serde(default)]
+    pub secret_names: Vec<String>,
 }
 
 impl From<ComputeFn> for data_model::ComputeFn {
@@ -173,6 +175,7 @@ impl From<ComputeFn> for data_model::ComputeFn {
             input_encoder: val.input_encoder.clone(),
             output_encoder: val.output_encoder.clone(),
             image_information: val.image_information.into(),
+            secret_names: Some(val.secret_names),
         }
     }
 }
@@ -187,6 +190,7 @@ impl From<data_model::ComputeFn> for ComputeFn {
             input_encoder: c.input_encoder,
             output_encoder: c.output_encoder,
             image_information: c.image_information.into(),
+            secret_names: c.secret_names.unwrap_or(vec![]),
         }
     }
 }
@@ -202,6 +206,8 @@ pub struct DynamicRouter {
     #[serde(default = "default_encoder")]
     pub output_encoder: String,
     pub image_information: ImageInformation,
+    #[serde(default)]
+    pub secret_names: Vec<String>,
 }
 
 impl From<DynamicRouter> for data_model::DynamicEdgeRouter {
@@ -214,6 +220,7 @@ impl From<DynamicRouter> for data_model::DynamicEdgeRouter {
             input_encoder: val.input_encoder.clone(),
             output_encoder: val.output_encoder.clone(),
             image_information: val.image_information.clone().into(),
+            secret_names: Some(val.secret_names),
         }
     }
 }
@@ -228,6 +235,7 @@ impl From<data_model::DynamicEdgeRouter> for DynamicRouter {
             input_encoder: d.input_encoder,
             output_encoder: d.output_encoder,
             image_information: d.image_information.into(),
+            secret_names: d.secret_names.unwrap_or(vec![]),
         }
     }
 }
@@ -490,6 +498,7 @@ pub struct Task {
     pub reducer_output_id: Option<String>,
     pub graph_version: GraphVersion,
     pub image_uri: Option<String>,
+    pub secret_names: Vec<String>,
 }
 
 impl From<data_model::Task> for Task {
@@ -506,6 +515,7 @@ impl From<data_model::Task> for Task {
             reducer_output_id: task.reducer_output_id,
             graph_version: task.graph_version.into(),
             image_uri: task.image_uri,
+            secret_names: task.secret_names.unwrap_or_default(),
         }
     }
 }


### PR DESCRIPTION
## Context

<!--
In a few sentences or less, please explain the context behind this change to help answer why this change is needed.

If this is a bug fix, make sure to include "fixes #xxxx", or
"closes #xxxx".

Screenshots, logs, code or other visual aids are greatly appreciated.
 -->

## What

Adding support for storing secrets metadata on the server.
It also returns secret names in tasks sent to the executor for implementing a secret fetching strategy.

Goes with https://github.com/tensorlakeai/tensorlake/pull/63

This is also backward compatible. Existing tensorlake SDK will work with the new version of the server. We store an empty list of secret names. We default to an empty list if none exist in storage.

<img width="476" alt="image" src="https://github.com/user-attachments/assets/607af6da-223f-40be-b35e-a13930228326" />


<!--
In a few sentences, please summarize the change to help reviewers.

Consider providing screenshots, logs, code or other visual aids to help the reviewer understand the approach taken.
-->

## Testing

<!--
Please include steps used to verify the change.

Consider providing screenshots, logs, code or other visual aids to help the reviewer in their testing.
-->

## Contribution Checklist

- [x] If a Python package was changed, please run `make fmt` in the package directory.
- [x] If the server was changed, please run `make fmt` in `server/`.
- [x] Make sure all PR Checks are passing.
<!--
Notes:

Tests of a Python package can be run manually. Start a Server and an Executor then
run `make test` in the Python package directory.

To test if changes to the server are backward compatible with the latest
release, label the PR with `ci_compat_test`. This might report failures
unrelated to your change if previous incompatible changes were pushed without
being released yet
-->
