### PR TITLE
Make sure pdf parser image has the right torch version

### DIFF
--- a/examples/pdf_document_extraction/images.py
+++ b/examples/pdf_document_extraction/images.py
@@ -34,4 +34,5 @@ inkwell_image_gpu = (
     .run("apt update")
     .run("apt install -y libgl1-mesa-glx")
     .run('pip install docling')
+    .run('pip install torch==2.5.1 torchvision==0.2.1')
 )


### PR DESCRIPTION
## Context

Make sure the pdf parser image has the right version of the libs installed while running this example.

## What
Changes image file.

## Testing
```
root@d25a6cfe22ef:/app# pip freeze | grep torch
torch==2.5.1+cu124
torchaudio==2.5.1+cu124
torchelastic==0.2.2
torchvision==0.2.1
```
