### PR TITLE
Add protoc option --experimental_allow_proto3_optional

### DIFF
--- a/server/executor_api/build.rs
+++ b/server/executor_api/build.rs
@@ -8,6 +8,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .build_client(false) // Don't build client code as it's not needed for now
         .build_server(true)
         .file_descriptor_set_path(out_dir.join("executor_api_descriptor.bin"))
+        .protoc_arg("--experimental_allow_proto3_optional") // Required for building on Ubuntu 22.04
         .compile_protos(&proto_files, &["proto"])?;
     Ok(())
 }


### PR DESCRIPTION
This is required for building on Ubuntu 22.04
