### PR TITLE
Don't report task outcomes on Executor shutdown

### DIFF
--- a/indexify/src/indexify/executor/executor.py
+++ b/indexify/src/indexify/executor/executor.py
@@ -346,6 +346,7 @@ class Executor:
 
         self._is_shutdown = True
         await self._monitoring_server.shutdown()
+        await self._task_reporter.shutdown()
 
         if self._task_runner is not None:
             await self._task_runner.shutdown()


### PR DESCRIPTION
Doing this results in false positive task failures reported to Server.
