### PR TITLE
feat: stop persisting executor metadata

### DIFF
--- a/server/data_model/src/lib.rs
+++ b/server/data_model/src/lib.rs
@@ -1375,6 +1375,7 @@ pub enum ChangeType {
     ExecutorAdded(ExecutorAddedEvent),
     TombStoneExecutor(ExecutorRemovedEvent),
     ExecutorRemoved(ExecutorRemovedEvent),
+    HandleAbandonedAllocations,
 }
 
 impl fmt::Display for ChangeType {
@@ -1411,6 +1412,9 @@ impl fmt::Display for ChangeType {
                 "TombstoneInvocation, ns: {}, compute_graph: {}, invocation_id: {}",
                 ev.namespace, ev.compute_graph, ev.invocation_id
             ),
+            ChangeType::HandleAbandonedAllocations => {
+                write!(f, "HandleAbandonedAllocations")
+            }
         }
     }
 }

--- a/server/data_model/src/lib.rs
+++ b/server/data_model/src/lib.rs
@@ -1375,7 +1375,6 @@ pub enum ChangeType {
     ExecutorAdded(ExecutorAddedEvent),
     TombStoneExecutor(ExecutorRemovedEvent),
     ExecutorRemoved(ExecutorRemovedEvent),
-    HandleAbandonedAllocations,
 }
 
 impl fmt::Display for ChangeType {
@@ -1412,9 +1411,6 @@ impl fmt::Display for ChangeType {
                 "TombstoneInvocation, ns: {}, compute_graph: {}, invocation_id: {}",
                 ev.namespace, ev.compute_graph, ev.invocation_id
             ),
-            ChangeType::HandleAbandonedAllocations => {
-                write!(f, "HandleAbandonedAllocations")
-            }
         }
     }
 }

--- a/server/processor/src/graph_processor.rs
+++ b/server/processor/src/graph_processor.rs
@@ -220,9 +220,6 @@ impl GraphProcessor {
                     result
                         .new_allocations
                         .extend(placement_result.new_allocations);
-                    result
-                        .remove_allocations
-                        .extend(placement_result.remove_allocations);
                     result.updated_tasks.extend(placement_result.updated_tasks);
                     Ok(StateMachineUpdateRequest {
                         payload: RequestPayload::SchedulerUpdate(Box::new(result)),

--- a/server/processor/src/graph_processor.rs
+++ b/server/processor/src/graph_processor.rs
@@ -235,8 +235,7 @@ impl GraphProcessor {
             }
             ChangeType::ExecutorAdded(_) |
             ChangeType::ExecutorRemoved(_) |
-            ChangeType::TombStoneExecutor(_) |
-            ChangeType::HandleAbandonedAllocations => {
+            ChangeType::TombStoneExecutor(_) => {
                 let scheduler_update = self
                     .task_allocator
                     .invoke(&state_change.change_type, &mut indexes);

--- a/server/processor/src/graph_processor.rs
+++ b/server/processor/src/graph_processor.rs
@@ -229,7 +229,7 @@ impl GraphProcessor {
                         processed_state_changes: vec![state_change.clone()],
                     })
                 } else {
-                    error!("error creating tasks: {:?}", scheduler_update.err());
+                    error!("error invoking task creator: {:?}", scheduler_update.err());
                     Ok(StateMachineUpdateRequest {
                         payload: RequestPayload::Noop,
                         processed_state_changes: vec![state_change.clone()],
@@ -238,7 +238,8 @@ impl GraphProcessor {
             }
             ChangeType::ExecutorAdded(_) |
             ChangeType::ExecutorRemoved(_) |
-            ChangeType::TombStoneExecutor(_) => {
+            ChangeType::TombStoneExecutor(_) |
+            ChangeType::HandleAbandonedAllocations => {
                 let scheduler_update = self
                     .task_allocator
                     .invoke(&state_change.change_type, &mut indexes);
@@ -249,7 +250,7 @@ impl GraphProcessor {
                     })
                 } else {
                     error!(
-                        "error scheduling unplaced tasks: {:?}",
+                        "error invoking task allocator: {:?}",
                         scheduler_update.err()
                     );
                     Ok(StateMachineUpdateRequest {

--- a/server/processor/src/task_creator.rs
+++ b/server/processor/src/task_creator.rs
@@ -78,9 +78,11 @@ impl TaskCreator {
                     indexes.invocation_ctx.insert(ctx.key(), Box::new(ctx));
                 }
                 return Ok(SchedulerUpdateRequest {
-                    new_allocations: vec![],
-                    remove_allocations: vec![],
-                    updated_tasks: result.tasks,
+                    updated_tasks: result
+                        .tasks
+                        .into_iter()
+                        .map(|t| (t.id.clone(), t))
+                        .collect(),
                     updated_invocations_states: result
                         .invocation_ctx
                         .map(|ctx| ctx.clone())
@@ -90,7 +92,7 @@ impl TaskCreator {
                         new_reduction_tasks: result.new_reduction_tasks,
                         processed_reduction_tasks: result.processed_reduction_tasks,
                     },
-                    remove_executors: vec![],
+                    ..Default::default()
                 });
             }
             ChangeType::InvokeComputeGraph(ev) => {
@@ -105,9 +107,11 @@ impl TaskCreator {
                     indexes.invocation_ctx.insert(ctx.key(), Box::new(ctx));
                 }
                 return Ok(SchedulerUpdateRequest {
-                    new_allocations: vec![],
-                    remove_allocations: vec![],
-                    updated_tasks: result.tasks,
+                    updated_tasks: result
+                        .tasks
+                        .into_iter()
+                        .map(|t| (t.id.clone(), t))
+                        .collect(),
                     updated_invocations_states: result
                         .invocation_ctx
                         .map(|ctx| ctx.clone())
@@ -117,7 +121,7 @@ impl TaskCreator {
                         new_reduction_tasks: result.new_reduction_tasks,
                         processed_reduction_tasks: result.processed_reduction_tasks,
                     },
-                    remove_executors: vec![],
+                    ..Default::default()
                 });
             }
             _ => {

--- a/server/src/executors.rs
+++ b/server/src/executors.rs
@@ -69,20 +69,27 @@ impl ExecutorManager {
         Ok(executors)
     }
 
-    pub async fn list_allocations(&self) -> HashMap<String, Vec<Allocation>> {
+    pub async fn list_allocations(&self) -> HashMap<String, HashMap<String, Vec<Allocation>>> {
         self.indexify_state
             .in_memory_state
             .read()
             .await
-            .allocations_by_executor
+            .allocations_by_fn
             .iter()
-            .map(|(executor_id, allocations)| {
+            .map(|(executor_id, fns)| {
                 let executor_id = executor_id.clone();
-                let mut allocs = vec![];
-                for allocation in allocations {
-                    allocs.push(*allocation.clone());
-                }
-                (executor_id, allocs)
+                let fns = fns
+                    .iter()
+                    .map(|(fn_name, allocations)| {
+                        let fn_name = fn_name.clone();
+                        let mut allocs: Vec<Allocation> = vec![];
+                        for allocation in allocations {
+                            allocs.push((**allocation).clone());
+                        }
+                        (fn_name, allocs)
+                    })
+                    .collect();
+                (executor_id, fns)
             })
             .collect()
     }

--- a/server/src/http_objects.rs
+++ b/server/src/http_objects.rs
@@ -740,13 +740,20 @@ pub struct UnallocatedTasks {
 }
 
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
-pub struct ExecutorAllocations {
+pub struct ExecutorFns {
     pub count: usize,
+    pub fn_name: String,
     pub allocations: Vec<Allocation>,
 }
 
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
-pub struct ExecutorsAllocations {
+pub struct ExecutorAllocations {
+    pub total: usize,
+    pub executor_fns: Vec<ExecutorFns>,
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct ExecutorsAllocationsResponse {
     pub allocations: HashMap<String, ExecutorAllocations>,
 }
 

--- a/server/state_store/src/in_memory_state.rs
+++ b/server/state_store/src/in_memory_state.rs
@@ -132,15 +132,6 @@ impl InMemoryState {
             }
         }
 
-        // Creating Executors
-        let mut executors = im::HashMap::new();
-        {
-            let all_executors = reader.get_all_executors()?;
-            for executor in &all_executors {
-                executors.insert(executor.id.get().to_string(), Box::new(executor.clone()));
-            }
-        }
-
         // Creating Allocated Tasks By Executor
         let mut allocations_by_executor: im::HashMap<String, im::Vector<Box<Allocation>>> =
             im::HashMap::new();
@@ -289,7 +280,7 @@ impl InMemoryState {
             namespaces,
             compute_graphs,
             compute_graph_versions,
-            executors,
+            executors: im::HashMap::new(),
             allocations_by_executor,
             tasks,
             unallocated_tasks,

--- a/server/state_store/src/lib.rs
+++ b/server/state_store/src/lib.rs
@@ -323,9 +323,6 @@ impl IndexifyState {
                     vec![]
                 }
             }
-            RequestPayload::HandleAbandonedAllocations => {
-                state_changes::handle_abandoned_allocations(&self.last_state_change_id)?
-            }
             RequestPayload::RemoveGcUrls(urls) => {
                 state_machine::remove_gc_urls(self.db.clone(), &txn, urls.clone())?;
                 vec![]

--- a/server/state_store/src/migrations.rs
+++ b/server/state_store/src/migrations.rs
@@ -351,17 +351,17 @@ pub fn read_sm_meta(db: &TransactionDB) -> Result<StateMachineMetadata> {
     }
 }
 
-#[tracing::instrument(skip(db))]
+#[tracing::instrument(skip(db, existing_cfs))]
 pub fn drop_unused_cfs(existing_cfs: &Vec<String>, db: &mut TransactionDB) -> Result<()> {
-    if existing_cfs.contains(&"Executors".to_string()) {
-        info!("Dropping Executors column family during migration");
-        db.drop_cf("Executors")?;
+    let cfs_to_drop = vec!["Executors", "UnallocatedTasks", "TaskAllocations"];
+
+    for cf_name in cfs_to_drop {
+        if existing_cfs.contains(&cf_name.to_string()) {
+            info!("Dropping unused {} column family", cf_name);
+            db.drop_cf(cf_name)?;
+        }
     }
 
-    if existing_cfs.contains(&"UnallocatedTasks".to_string()) {
-        info!("Dropping UnallocatedTasks column family during migration");
-        db.drop_cf("UnallocatedTasks")?;
-    }
     Ok(())
 }
 

--- a/server/state_store/src/requests.rs
+++ b/server/state_store/src/requests.rs
@@ -32,7 +32,6 @@ pub enum RequestPayload {
     SchedulerUpdate(Box<SchedulerUpdateRequest>),
     RegisterExecutor(RegisterExecutorRequest),
     DeregisterExecutor(DeregisterExecutorRequest),
-    HandleAbandonedAllocations,
     RemoveGcUrls(Vec<String>),
     DeleteComputeGraphRequest(DeleteComputeGraphRequest),
     DeleteInvocationRequest(DeleteInvocationRequest),

--- a/server/state_store/src/requests.rs
+++ b/server/state_store/src/requests.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use data_model::{
     Allocation,
     ComputeGraph,
@@ -10,6 +12,7 @@ use data_model::{
     StateChange,
     Task,
     TaskDiagnostics,
+    TaskId,
 };
 
 #[derive(Debug)]
@@ -36,32 +39,14 @@ pub enum RequestPayload {
     Noop,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct SchedulerUpdateRequest {
     pub new_allocations: Vec<Allocation>,
     pub remove_allocations: Vec<Allocation>,
-    pub updated_tasks: Vec<Task>,
+    pub updated_tasks: HashMap<TaskId, Task>,
     pub updated_invocations_states: Vec<GraphInvocationCtx>,
     pub reduction_tasks: ReductionTasks,
     pub remove_executors: Vec<ExecutorId>,
-}
-
-impl SchedulerUpdateRequest {
-    pub fn merge(&mut self, other: &SchedulerUpdateRequest) {
-        self.new_allocations.extend(other.new_allocations.clone());
-        self.remove_allocations
-            .extend(other.remove_allocations.clone());
-        self.updated_tasks.extend(other.updated_tasks.clone());
-        self.updated_invocations_states
-            .extend(other.updated_invocations_states.clone());
-        self.reduction_tasks
-            .new_reduction_tasks
-            .extend(other.reduction_tasks.new_reduction_tasks.clone());
-        self.reduction_tasks
-            .processed_reduction_tasks
-            .extend(other.reduction_tasks.processed_reduction_tasks.clone());
-        self.remove_executors.extend(other.remove_executors.clone());
-    }
 }
 
 #[derive(Debug, Clone)]

--- a/server/state_store/src/requests.rs
+++ b/server/state_store/src/requests.rs
@@ -29,6 +29,7 @@ pub enum RequestPayload {
     SchedulerUpdate(Box<SchedulerUpdateRequest>),
     RegisterExecutor(RegisterExecutorRequest),
     DeregisterExecutor(DeregisterExecutorRequest),
+    HandleAbandonedAllocations,
     RemoveGcUrls(Vec<String>),
     DeleteComputeGraphRequest(DeleteComputeGraphRequest),
     DeleteInvocationRequest(DeleteInvocationRequest),
@@ -43,6 +44,24 @@ pub struct SchedulerUpdateRequest {
     pub updated_invocations_states: Vec<GraphInvocationCtx>,
     pub reduction_tasks: ReductionTasks,
     pub remove_executors: Vec<ExecutorId>,
+}
+
+impl SchedulerUpdateRequest {
+    pub fn merge(&mut self, other: &SchedulerUpdateRequest) {
+        self.new_allocations.extend(other.new_allocations.clone());
+        self.remove_allocations
+            .extend(other.remove_allocations.clone());
+        self.updated_tasks.extend(other.updated_tasks.clone());
+        self.updated_invocations_states
+            .extend(other.updated_invocations_states.clone());
+        self.reduction_tasks
+            .new_reduction_tasks
+            .extend(other.reduction_tasks.new_reduction_tasks.clone());
+        self.reduction_tasks
+            .processed_reduction_tasks
+            .extend(other.reduction_tasks.processed_reduction_tasks.clone());
+        self.remove_executors.extend(other.remove_executors.clone());
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/server/state_store/src/scanner.rs
+++ b/server/state_store/src/scanner.rs
@@ -5,7 +5,6 @@ use data_model::{
     ComputeGraph,
     ComputeGraphVersion,
     DataPayload,
-    ExecutorMetadata,
     GraphInvocationCtx,
     GraphVersion,
     InvocationPayload,
@@ -823,19 +822,6 @@ impl StateReader {
             .filter_map(|v| v)
             .collect();
         Ok(data_objects)
-    }
-
-    pub fn get_all_executors(&self) -> Result<Vec<ExecutorMetadata>> {
-        let kvs = &[KeyValue::new("op", "get_all_executors")];
-        let _timer = Timer::start_with_labels(&self.metrics.state_read, kvs);
-
-        let (executors, _) = self.get_rows_from_cf_with_limits::<ExecutorMetadata>(
-            &[],
-            None,
-            IndexifyObjectsColumns::Executors,
-            None,
-        )?;
-        Ok(executors)
     }
 
     pub fn invocation_ctx(

--- a/server/state_store/src/state_changes.rs
+++ b/server/state_store/src/state_changes.rs
@@ -188,3 +188,18 @@ pub fn register_executor(
 
     Ok(vec![state_change])
 }
+
+pub fn handle_abandoned_allocations(last_state_change_id: &AtomicU64) -> Result<Vec<StateChange>> {
+    let last_change_id = last_state_change_id.fetch_add(1, atomic::Ordering::Relaxed);
+    let state_change = StateChangeBuilder::default()
+        .change_type(ChangeType::HandleAbandonedAllocations)
+        .namespace(None)
+        .compute_graph(None)
+        .invocation(None)
+        .created_at(get_epoch_time_in_ms())
+        .object_id(format!("handle-abandoned-allocations-{}", last_change_id))
+        .id(StateChangeId::new(last_change_id))
+        .processed_at(None)
+        .build()?;
+    Ok(vec![state_change])
+}

--- a/server/state_store/src/state_changes.rs
+++ b/server/state_store/src/state_changes.rs
@@ -181,18 +181,3 @@ pub fn register_executor(
 
     Ok(vec![state_change])
 }
-
-pub fn handle_abandoned_allocations(last_state_change_id: &AtomicU64) -> Result<Vec<StateChange>> {
-    let last_change_id = last_state_change_id.fetch_add(1, atomic::Ordering::Relaxed);
-    let state_change = StateChangeBuilder::default()
-        .change_type(ChangeType::HandleAbandonedAllocations)
-        .namespace(None)
-        .compute_graph(None)
-        .invocation(None)
-        .created_at(get_epoch_time_in_ms())
-        .object_id(format!("handle-abandoned-allocations-{}", last_change_id))
-        .id(StateChangeId::new(last_change_id))
-        .processed_at(None)
-        .build()?;
-    Ok(vec![state_change])
-}

--- a/server/state_store/src/state_changes.rs
+++ b/server/state_store/src/state_changes.rs
@@ -120,32 +120,25 @@ pub fn task_outputs_ingested(
     Ok(vec![state_change])
 }
 
-pub fn deregister_executor_events(
+pub fn deregister_executor_event(
     last_state_change_id: &AtomicU64,
-    executor_ids: &[ExecutorId],
+    executor_id: ExecutorId,
 ) -> Result<Vec<StateChange>> {
-    let state_changes = executor_ids
-        .iter()
-        .map(|executor_id| -> Result<StateChange> {
-            let last_change_id = last_state_change_id.fetch_add(1, atomic::Ordering::Relaxed);
-            let state_change = StateChangeBuilder::default()
-                .change_type(ChangeType::ExecutorRemoved(ExecutorRemovedEvent {
-                    executor_id: executor_id.clone(),
-                }))
-                .namespace(None)
-                .compute_graph(None)
-                .invocation(None)
-                .created_at(get_epoch_time_in_ms())
-                .object_id(executor_id.get().to_string())
-                .id(StateChangeId::new(last_change_id))
-                .processed_at(None)
-                .build()?;
+    let last_change_id = last_state_change_id.fetch_add(1, atomic::Ordering::Relaxed);
+    let state_change = StateChangeBuilder::default()
+        .change_type(ChangeType::ExecutorRemoved(ExecutorRemovedEvent {
+            executor_id: executor_id.clone(),
+        }))
+        .namespace(None)
+        .compute_graph(None)
+        .invocation(None)
+        .created_at(get_epoch_time_in_ms())
+        .object_id(executor_id.get().to_string())
+        .id(StateChangeId::new(last_change_id))
+        .processed_at(None)
+        .build()?;
 
-            Ok(state_change)
-        })
-        .collect::<Result<Vec<_>>>()?;
-
-    Ok(state_changes)
+    Ok(vec![state_change])
 }
 
 pub fn tombstone_executor(

--- a/server/state_store/src/state_machine.rs
+++ b/server/state_store/src/state_machine.rs
@@ -67,7 +67,6 @@ pub enum IndexifyObjectsColumns {
 
     UnprocessedStateChanges, //  StateChangeId -> StateChange
     Allocations,             // Allocation ID -> Allocation
-    TaskAllocations,         //  ExecutorId -> Task_Key
 
     GcUrls, // List of URLs pending deletion
 


### PR DESCRIPTION
## Context

<!--
In a few sentences or less, please explain the context behind this change to help answer why this change is needed.

If this is a bug fix, make sure to include "fixes #xxxx", or
"closes #xxxx".

Screenshots, logs, code or other visual aids are greatly appreciated.
 -->

As part of changing the protocol between executors and servers, it has become obvious that persisting executors is not required and adds complexity.

## What

This PR moves executor to only live in memory. Additionally, we look at persisted allocations to determine whether some allocations were abandoned when the server restarts for executors that did not reconnect within 30s.

The graph processor is also now running within its own thread.

<!--
In a few sentences, please summarize the change to help reviewers.

Consider providing screenshots, logs, code or other visual aids to help the reviewer understand the approach taken.
-->

## Testing

<!--
Please include steps used to verify the change.

Consider providing screenshots, logs, code or other visual aids to help the reviewer in their testing.
-->

## Contribution Checklist

- [x] If a Python package was changed, please run `make fmt` in the package directory.
- [x] If the server was changed, please run `make fmt` in `server/`.
- [x] Make sure all PR Checks are passing.
<!--
Notes:

Tests of a Python package can be run manually. Start a Server and an Executor then
run `make test` in the Python package directory.

To test if changes to the server are backward compatible with the latest
release, label the PR with `ci_compat_test`. This might report failures
unrelated to your change if previous incompatible changes were pushed without
being released yet
-->
