### PR TITLE
Add GH test action with Server <-> Executor gRPC enabled

### DIFF
--- a/.github/workflows/tests_grpc.yaml
+++ b/.github/workflows/tests_grpc.yaml
@@ -1,0 +1,180 @@
+name: Tests with gRPC enabled
+
+on:
+  push:
+    branches:
+      - 'main'
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+    paths:
+      - 'server/**'
+      - 'indexify/**'
+      - 'tensorlake'
+      - '.github/workflows/tests_grpc.yaml'
+
+env:
+  CARGO_TERM_COLOR: always
+  INDEXIFY_URL: http://localhost:8900
+
+jobs:
+  lint_server:
+    name: Lint Indexify Server
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Lint indexify-server
+        run: |
+          cd server
+          make check
+
+  build_server:
+    name: Build Indexify Server
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install protobuf package
+        run: sudo apt install -y protobuf-compiler
+      - uses: actions/checkout@v4
+      - name: Copy rust-toolchain
+        run: cp server/rust-toolchain.toml .
+      - name: Setup Rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          cache-directories: |
+            server/target
+      - name: Setup Rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          cache-directories: |
+            server/target
+      - name: Build indexify-server
+        run: |
+          cd server
+          cargo build
+      - name: Lint indexify-server
+        run: |
+          cd server
+          make check
+      - name: Test indexify-server
+        run: |
+          cd server
+          cargo test --workspace -- --test-threads 1
+      - name: Upload indexify-server
+        uses: actions/upload-artifact@v4
+        with:
+          name: indexify-server
+          path: server/target/debug/indexify-server
+
+  lint_python_packages:
+    name: Lint Python packages
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: Install poetry
+        run: pipx install --force 'poetry==2.0.0'
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.9
+          cache: 'poetry'
+      - name: Build and lint indexify
+        run: cd indexify && make build && make check
+
+  acceptance_tests:
+    name: Run Acceptance Tests
+    needs: [build_server, lint_python_packages]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - name: Download indexify-server
+        uses: actions/download-artifact@v4
+        with:
+          name: indexify-server
+      - name: Start Background Indexify Server
+        uses: JarvusInnovations/background-action@v1
+        with:
+          run: |
+            chmod u+x ./indexify-server
+            RUST_LOG=debug ./indexify-server &
+            echo $! > /tmp/indexify-server.pid &
+
+          wait-on: |
+            tcp:localhost:8900
+
+          tail: true
+          wait-for: 30s
+          log-output: true
+          # always logging the output to debug test failures.
+          log-output-if: true
+
+      - name: Install poetry
+        run: pipx install --force 'poetry==2.0.0'
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.9
+          cache: 'poetry'
+      - name: Build tensorlake
+        run: cd tensorlake && make build
+      - name: Build indexify
+        run: cd indexify && make build
+      - name: Start Background Indexify Executor
+        uses: JarvusInnovations/background-action@v1
+        with:
+          run: |
+            cd indexify
+            poetry run indexify-cli executor --dev --grpc-server-addr localhost:8901 &
+            echo $! > /tmp/indexify-executor.pid &
+
+          wait-on: |
+            tcp:localhost:7000
+
+          tail: true
+          wait-for: 10s
+          log-output: true
+          # always logging the output to debug test failures.
+          log-output-if: true
+      - name: Wait for readiness
+        run: |
+          serverReady=false
+          counter=0
+          while [ "$serverReady" != true ]; do
+            output=$(curl --silent --fail http://localhost:8900/internal/executors | jq '. | length' 2>/dev/null)
+            if [[ $? -eq 0 && "$output" -ge 1 ]]; then
+                echo "Server ready with executors."
+                serverReady=true
+            else
+                echo 'Waiting for executors to join server...'
+                counter=$((counter+1))
+                if [ $counter -gt 6 ]; then
+                    echo "Timeout waiting for executors to join server."
+                    exit 1
+                fi
+                sleep 5
+            fi
+          done
+      - name: Run all tests
+        run: cd indexify && make test
+      - name: Terminate processes
+        # We want to test clean termination of processes.
+        run: |
+          pkill -SIGTERM -F /tmp/indexify-server.pid
+          pkill -SIGTERM -F /tmp/indexify-executor.pid
+      - name: Wait for processes termination
+        run: |
+          pid_files="/tmp/indexify-server.pid /tmp/indexify-executor.pid"
+          for pid_file in $pid_files; do
+            while pkill -0 -F "$pid_file" 2>/dev/null; do
+              echo "waiting for process $pid_file to exit..."
+              sleep 1
+            done
+          done
+      - name: Validate that all processes terminated
+        run: |
+          if pgrep -f indexify; then
+            echo "Error: Some Indexify processes are still running."
+            exit 1
+          fi


### PR DESCRIPTION
This allows us to continuously test for regressions when the new gRPC protocol is enabled.

This action is a copy of existing tests.yaml with extra executor CLI flag that enables gRPC Executor state reporting
at the supplied gRPC Server endpoint.