### PR TITLE
Making the server get the URLs of stored outputs from executor and returning URLs as inputs to functions 

### DIFF
--- a/server/blob_store/src/lib.rs
+++ b/server/blob_store/src/lib.rs
@@ -50,7 +50,7 @@ impl Default for BlobStorageConfig {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PutResult {
     pub url: String,
     pub size_bytes: u64,

--- a/server/data_model/src/lib.rs
+++ b/server/data_model/src/lib.rs
@@ -568,8 +568,6 @@ pub struct NodeOutput {
     pub reduced_state: bool,
     pub created_at: u64,
     pub encoding: String,
-    #[serde(default)]
-    pub output_urls: Vec<String>,
     #[serde(default = "default_output_encoding_version")]
     pub output_encoding_version: u64,
 }
@@ -629,7 +627,6 @@ impl NodeOutputBuilder {
             .output_encoding_version
             .clone()
             .unwrap_or_else(default_output_encoding_version);
-        let output_urls = self.output_urls.clone().unwrap_or_default();
         let payload = self.payload.clone().ok_or(anyhow!("payload is required"))?;
         let reduced_state = self.reduced_state.clone().unwrap_or(false);
         let created_at: u64 = get_epoch_time_in_ms();
@@ -658,7 +655,6 @@ impl NodeOutputBuilder {
             reduced_state,
             created_at,
             encoding,
-            output_urls,
             output_encoding_version,
         })
     }
@@ -974,12 +970,12 @@ pub struct ExecutorTask {
     pub graph_version: GraphVersion,
     pub image_uri: Option<String>,
     pub secret_names: Option<Vec<String>>,
-    pub input_urls: Option<Vec<String>>,
+    pub input: DataPayload,
     pub input_encoding_version: u64,
 }
 
 impl ExecutorTask {
-    pub fn from_task(task: &Task, input_urls: Vec<String>) -> Self {
+    pub fn from_task(task: &Task, input: DataPayload) -> Self {
         ExecutorTask {
             id: task.id.clone(),
             namespace: task.namespace.clone(),
@@ -992,7 +988,7 @@ impl ExecutorTask {
             graph_version: task.graph_version.clone(),
             image_uri: task.image_uri.clone(),
             secret_names: task.secret_names.clone(),
-            input_urls: Some(input_urls),
+            input,
             input_encoding_version: 0,
         }
     }

--- a/server/src/gc_test.rs
+++ b/server/src/gc_test.rs
@@ -86,7 +86,6 @@ mod tests {
             reduced_state: false,
             created_at: 5,
             encoding: "application/octet-stream".to_string(),
-            output_urls: vec![],
             output_encoding_version: 0,
         };
         let key = output.key(&output.invocation_id);

--- a/server/src/gc_test.rs
+++ b/server/src/gc_test.rs
@@ -86,6 +86,8 @@ mod tests {
             reduced_state: false,
             created_at: 5,
             encoding: "application/octet-stream".to_string(),
+            output_urls: vec![],
+            output_encoding_version: 0,
         };
         let key = output.key(&output.invocation_id);
         let serialized_output = JsonEncoder::encode(&output)?;

--- a/server/src/integration_test.rs
+++ b/server/src/integration_test.rs
@@ -1607,7 +1607,18 @@ mod tests {
         let res = stream.next().await.unwrap()?;
         assert_eq!(res.len(), 1);
 
-        let mut task = res.first().unwrap().clone();
+        let executor_task = res.first().unwrap().clone();
+        let mut task = indexify_state
+            .reader()
+            .get_task(
+                &executor_task.namespace,
+                &executor_task.compute_graph_name,
+                &executor_task.invocation_id,
+                &executor_task.compute_fn_name,
+                &executor_task.id.get(),
+            )
+            .unwrap()
+            .unwrap();
         task.status = TaskStatus::Completed;
         task.outcome = TaskOutcome::Success;
 

--- a/server/src/routes.rs
+++ b/server/src/routes.rs
@@ -17,7 +17,7 @@ use axum_tracing_opentelemetry::{
 };
 use base64::prelude::*;
 use blob_store::PutResult;
-use data_model::{ComputeGraphError, ExecutorId};
+use data_model::{ComputeGraphError, ExecutorId, ExecutorTask};
 use futures::StreamExt;
 use hyper::StatusCode;
 use indexify_ui::Assets as UiAssets;
@@ -831,7 +831,7 @@ async fn executor_tasks(
     let stream = stream
         .map(|item| match item {
             Ok(item) => {
-                let item: Vec<Task> = item.into_iter().map(Into::into).collect();
+                let item: Vec<ExecutorTask> = item.into_iter().map(Into::into).collect();
                 axum::response::sse::Event::default().json_data(item)
             }
             Err(e) => {


### PR DESCRIPTION
Getting the server ready to accept function output urls from the executor. 

We will expect the executor to send JSON payload of the URLs where it stores the fucntion outputs - 

```
{
  "url": ..
   "checksum": ...
   "size":...
}

Which is same as `PutResult` we use in the server internally to track the outputs. Everything else more or less remains same. 

We are also sending the executor the DataPayload object which is the URL of the input which it needs to download 