### PR TITLE
Fn metrics

### DIFF
--- a/indexify/src/indexify/executor/function_executor/single_task_runner.py
+++ b/indexify/src/indexify/executor/function_executor/single_task_runner.py
@@ -26,7 +26,7 @@ from .server.function_executor_server_factory import (
     FunctionExecutorServerFactory,
 )
 from .task_input import TaskInput
-from .task_output import TaskOutput
+from .task_output import TaskMetrics, TaskOutput
 
 
 class SingleTaskRunner:

--- a/indexify/src/indexify/executor/function_executor/task_output.py
+++ b/indexify/src/indexify/executor/function_executor/task_output.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, Dict
 
 from tensorlake.function_executor.proto.function_executor_pb2 import (
     FunctionOutput,

--- a/indexify/src/indexify/executor/function_executor/task_output.py
+++ b/indexify/src/indexify/executor/function_executor/task_output.py
@@ -6,6 +6,13 @@ from tensorlake.function_executor.proto.function_executor_pb2 import (
 )
 
 
+class TaskMetrics:
+    """Metrics for a task."""
+
+    def __init__(self, counters: Dict[str, int], timers: Dict[str, float]):
+        self.counters = counters
+        self.timers = timers
+
 class TaskOutput:
     """Result of running a task."""
 


### PR DESCRIPTION
Logging "Customer Metrics" in executor logs, so that they can be pushed into logging systems for observing internal metrics of functions. 

We have to figure out the "platform" story for metrics, since we want them to be accessed through tensorlake cloud. 

For open source we probably need a way to disable logging metrics. But skipping this for now in interest of time. Updated graph behavior test in tensorlake repo - https://github.com/tensorlakeai/tensorlake/pull/78

Tests 

```
2025-03-21 22:59:52 [info     ] task execution finished        function_name=simple_function_ctx graph=__main___TestGraphBehaviors_test_graph_context_1 graph_version=6lo-Ia_4i6uyVD1gkUSR7 invocation_id=82e041e801c18e1e module=indexify.executor.executor namespace=default success=True task_id=063109cd-4bf7-4f08-8d9b-29fdf64f217a
2025-03-21 22:59:52 [info     ] customer_metric                counter_name=test_counter counter_value=8 function_name=simple_function_ctx graph_name=__main___TestGraphBehaviors_test_graph_context_1 invocation_id=82e041e801c18e1e module=indexify.executor.executor namespace=default
2025-03-21 22:59:52 [info     ] customer_metric                function_name=simple_function_ctx graph_name=__main___TestGraphBehaviors_test_graph_context_1 invocation_id=82e041e801c18e1e module=indexify.executor.executor namespace=default timer_name=test_timer timer_value=1.7999999523162842
2025-03-21 22:59:52 [info     ] reporting task outcome         function_name=simple_function_ctx graph=__main___TestGraphBehaviors_test_graph_context_1 graph_version=6lo-Ia_4i6uyVD1gkUSR7 invocation_id=82e041e801c18e1e module=indexify.executor.task_reporter namespace=default output_bytes=4404 output_files=1 retries=0 router_output_count=0 stderr_bytes=0 stdout_bytes=0 task_id=063109cd-4bf7-4f08-8d9b-29fdf64f217a total_bytes=4404 total_files=3
````