### PR TITLE
test: properly assert gcurls of deleted graphs

### DIFF
--- a/server/src/integration_test.rs
+++ b/server/src/integration_test.rs
@@ -414,8 +414,8 @@ mod tests {
             assert_cf_counts(
                 indexify_state.db.clone(),
                 HashMap::from([
-                    (IndexifyObjectsColumns::GcUrls.as_ref().to_string(), 6), /* 1x input, 3x
-                                                                               * output, 2x
+                    (IndexifyObjectsColumns::GcUrls.as_ref().to_string(), 8), /* 1x input, 3x
+                                                                               * output, 4x
                                                                                * diagnostics */
                 ]),
             )?;

--- a/server/src/testing.rs
+++ b/server/src/testing.rs
@@ -214,7 +214,7 @@ impl FinalizeTaskArgs {
         self.diagnostics = Some(TaskDiagnostics {
             stdout: if stdout {
                 Some(DataPayload {
-                    path: "stdout".to_string(),
+                    path: format!("stdout_{}", uuid::Uuid::new_v4().to_string()),
                     size: 0,
                     sha256_hash: "".to_string(),
                 })
@@ -223,7 +223,7 @@ impl FinalizeTaskArgs {
             },
             stderr: if stderr {
                 Some(DataPayload {
-                    path: "stderr".to_string(),
+                    path: format!("stderr_{}", uuid::Uuid::new_v4().to_string()),
                     size: 0,
                     sha256_hash: "".to_string(),
                 })


### PR DESCRIPTION
## Context

<!--
In a few sentences or less, please explain the context behind this change to help answer why this change is needed.

If this is a bug fix, make sure to include "fixes #xxxx", or
"closes #xxxx".

Screenshots, logs, code or other visual aids are greatly appreciated.
 -->

By using the same path for stderr and stdout, we were not correctly testing tha twe were deleting all files from blob storage.

## What

<!--
In a few sentences, please summarize the change to help reviewers.

Consider providing screenshots, logs, code or other visual aids to help the reviewer understand the approach taken.
-->

Make path of diagnostic files unique and change the assertion around them.

## Testing

<!--
Please include steps used to verify the change.

Consider providing screenshots, logs, code or other visual aids to help the reviewer in their testing.
-->

## Contribution Checklist

- [x] If a Python package was changed, please run `make fmt` in the package directory.
- [x] If the server was changed, please run `make fmt` in `server/`.
- [x] Make sure all PR Checks are passing.
<!--
Notes:

Tests of a Python package can be run manually. Start a Server and an Executor then
run `make test` in the Python package directory.

To test if changes to the server are backward compatible with the latest
release, label the PR with `ci_compat_test`. This might report failures
unrelated to your change if previous incompatible changes were pushed without
being released yet
-->
