### PR TITLE
feat: implement server heartbeats

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -790,6 +790,7 @@ dependencies = [
  "anyhow",
  "derive_builder",
  "indexify_utils",
+ "nanoid",
  "rand",
  "serde",
  "serde_json",

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -1621,6 +1621,7 @@ dependencies = [
  "futures",
  "pin-project",
  "serde_json",
+ "tokio",
 ]
 
 [[package]]

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -1575,6 +1575,7 @@ dependencies = [
  "opentelemetry-otlp",
  "opentelemetry-prometheus",
  "opentelemetry_sdk",
+ "priority-queue",
  "processor",
  "prometheus",
  "prost",
@@ -2322,6 +2323,17 @@ checksum = "5316f57387668042f561aae71480de936257848f9c43ce528e311d89a07cadeb"
 dependencies = [
  "proc-macro2",
  "syn",
+]
+
+[[package]]
+name = "priority-queue"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef08705fa1589a1a59aa924ad77d14722cb0cd97b67dd5004ed5f4a4873fce8d"
+dependencies = [
+ "autocfg",
+ "equivalent",
+ "indexmap 2.7.1",
 ]
 
 [[package]]

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -143,11 +143,13 @@ tonic = { workspace = true }
 prost = { workspace = true }
 tonic-reflection = { workspace = true }
 tokio-stream = { workspace = true }
+priority-queue = "2.3.1"
 
 [dev-dependencies]
 tempfile = { workspace = true }
 strum = { workspace = true }
 rocksdb = { workspace = true }
+tokio = { workspace = true, features = ["test-util"] }
 
 [build-dependencies]
 # All features enabled

--- a/server/data_model/Cargo.toml
+++ b/server/data_model/Cargo.toml
@@ -13,6 +13,7 @@ serde_json = { workspace = true }
 indexify_utils = { workspace = true }
 rand = { workspace = true }
 uuid = { workspace = true }
+nanoid = { workspace = true }
 sha2 = { workspace = true }
 strum = { workspace = true }
 tracing = { workspace = true }

--- a/server/data_model/src/lib.rs
+++ b/server/data_model/src/lib.rs
@@ -1254,12 +1254,7 @@ pub struct ExecutorMetadata {
     pub function_executors: HashMap<String, FunctionExecutor>,
     pub host_resources: HostResources,
     pub state: ExecutorState,
-}
-
-impl ExecutorMetadata {
-    pub fn key(&self) -> String {
-        format!("{}", self.id)
-    }
+    pub tombstoned: bool,
 }
 
 impl ExecutorMetadataBuilder {
@@ -1284,6 +1279,7 @@ impl ExecutorMetadataBuilder {
             .clone()
             .ok_or(anyhow!("host_resources is required"))?;
         let state = self.state.clone().ok_or(anyhow!("state is required"))?;
+        let tombstoned = self.tombstoned.unwrap_or(false);
         Ok(ExecutorMetadata {
             id,
             executor_version,
@@ -1293,6 +1289,7 @@ impl ExecutorMetadataBuilder {
             function_executors,
             host_resources,
             state,
+            tombstoned,
         })
     }
 }

--- a/server/data_model/src/lib.rs
+++ b/server/data_model/src/lib.rs
@@ -1216,7 +1216,6 @@ pub struct FunctionExecutor {
 
 impl FunctionExecutorBuilder {
     pub fn build(&mut self) -> Result<FunctionExecutor> {
-        let id = self.id.clone().ok_or(anyhow!("id is required"))?;
         let namespace = self
             .namespace
             .clone()
@@ -1231,6 +1230,7 @@ impl FunctionExecutorBuilder {
             .ok_or(anyhow!("compute_fn_name is required"))?;
         let version = self.version.clone().ok_or(anyhow!("version is required"))?;
         let status = self.status.clone().ok_or(anyhow!("status is required"))?;
+        let id = nanoid::nanoid!();
         Ok(FunctionExecutor {
             id,
             namespace,

--- a/server/data_model/src/test_objects.rs
+++ b/server/data_model/src/test_objects.rs
@@ -319,6 +319,7 @@ pub mod tests {
             host_resources: Default::default(),
             state: Default::default(),
             function_executors: Default::default(),
+            tombstoned: false,
         }
     }
 }

--- a/server/processor/src/task_allocator.rs
+++ b/server/processor/src/task_allocator.rs
@@ -13,7 +13,6 @@ use data_model::{
     TaskId,
     TaskStatus,
 };
-use im::Vector;
 use itertools::Itertools;
 use rand::seq::SliceRandom;
 use state_store::{
@@ -198,10 +197,12 @@ impl TaskAllocationProcessor {
             let executors = indexes
                 .executors
                 .iter()
+                // filter out executors that are tombstoned
+                .filter(|(_, executor)| !executor.tombstoned)
                 .filter(|(k, _)| {
                     let all_allocations = indexes.allocations_by_fn.get(*k);
                     let allocations_for_fn = all_allocations.map_or(0, |allocs| {
-                        allocs.get(&task.fn_uri()).unwrap_or(&Vector::new()).len()
+                        allocs.get(&task.fn_uri()).map_or(0, |v| v.len())
                     });
                     allocations_for_fn < MAX_ALLOCATIONS_PER_FN_EXECUTOR
                 })

--- a/server/src/executor_api.rs
+++ b/server/src/executor_api.rs
@@ -6,16 +6,37 @@ pub mod executor_api_pb {
 use std::{collections::HashMap, pin::Pin, sync::Arc};
 
 use data_model::{
-    DataPayload, ExecutorId, ExecutorMetadata, ExecutorMetadataBuilder, FunctionExecutor,
-    FunctionExecutorStatus, FunctionURI, GpuResources, GraphVersion, HostResources,
-    NodeOutputBuilder, OutputPayload, TaskDiagnostics, TaskOutcome, TaskOutputsIngestionStatus,
+    DataPayload,
+    ExecutorId,
+    ExecutorMetadata,
+    ExecutorMetadataBuilder,
+    FunctionExecutor,
+    FunctionExecutorStatus,
+    FunctionURI,
+    GpuResources,
+    GraphVersion,
+    HostResources,
+    NodeOutputBuilder,
+    OutputPayload,
+    TaskDiagnostics,
+    TaskOutcome,
+    TaskOutputsIngestionStatus,
     TaskStatus,
 };
 use executor_api_pb::{
-    executor_api_server::ExecutorApi, AllowedFunction, DesiredExecutorState, ExecutorState,
-    ExecutorStatus, FunctionExecutorDescription, GetDesiredExecutorStatesRequest, GpuModel,
-    OutputEncoding, ReportExecutorStateRequest, ReportExecutorStateResponse,
-    ReportTaskOutcomeRequest, ReportTaskOutcomeResponse,
+    executor_api_server::ExecutorApi,
+    AllowedFunction,
+    DesiredExecutorState,
+    ExecutorState,
+    ExecutorStatus,
+    FunctionExecutorDescription,
+    GetDesiredExecutorStatesRequest,
+    GpuModel,
+    OutputEncoding,
+    ReportExecutorStateRequest,
+    ReportExecutorStateResponse,
+    ReportTaskOutcomeRequest,
+    ReportTaskOutcomeResponse,
 };
 use metrics::api_io_stats;
 use state_store::{

--- a/server/src/executor_api.rs
+++ b/server/src/executor_api.rs
@@ -241,14 +241,9 @@ impl ExecutorApi for ExecutorAPIService {
             "Got report_executor_state request from Executor with ID {}",
             executor_state.executor_id()
         );
-        // Comment out not finished functionality.
-        // let executor_metadata =
-        ExecutorMetadata::try_from(executor_state)
-            .map_err(|e| Status::invalid_argument(e.to_string()))?;
-        // self.executor_manager
-        //     .heartbeat(executor_metadata)
-        //     .await
-        //     .map_err(|e| Status::internal(e.to_string()))?;
+        let _executor_id = executor_state
+            .executor_id
+            .ok_or(Status::invalid_argument("executor_id is required"))?;
         Ok(Response::new(ReportExecutorStateResponse {}))
     }
 

--- a/server/src/executors.rs
+++ b/server/src/executors.rs
@@ -56,6 +56,13 @@ impl ExecutorManager {
         ExecutorManager { indexify_state }
     }
 
+    #[allow(dead_code)]
+    pub async fn heartbeat(&self, executor: ExecutorMetadata) -> Result<()> {
+        let in_memory_state = self.indexify_state.in_memory_state.read().await;
+        let _executor_state = in_memory_state.executors.get(&executor.id.to_string());
+        Ok(())
+    }
+
     pub async fn register_executor(&self, executor: ExecutorMetadata) -> Result<()> {
         let sm_req = StateMachineUpdateRequest {
             payload: RequestPayload::RegisterExecutor(RegisterExecutorRequest { executor }),

--- a/server/src/executors.rs
+++ b/server/src/executors.rs
@@ -1,32 +1,80 @@
-use std::{collections::HashMap, sync::Arc, time::Duration, vec};
+use std::{cmp::Ordering, collections::HashMap, sync::Arc, time::Duration, vec};
 
 use anyhow::Result;
 use data_model::{Allocation, ExecutorId, ExecutorMetadata};
+use priority_queue::PriorityQueue;
 use state_store::{
     requests::{
         DeregisterExecutorRequest,
-        RegisterExecutorRequest,
         RequestPayload,
         StateMachineUpdateRequest,
+        UpsertExecutorRequest,
     },
     IndexifyState,
 };
-use tracing::error;
+use tokio::{
+    sync::{watch, Notify, RwLock},
+    time::Instant,
+};
+use tracing::{error, trace};
 
 pub const EXECUTOR_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Wrapper for `tokio::time::Instant` that reverses the ordering for deadline.
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub struct ReverseInstant(pub Instant);
+
+impl Ord for ReverseInstant {
+    fn cmp(&self, other: &Self) -> Ordering {
+        other.0.cmp(&self.0) // Reverse ordering
+    }
+}
+
+impl PartialOrd for ReverseInstant {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
 pub struct ExecutorManager {
+    heartbeat_state: RwLock<PriorityQueue<ExecutorId, ReverseInstant>>,
+    /// Used to wake the monitor only when necessary
+    notify: Arc<Notify>,
     indexify_state: Arc<IndexifyState>,
+}
+
+/// Represents the possible outcomes of waiting for an event in the heartbeat
+/// monitor
+enum WaitResult {
+    /// A deadline for executor heartbeat has been reached
+    Deadline,
+    /// A notification about executor state has been received
+    Notified,
+    /// A shutdown signal has been received
+    Shutdown,
 }
 
 impl ExecutorManager {
     pub async fn new(indexify_state: Arc<IndexifyState>) -> Self {
-        let state = indexify_state.clone();
+        let em = ExecutorManager {
+            indexify_state,
+            heartbeat_state: RwLock::new(PriorityQueue::new()),
+            notify: Arc::new(Notify::new()),
+        };
+
+        em.schedule_clean_lapsed_executors();
+
+        em
+    }
+
+    pub fn schedule_clean_lapsed_executors(&self) {
+        let indexify_state = self.indexify_state.clone();
         tokio::spawn(async move {
             tokio::time::sleep(EXECUTOR_TIMEOUT).await;
 
             // Get all executor IDs of executors that haven't registered.
             let missing_executor_ids: Vec<String> = {
-                let indexes = state.in_memory_state.read().await;
+                let indexes = indexify_state.in_memory_state.read().await;
 
                 indexes
                     .allocations_by_fn
@@ -44,7 +92,7 @@ impl ExecutorManager {
                     }),
                     processed_state_changes: vec![],
                 };
-                if let Err(err) = state.write(sm_req).await {
+                if let Err(err) = indexify_state.write(sm_req).await {
                     error!(
                         executor_id = executor_id,
                         "failed to deregister lapsed executor: {:?}", err
@@ -52,20 +100,173 @@ impl ExecutorManager {
                 }
             }
         });
-
-        ExecutorManager { indexify_state }
     }
 
-    #[allow(dead_code)]
+    /// Heartbeat an executor to keep it alive and update its metadata
     pub async fn heartbeat(&self, executor: ExecutorMetadata) -> Result<()> {
-        let in_memory_state = self.indexify_state.in_memory_state.read().await;
-        let _executor_state = in_memory_state.executors.get(&executor.id.to_string());
+        let first_executor = {
+            // 1. Create new deadline
+            let new_deadline = ReverseInstant(Instant::now() + EXECUTOR_TIMEOUT);
+
+            trace!(executor_id = executor.id.get(), "Heartbeat received");
+
+            // 2. Acquire a write lock on the heartbeat state
+            let mut state = self.heartbeat_state.write().await;
+
+            let was_empty = state.is_empty();
+
+            // 3. Update the executor's deadline or add it to the queue
+            if state.change_priority(&executor.id, new_deadline).is_none() {
+                state.push(executor.id.clone(), new_deadline);
+            }
+
+            was_empty
+        };
+
+        // 4. Notify of a first executor to wake up the monitor
+        if first_executor {
+            self.notify.notify_one();
+        }
+
+        // 5. Register the executor to upsert its metadata
+        let err = self.register_executor(executor.clone()).await;
+        if let Err(e) = err {
+            error!("failed to register executor {}: {:?}", executor.id.get(), e);
+            return Err(e);
+        }
+
+        Ok(())
+    }
+
+    /// Waits for the next event in the heartbeat monitoring process
+    async fn wait_for_heartbeat_event(&self, shutdown_rx: &mut watch::Receiver<()>) -> WaitResult {
+        // 1. Retrieve the next deadline from the queue
+        let next_deadline = {
+            let state = self.heartbeat_state.read().await;
+            // Peek at the next deadline without removing it from the queue
+            state.peek().map(|(_, deadline)| deadline.0)
+        };
+
+        match next_deadline {
+            // 2. If there is a deadline in the queue
+            Some(deadline) => {
+                trace!(
+                    deadline = (deadline - Instant::now()).as_secs_f64(),
+                    "Waiting for next deadline"
+                );
+                tokio::select! {
+                    // 2.1 Wait until the deadline arrives
+                    _ = tokio::time::sleep_until(deadline) => WaitResult::Deadline,
+
+                    // 2.2 Handle early notification about executor state changes
+                    _ = self.notify.notified() => WaitResult::Notified,
+
+                    // 2.3 Handle potential shutdown signal
+                    _ = shutdown_rx.changed() => WaitResult::Shutdown,
+                }
+            }
+            // 3. If no deadline is present
+            None => {
+                trace!("Waiting for notification, no deadline to wait for");
+                tokio::select! {
+                    // 3.1 Wait for a notification about executor registration
+                    _ = self.notify.notified() => WaitResult::Notified,
+
+                    // 3.2 Handle potential shutdown signal
+                    _ = shutdown_rx.changed() => WaitResult::Shutdown,
+                }
+            }
+        }
+    }
+
+    /// Starts the heartbeat monitoring loop for executors
+    pub async fn start_heartbeat_monitor(self: Arc<Self>, mut shutdown_rx: watch::Receiver<()>) {
+        loop {
+            match self.wait_for_heartbeat_event(&mut shutdown_rx).await {
+                // Deadline reached - process lapsed executors
+                WaitResult::Deadline => {
+                    trace!("Received deadline");
+                    // Attempt to deregister executors that have missed their heartbeat
+                    if let Err(err) = self.process_lapsed_executors().await {
+                        error!("Failed to process lapsed executors: {:?}", err);
+                    }
+
+                    // Wait for 1 second to batch potential subsequent executor lapsing
+                    tokio::time::sleep(Duration::from_secs(1)).await;
+                }
+
+                // Notification received - restart the loop to reprocess the next deadline
+                WaitResult::Notified => {
+                    trace!("Received notification");
+                    continue;
+                }
+
+                // Shutdown signal received - exit the loop
+                WaitResult::Shutdown => {
+                    trace!("Received shutdown signal");
+                    break;
+                }
+            }
+        }
+    }
+
+    /// Processes and deregisters executors that have missed their heartbeat
+    async fn process_lapsed_executors(&self) -> Result<()> {
+        // 1. Get the current time
+        let now = Instant::now();
+
+        // 2. Get all executor IDs that have lapsed
+        let mut lapsed_executors = Vec::new();
+        {
+            // Lock heartbeat_state briefly
+            let mut state = self.heartbeat_state.write().await;
+
+            while let Some((_, next_deadline)) = state.peek() {
+                trace!(
+                    check_lapsed_s = (next_deadline.0 - now).as_secs_f64(),
+                    "Check for lapsed executor"
+                );
+                if next_deadline.0 > now {
+                    trace!(
+                    "Next executor's deadline is in the future, stop checking for lapsed executors"
+                );
+                    break;
+                }
+
+                // Remove from queue and store for later processing
+                if let Some((executor_id, deadline)) = state.pop() {
+                    lapsed_executors.push((executor_id, deadline.0));
+                } else {
+                    error!("peeked executor not found in queue");
+                    break;
+                }
+            }
+        }
+
+        // 3. Deregister each lapsed executor without holding the lock
+        for (executor_id, deadline) in lapsed_executors {
+            trace!(
+                executor_id = executor_id.get(),
+                lapsed_after_s = (deadline - now).as_secs_f64(),
+                "Deregistering lapsed executor"
+            );
+
+            let sm_req = StateMachineUpdateRequest {
+                payload: RequestPayload::DeregisterExecutor(DeregisterExecutorRequest {
+                    executor_id: executor_id.clone(),
+                }),
+                processed_state_changes: vec![],
+            };
+
+            self.indexify_state.write(sm_req).await?;
+        }
+
         Ok(())
     }
 
     pub async fn register_executor(&self, executor: ExecutorMetadata) -> Result<()> {
         let sm_req = StateMachineUpdateRequest {
-            payload: RequestPayload::RegisterExecutor(RegisterExecutorRequest { executor }),
+            payload: RequestPayload::UpsertExecutor(UpsertExecutorRequest { executor }),
             processed_state_changes: vec![],
         };
         self.indexify_state.write(sm_req).await
@@ -137,6 +338,7 @@ pub fn schedule_deregister(ex: Arc<ExecutorManager>, executor_id: ExecutorId, du
 mod tests {
     use anyhow::Result;
     use data_model::{ExecutorId, ExecutorMetadata};
+    use tokio::time;
 
     use super::*;
     use crate::{service::Service, testing};
@@ -147,14 +349,8 @@ mod tests {
         let Service {
             indexify_state,
             executor_manager,
-            graph_processor,
-            shutdown_rx,
             ..
         } = test_srv.service;
-
-        tokio::spawn(async move {
-            graph_processor.start(shutdown_rx).await;
-        });
 
         let executor = ExecutorMetadata {
             id: ExecutorId::new("test".to_string()),
@@ -165,6 +361,7 @@ mod tests {
             function_executors: Default::default(),
             host_resources: Default::default(),
             state: Default::default(),
+            tombstoned: false,
         };
         executor_manager.register_executor(executor).await?;
 
@@ -185,14 +382,8 @@ mod tests {
         let Service {
             indexify_state,
             executor_manager,
-            graph_processor,
-            shutdown_rx,
             ..
-        } = test_srv.service;
-
-        tokio::spawn(async move {
-            graph_processor.start(shutdown_rx).await;
-        });
+        } = test_srv.service.clone();
 
         let executor = ExecutorMetadata {
             id: ExecutorId::new("test".to_string()),
@@ -203,6 +394,7 @@ mod tests {
             function_executors: Default::default(),
             host_resources: Default::default(),
             state: Default::default(),
+            tombstoned: false,
         };
         executor_manager.register_executor(executor.clone()).await?;
 
@@ -219,12 +411,12 @@ mod tests {
         schedule_deregister(
             executor_manager.clone(),
             executor.id.clone(),
-            Duration::from_secs(1),
+            Duration::from_millis(100),
         );
         schedule_deregister(
             executor_manager.clone(),
             executor.id.clone(),
-            Duration::from_secs(2),
+            Duration::from_millis(200),
         );
 
         let executors = indexify_state
@@ -237,6 +429,8 @@ mod tests {
 
         let time = std::time::Instant::now();
         loop {
+            test_srv.process_all_state_changes().await?;
+
             let executors = indexify_state
                 .in_memory_state
                 .read()
@@ -249,7 +443,197 @@ mod tests {
             if time.elapsed().as_secs() > 10 {
                 panic!("executor was not deregistered");
             }
-            tokio::time::sleep(Duration::from_secs(1)).await;
+            tokio::time::sleep(Duration::from_millis(300)).await;
+        }
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_heartbeat_lapsed_executor() -> Result<()> {
+        let test_srv = testing::TestService::new().await?;
+        let Service {
+            indexify_state,
+            executor_manager,
+            ..
+        } = test_srv.service.clone();
+
+        // Create a shutdown watcher to pass to wait_for_next_event
+        let (_shutdown_tx, mut shutdown_rx) = watch::channel(());
+
+        let executor1 = ExecutorMetadata {
+            id: ExecutorId::new("test-executor-1".to_string()),
+            executor_version: "1.0".to_string(),
+            function_allowlist: None,
+            addr: "".to_string(),
+            labels: Default::default(),
+            function_executors: Default::default(),
+            host_resources: Default::default(),
+            state: Default::default(),
+            tombstoned: false,
+        };
+
+        let executor2 = ExecutorMetadata {
+            id: ExecutorId::new("test-executor-2".to_string()),
+            executor_version: "1.0".to_string(),
+            function_allowlist: None,
+            addr: "".to_string(),
+            labels: Default::default(),
+            function_executors: Default::default(),
+            host_resources: Default::default(),
+            state: Default::default(),
+            tombstoned: false,
+        };
+
+        let executor3 = ExecutorMetadata {
+            id: ExecutorId::new("test-executor-3".to_string()),
+            executor_version: "1.0".to_string(),
+            function_allowlist: None,
+            addr: "".to_string(),
+            labels: Default::default(),
+            function_executors: Default::default(),
+            host_resources: Default::default(),
+            state: Default::default(),
+            tombstoned: false,
+        };
+
+        // Pause time and send an initial heartbeats
+        {
+            time::pause();
+
+            executor_manager.heartbeat(executor1.clone()).await?;
+            executor_manager.heartbeat(executor2.clone()).await?;
+            executor_manager.heartbeat(executor3.clone()).await?;
+        }
+
+        // Heartbeat the executors 5s later to reset their deadlines
+        {
+            time::advance(Duration::from_secs(5)).await;
+
+            executor_manager.heartbeat(executor1.clone()).await?;
+            executor_manager.heartbeat(executor2.clone()).await?;
+            executor_manager.heartbeat(executor3.clone()).await?;
+
+            executor_manager.process_lapsed_executors().await?;
+            test_srv.process_all_state_changes().await?;
+
+            // Ensure that no executor has been removed
+            let executors = indexify_state
+                .in_memory_state
+                .read()
+                .await
+                .executors
+                .clone();
+            assert_eq!(
+                3,
+                executors.len(),
+                "Expected 3 executors, but found: {:?}",
+                executors
+            );
+        }
+
+        // Heartbeat executor 5s later to reset their deadlines
+        {
+            time::advance(Duration::from_secs(15)).await;
+
+            executor_manager.heartbeat(executor1.clone()).await?;
+            executor_manager.heartbeat(executor2.clone()).await?;
+            // Executor 3 goes offline
+            // executor_manager.heartbeat(executor3.clone()).await?;
+
+            executor_manager.process_lapsed_executors().await?;
+            test_srv.process_all_state_changes().await?;
+
+            // Ensure that no executor has been removed
+            let executors = indexify_state
+                .in_memory_state
+                .read()
+                .await
+                .executors
+                .clone();
+            assert_eq!(
+                3,
+                executors.len(),
+                "Expected 3 executors, but found: {:?}",
+                executors
+            );
+        }
+
+        // Advance time to lapse executor3
+        {
+            // 30s from the last executor3 heartbeat
+            time::advance(Duration::from_secs(15)).await;
+
+            executor_manager.process_lapsed_executors().await?;
+            test_srv.process_all_state_changes().await?;
+
+            // Ensure that no executor has been removed
+            let executors = indexify_state
+                .in_memory_state
+                .read()
+                .await
+                .executors
+                .clone();
+            assert_eq!(
+                2,
+                executors.len(),
+                "Expected 2 executors, but found: {:?}",
+                executors
+            );
+        }
+
+        // Advance time past the lapsed deadline to trigger the deregistration of all
+        // executors
+        {
+            time::advance(EXECUTOR_TIMEOUT).await;
+
+            match executor_manager
+                .wait_for_heartbeat_event(&mut shutdown_rx)
+                .await
+            {
+                WaitResult::Deadline => {
+                    trace!("Received deadline");
+                    executor_manager.process_lapsed_executors().await?;
+                }
+                WaitResult::Notified => {
+                    trace!("Got notified, only possible in test since we don't run the monitor in a separate task");
+                    match executor_manager
+                        .wait_for_heartbeat_event(&mut shutdown_rx)
+                        .await
+                    {
+                        WaitResult::Deadline => {
+                            trace!("Received deadline");
+                            executor_manager.process_lapsed_executors().await?;
+                        }
+                        WaitResult::Notified => {
+                            panic!("Expected a deadline event, not a notification")
+                        }
+                        WaitResult::Shutdown => {
+                            panic!("Expected a deadline event, not a shutdown signal")
+                        }
+                    }
+                }
+                WaitResult::Shutdown => {
+                    panic!("Expected a deadline event, not a shutdown signal")
+                }
+            }
+
+            test_srv.process_all_state_changes().await?;
+        }
+
+        // Ensure that the executor has been removed
+        {
+            let executors = indexify_state
+                .in_memory_state
+                .read()
+                .await
+                .executors
+                .clone();
+            assert!(
+                executors.is_empty(),
+                "Expected no executors, but found: {:?}",
+                executors
+            );
         }
 
         Ok(())

--- a/server/src/integration_test.rs
+++ b/server/src/integration_test.rs
@@ -1848,6 +1848,7 @@ mod tests {
             .write(StateMachineUpdateRequest {
                 payload: RequestPayload::UpsertExecutor(UpsertExecutorRequest {
                     executor: mock_executor(),
+                    for_task_stream: true,
                 }),
                 processed_state_changes: vec![],
             })

--- a/server/src/integration_test.rs
+++ b/server/src/integration_test.rs
@@ -28,9 +28,9 @@ mod tests {
             DeleteComputeGraphRequest,
             IngestTaskOutputsRequest,
             InvokeComputeGraphRequest,
-            RegisterExecutorRequest,
             RequestPayload,
             StateMachineUpdateRequest,
+            UpsertExecutorRequest,
         },
         state_machine::IndexifyObjectsColumns,
         task_stream,
@@ -1846,7 +1846,7 @@ mod tests {
 
         indexify_state
             .write(StateMachineUpdateRequest {
-                payload: RequestPayload::RegisterExecutor(RegisterExecutorRequest {
+                payload: RequestPayload::UpsertExecutor(UpsertExecutorRequest {
                     executor: mock_executor(),
                 }),
                 processed_state_changes: vec![],
@@ -1862,7 +1862,7 @@ mod tests {
             .active_tasks_for_executor(mock_executor_id().get());
         assert_eq!(res.len(), 1);
 
-        let mut stream = task_stream(indexify_state.clone(), mock_executor_id().clone(), 10);
+        let mut stream = task_stream(indexify_state.clone(), mock_executor_id().clone());
 
         let res = stream.next().await.unwrap()?;
         assert_eq!(res.len(), 1);

--- a/server/src/routes.rs
+++ b/server/src/routes.rs
@@ -834,17 +834,20 @@ async fn executor_tasks(
     }
     let err = state
         .executor_manager
-        .register_executor(data_model::ExecutorMetadata {
-            id: executor_id.clone(),
-            executor_version: payload.executor_version.clone(),
-            addr: payload.addr.clone(),
-            function_allowlist,
-            labels: payload.labels.clone(),
-            host_resources: HostResources::default(),
-            state: ExecutorState::default(),
-            function_executors,
-            tombstoned: false,
-        })
+        .register_executor(
+            data_model::ExecutorMetadata {
+                id: executor_id.clone(),
+                executor_version: payload.executor_version.clone(),
+                addr: payload.addr.clone(),
+                function_allowlist,
+                labels: payload.labels.clone(),
+                host_resources: HostResources::default(),
+                state: ExecutorState::default(),
+                function_executors,
+                tombstoned: false,
+            },
+            true,
+        )
         .await;
     if let Err(e) = err {
         error!("failed to register executor {}: {:?}", executor_id, e);

--- a/server/src/testing.rs
+++ b/server/src/testing.rs
@@ -16,9 +16,9 @@ use state_store::{
     requests::{
         DeregisterExecutorRequest,
         IngestTaskOutputsRequest,
-        RegisterExecutorRequest,
         RequestPayload,
         StateMachineUpdateRequest,
+        UpsertExecutorRequest,
     },
     state_machine::IndexifyObjectsColumns,
 };
@@ -105,7 +105,7 @@ impl TestService {
         self.service
             .indexify_state
             .write(StateMachineUpdateRequest {
-                payload: RequestPayload::RegisterExecutor(RegisterExecutorRequest {
+                payload: RequestPayload::UpsertExecutor(UpsertExecutorRequest {
                     executor: executor.clone(),
                 }),
                 processed_state_changes: vec![],

--- a/server/src/testing.rs
+++ b/server/src/testing.rs
@@ -107,6 +107,7 @@ impl TestService {
             .write(StateMachineUpdateRequest {
                 payload: RequestPayload::UpsertExecutor(UpsertExecutorRequest {
                     executor: executor.clone(),
+                    for_task_stream: true,
                 }),
                 processed_state_changes: vec![],
             })

--- a/server/state_store/src/in_memory_state.rs
+++ b/server/state_store/src/in_memory_state.rs
@@ -514,11 +514,17 @@ impl InMemoryState {
                         .remove(&executor_id.get().to_string());
                 }
             }
-            RequestPayload::RegisterExecutor(req) => {
+            RequestPayload::UpsertExecutor(req) => {
                 self.executors.insert(
                     req.executor.id.get().to_string(),
                     Box::new(req.executor.clone()),
                 );
+            }
+            RequestPayload::DeregisterExecutor(req) => {
+                let executor = self.executors.get_mut(&req.executor_id.get().to_string());
+                if let Some(executor) = executor {
+                    executor.tombstoned = true;
+                }
             }
             _ => {}
         }

--- a/server/state_store/src/requests.rs
+++ b/server/state_store/src/requests.rs
@@ -29,7 +29,7 @@ pub enum RequestPayload {
     TombstoneComputeGraph(DeleteComputeGraphRequest),
     TombstoneInvocation(DeleteInvocationRequest),
     SchedulerUpdate(Box<SchedulerUpdateRequest>),
-    RegisterExecutor(RegisterExecutorRequest),
+    UpsertExecutor(UpsertExecutorRequest),
     DeregisterExecutor(DeregisterExecutorRequest),
     RemoveGcUrls(Vec<String>),
     DeleteComputeGraphRequest(DeleteComputeGraphRequest),
@@ -104,7 +104,7 @@ pub struct DeleteInvocationRequest {
 }
 
 #[derive(Debug, Clone)]
-pub struct RegisterExecutorRequest {
+pub struct UpsertExecutorRequest {
     pub executor: ExecutorMetadata,
 }
 

--- a/server/state_store/src/requests.rs
+++ b/server/state_store/src/requests.rs
@@ -106,6 +106,7 @@ pub struct DeleteInvocationRequest {
 #[derive(Debug, Clone)]
 pub struct UpsertExecutorRequest {
     pub executor: ExecutorMetadata,
+    pub for_task_stream: bool,
 }
 
 #[derive(Debug, Clone)]

--- a/server/state_store/src/state_changes.rs
+++ b/server/state_store/src/state_changes.rs
@@ -25,7 +25,7 @@ use crate::requests::{
     DeregisterExecutorRequest,
     IngestTaskOutputsRequest,
     InvokeComputeGraphRequest,
-    RegisterExecutorRequest,
+    UpsertExecutorRequest,
 };
 
 pub fn invoke_compute_graph(
@@ -163,7 +163,7 @@ pub fn tombstone_executor(
 
 pub fn register_executor(
     last_state_change_id: &AtomicU64,
-    request: &RegisterExecutorRequest,
+    request: &UpsertExecutorRequest,
 ) -> Result<Vec<StateChange>> {
     let last_change_id = last_state_change_id.fetch_add(1, atomic::Ordering::Relaxed);
     let state_change = StateChangeBuilder::default()

--- a/server/state_store/src/state_machine.rs
+++ b/server/state_store/src/state_machine.rs
@@ -849,8 +849,8 @@ pub(crate) fn mark_state_changes_processed(
 ) -> Result<()> {
     for state_change in processed_state_changes {
         debug!(
-            "marking state change as processed: {}",
-            state_change.change_type
+            change_type = %state_change.change_type,
+            "marking state change as processed"
         );
         let key = &state_change.key();
         txn.delete_cf(

--- a/server/utils/Cargo.toml
+++ b/server/utils/Cargo.toml
@@ -4,8 +4,9 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-futures = {workspace = true}
-pin-project = {workspace = true}
-serde_json = {workspace = true}
-ciborium = {workspace=true}
-anyhow = {workspace=true}
+futures = { workspace = true }
+pin-project = { workspace = true }
+serde_json = { workspace = true }
+ciborium = { workspace = true }
+anyhow = { workspace = true }
+tokio = { workspace = true }

--- a/server/utils/src/dynamic_sleep.rs
+++ b/server/utils/src/dynamic_sleep.rs
@@ -1,0 +1,239 @@
+use std::{
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+    time::Duration,
+};
+
+use tokio::{
+    sync::watch,
+    time::{sleep_until, Instant, Sleep},
+};
+
+pub struct DynamicSleepFuture {
+    receiver: watch::Receiver<Instant>,
+    current_sleep: Pin<Box<Sleep>>,
+    chunk_duration: Duration,
+    final_target: Instant,
+    min_sleep: Option<Duration>,
+}
+
+impl DynamicSleepFuture {
+    pub fn new(
+        initial_time: Instant,
+        chunk_duration: Duration,
+        min_sleep: Option<Duration>,
+    ) -> (Self, watch::Sender<Instant>) {
+        let (sender, receiver) = watch::channel(initial_time);
+        (
+            Self {
+                receiver,
+                current_sleep: Box::pin(sleep_until(initial_time)),
+                chunk_duration,
+                final_target: initial_time, // Initialize final target
+                min_sleep,
+            },
+            sender,
+        )
+    }
+}
+
+impl Future for DynamicSleepFuture {
+    type Output = ();
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        // 1. Check if the watch channel has a new value
+        if self.receiver.has_changed().unwrap_or(false) {
+            let new_target = *self.receiver.borrow_and_update();
+
+            // Update the final target to the new value
+            self.final_target = new_target;
+        }
+
+        let now = Instant::now();
+
+        // 2. If we've reached or passed the final target, complete the future
+        if now >= self.final_target {
+            return Poll::Ready(());
+        }
+
+        // 3. Calculate the next sleep time, either a chunk duration from now
+        // or up to the final target, whichever is shorter
+        let next_sleep_time = std::cmp::min(
+            now + self.chunk_duration,
+            // If min_sleep is set, use it to determine the next sleep time
+            std::cmp::max(self.final_target, now + self.min_sleep.unwrap_or_default()),
+        );
+
+        // 4. Update current sleep if the deadline has changed
+        if self.current_sleep.as_mut().as_ref().deadline() != next_sleep_time {
+            self.current_sleep = Box::pin(sleep_until(next_sleep_time));
+        }
+
+        // 5. Poll the current sleep future
+        match self.current_sleep.as_mut().poll(cx) {
+            Poll::Ready(()) => {
+                // 6. If we haven't reached final target, prepare current sleep for the next
+                //    poll
+                if now < self.final_target {
+                    let next_next_sleep_time =
+                        std::cmp::min(now + self.chunk_duration, self.final_target);
+                    self.current_sleep = Box::pin(sleep_until(next_next_sleep_time));
+                    Poll::Pending
+                } else {
+                    Poll::Ready(())
+                }
+            }
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration as StdDuration;
+
+    use tokio::time::{Duration, Instant};
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_initial_sleep() {
+        let now = Instant::now();
+        let target_time = now + Duration::from_millis(100);
+        let (sleep_future, _sender) =
+            DynamicSleepFuture::new(target_time, Duration::from_millis(50), None);
+
+        // Await the future
+        tokio::time::timeout(Duration::from_millis(500), sleep_future)
+            .await
+            .unwrap();
+
+        // Verify that we've slept approximately the right amount of time
+        let elapsed = now.elapsed();
+        assert!(elapsed >= StdDuration::from_millis(100));
+        assert!(elapsed < StdDuration::from_millis(200)); // Allow some buffer
+    }
+
+    #[tokio::test]
+    async fn test_dynamic_update_before_sleep_completes() {
+        let now = Instant::now();
+        let initial_target = now + Duration::from_millis(200);
+        let (sleep_future, sender) =
+            DynamicSleepFuture::new(initial_target, Duration::from_millis(50), None);
+
+        let sender_clone = sender.clone();
+        // Wait a bit, then update the target
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(50)).await;
+            let new_target = now + Duration::from_millis(300);
+            sender_clone.send(new_target).unwrap();
+        });
+
+        // Await the future
+        tokio::time::timeout(Duration::from_millis(500), sleep_future)
+            .await
+            .unwrap();
+
+        // Verify that we've slept approximately the updated duration
+        let elapsed = now.elapsed();
+        assert!(elapsed >= StdDuration::from_millis(300));
+        assert!(elapsed < StdDuration::from_millis(400)); // Allow some buffer
+    }
+
+    #[tokio::test]
+    async fn test_multiple_dynamic_updates() {
+        let now = Instant::now();
+        let initial_target = now + Duration::from_millis(400);
+        let (sleep_future, sender) =
+            DynamicSleepFuture::new(initial_target, Duration::from_millis(50), None);
+
+        // Multiple updates of the target time
+        let updates = vec![
+            (50, 300),  // First update after 50ms to 300ms
+            (100, 350), // Second update after 100ms to 350ms
+            (150, 400), // Final update after 150ms to 400ms
+        ];
+        let sender_clone = sender.clone();
+
+        // Spawn a task to make dynamic updates
+        tokio::spawn(async move {
+            for (delay_ms, new_duration_ms) in updates {
+                tokio::time::sleep(Duration::from_millis(delay_ms)).await;
+                let new_target = now + Duration::from_millis(new_duration_ms);
+                sender_clone.send(new_target).unwrap();
+            }
+        });
+
+        // Await the future
+        tokio::time::timeout(Duration::from_millis(500), sleep_future)
+            .await
+            .unwrap();
+
+        // Verify that we've slept approximately the final duration
+        let elapsed = now.elapsed();
+        assert!(elapsed >= StdDuration::from_millis(400));
+        assert!(elapsed < StdDuration::from_millis(500)); // Allow some buffer
+    }
+
+    #[tokio::test]
+    async fn test_update_to_shorter_duration() {
+        let now = Instant::now();
+        let initial_target = now + Duration::from_millis(300);
+        let (sleep_future, sender) =
+            DynamicSleepFuture::new(initial_target, Duration::from_millis(50), None);
+
+        let sender_clone = sender.clone();
+        // Update to a shorter duration after a short delay
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(50)).await;
+            let new_target = now + Duration::from_millis(100);
+            sender_clone.send(new_target).unwrap();
+        });
+
+        // Await the future
+        tokio::time::timeout(Duration::from_millis(500), sleep_future)
+            .await
+            .unwrap();
+
+        // Verify that we've slept approximately the updated (shorter) duration
+        let elapsed = now.elapsed();
+        assert!(elapsed >= StdDuration::from_millis(100));
+        assert!(elapsed < StdDuration::from_millis(200)); // Allow some buffer
+    }
+
+    #[tokio::test]
+    async fn test_update_to_longer_duration() {
+        let now = Instant::now();
+        let initial_target = now + Duration::from_millis(150);
+        let (sleep_future, sender) =
+            DynamicSleepFuture::new(initial_target, Duration::from_millis(50), None);
+
+        let sender_clone = sender.clone();
+
+        // Update to a longer duration after a more substantial delay
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(52)).await;
+            let new_target = now + Duration::from_millis(300);
+            sender_clone.send(new_target).unwrap();
+        });
+
+        // Await the future
+        tokio::time::timeout(Duration::from_millis(500), sleep_future)
+            .await
+            .unwrap();
+
+        // Verify that we've slept approximately the updated (longer) duration
+        let elapsed = now.elapsed();
+        assert!(
+            elapsed >= StdDuration::from_millis(300),
+            "Elapsed time: {:?}",
+            elapsed
+        );
+        assert!(
+            elapsed < StdDuration::from_millis(400),
+            "Elapsed time: {:?}",
+            elapsed
+        ); // Allow some buffer
+    }
+}

--- a/server/utils/src/lib.rs
+++ b/server/utils/src/lib.rs
@@ -8,6 +8,8 @@ use anyhow::{anyhow, Result};
 use futures::Stream;
 use pin_project::{pin_project, pinned_drop};
 
+pub mod dynamic_sleep;
+
 #[macro_export]
 macro_rules! unwrap_or_continue {
     ($opt: expr) => {


### PR DESCRIPTION
## Context

<!--
In a few sentences or less, please explain the context behind this change to help answer why this change is needed.

If this is a bug fix, make sure to include "fixes #xxxx", or
"closes #xxxx".

Screenshots, logs, code or other visual aids are greatly appreciated.
 -->

As part of switching executor protocol to grpc for dynamic scheduling support, we are moving to heartbeat based executor management.

## What

This PR:
- Add back removed tombstoned executor support
- Add a worker to removed executor that havent send an heartbeat for more than 30s
- Change executor registration to upsert logic to allow heartbeat and task stream to coexist for now
- Remove the task_stream deregister logic

The heartbeat mechanism reuses the same future which can be mutated by a watcher sender. 

<!--
In a few sentences, please summarize the change to help reviewers.

Consider providing screenshots, logs, code or other visual aids to help the reviewer understand the approach taken.
-->

## Testing

<!--
Please include steps used to verify the change.

Consider providing screenshots, logs, code or other visual aids to help the reviewer in their testing.
-->

## Contribution Checklist

- [x] If a Python package was changed, please run `make fmt` in the package directory.
- [x] If the server was changed, please run `make fmt` in `server/`.
- [x] Make sure all PR Checks are passing.
<!--
Notes:

Tests of a Python package can be run manually. Start a Server and an Executor then
run `make test` in the Python package directory.

To test if changes to the server are backward compatible with the latest
release, label the PR with `ci_compat_test`. This might report failures
unrelated to your change if previous incompatible changes were pushed without
being released yet
-->
