### PR TITLE
fix: review all usage of rocksdb iterator prefix

### DIFF
--- a/indexify/tests/cli/test_server_task_distribution.py
+++ b/indexify/tests/cli/test_server_task_distribution.py
@@ -43,7 +43,7 @@ class TestServerTaskDistribution(unittest.TestCase):
                 "--monitoring-server-port",
                 "7001",
             ],
-            keep_std_outputs=False,
+            keep_std_outputs=True,
         ) as executor_a:
             executor_a: subprocess.Popen
             print(f"Started Executor A with PID: {executor_a.pid}")


### PR DESCRIPTION
## Context

<!--
In a few sentences or less, please explain the context behind this change to help answer why this change is needed.

If this is a bug fix, make sure to include "fixes #xxxx", or
"closes #xxxx".

Screenshots, logs, code or other visual aids are greatly appreciated.
 -->

Upgrading task versions would result in allocation not finding their compute graph version.

## What

This PR ensures that upgrading the version of a compute graph only updates tasks and invocation ctx that need to be updated.

<!--
In a few sentences, please summarize the change to help reviewers.

Consider providing screenshots, logs, code or other visual aids to help the reviewer understand the approach taken.
-->

## Testing

<!--
Please include steps used to verify the change.

Consider providing screenshots, logs, code or other visual aids to help the reviewer in their testing.
-->

## Contribution Checklist

- [x] If a Python package was changed, please run `make fmt` in the package directory.
- [x] If the server was changed, please run `make fmt` in `server/`.
- [x] Make sure all PR Checks are passing.
<!--
Notes:

Tests of a Python package can be run manually. Start a Server and an Executor then
run `make test` in the Python package directory.

To test if changes to the server are backward compatible with the latest
release, label the PR with `ci_compat_test`. This might report failures
unrelated to your change if previous incompatible changes were pushed without
being released yet
-->
