### PR TITLE
feat: allocating by function executor

### DIFF
--- a/indexify/tests/cli/test_server_task_distribution.py
+++ b/indexify/tests/cli/test_server_task_distribution.py
@@ -30,9 +30,9 @@ def success_func(sleep_secs: float) -> str:
 class TestServerTaskDistribution(unittest.TestCase):
     def test_server_distributes_invocations_fairly_between_two_executors(self):
         print(
-            "Waiting for 10 seconds for Server to notice that any previously existing Executors exited."
+            "Waiting for 30 seconds for Server to notice that any previously existing Executors exited."
         )
-        time.sleep(10)
+        time.sleep(30)
 
         with ExecutorProcessContextManager(
             [
@@ -81,9 +81,9 @@ class TestServerTaskDistribution(unittest.TestCase):
 
     def test_server_redistributes_invocations_when_new_executor_joins(self):
         print(
-            "Waiting for 10 seconds for Server to notice that any previously existing Executors exited."
+            "Waiting for 30 seconds for Server to notice that any previously existing Executors exited."
         )
-        time.sleep(10)
+        time.sleep(30)
 
         graph = Graph(
             name=test_graph_name(self),

--- a/indexify/tests/cli/test_server_task_distribution.py
+++ b/indexify/tests/cli/test_server_task_distribution.py
@@ -43,7 +43,7 @@ class TestServerTaskDistribution(unittest.TestCase):
                 "--monitoring-server-port",
                 "7001",
             ],
-            keep_std_outputs=True,
+            keep_std_outputs=False,
         ) as executor_a:
             executor_a: subprocess.Popen
             print(f"Started Executor A with PID: {executor_a.pid}")

--- a/indexify/tests/cli/testing.py
+++ b/indexify/tests/cli/testing.py
@@ -1,5 +1,7 @@
 import os
+import shutil
 import subprocess
+import tempfile
 import time
 import unittest
 from typing import Any, List, Optional
@@ -35,14 +37,17 @@ class ExecutorProcessContextManager:
     def __init__(
         self,
         args: List[str],
+        with_dedicated_executor_cache: bool = True,
         keep_std_outputs: bool = True,
         extra_env: Optional[dict] = None,
     ):
         self._args = ["indexify-cli", "executor"]
         self._args.extend(args)
+        self._with_dedicated_executor_cache = with_dedicated_executor_cache
         self._keep_std_outputs = keep_std_outputs
         self._extra_env = extra_env
         self._process: Optional[subprocess.Popen] = None
+        self._temp_dir: Optional[str] = None
 
     def __enter__(self) -> subprocess.Popen:
         kwargs = {}
@@ -52,6 +57,9 @@ class ExecutorProcessContextManager:
         if self._extra_env is not None:
             kwargs["env"] = os.environ.copy()
             kwargs["env"].update(self._extra_env)
+        if self._with_dedicated_executor_cache:
+            self._temp_dir = tempfile.mkdtemp(prefix="executor_cache_")
+            self._args.extend(["--executor-cache", self._temp_dir])
         self._process = subprocess.Popen(self._args, **kwargs)
         return self._process
 
@@ -59,6 +67,13 @@ class ExecutorProcessContextManager:
         if self._process:
             self._process.terminate()
             self._process.wait()
+        if self._temp_dir:
+            try:
+                shutil.rmtree(self._temp_dir)
+            except Exception as e:
+                print(
+                    f"Warning: Failed to clean up temp directory {self._temp_dir}: {e}"
+                )
 
 
 def wait_executor_startup(port: int):
@@ -66,7 +81,6 @@ def wait_executor_startup(port: int):
 
     import httpx
 
-    print(f"Waiting 5 secs for Executor to start at port {port}")
     attempts_left: int = 5
     while attempts_left > 0:
         try:
@@ -79,6 +93,9 @@ def wait_executor_startup(port: int):
                 raise
 
         attempts_left -= 1
+        print(
+            f"Waiting Executor to start at port {port} (attempts left: {attempts_left})"
+        )
         time.sleep(1)
 
 

--- a/server/data_model/src/lib.rs
+++ b/server/data_model/src/lib.rs
@@ -1221,6 +1221,30 @@ pub struct FunctionURI {
     pub version: Option<GraphVersion>,
 }
 
+impl FunctionURI {
+    pub fn matches(&self, other: &FunctionURI) -> bool {
+        self.namespace == other.namespace &&
+            self.compute_graph_name == other.compute_graph_name &&
+            self.compute_fn_name == other.compute_fn_name &&
+            (self.version.is_none() || self.version == other.version)
+    }
+}
+
+impl Display for FunctionURI {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}|{}|{}|{}",
+            self.namespace,
+            self.compute_graph_name,
+            self.compute_fn_name,
+            self.version
+                .as_ref()
+                .map_or("None".to_string(), |v| v.to_string())
+        )
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct GpuResources {
     pub count: u32,
@@ -1330,6 +1354,13 @@ impl FunctionExecutor {
         } else {
             false
         }
+    }
+
+    pub fn matches_fn(&self, other: &FunctionExecutor) -> bool {
+        self.namespace == other.namespace &&
+            self.compute_graph_name == other.compute_graph_name &&
+            self.compute_fn_name == other.compute_fn_name &&
+            self.version == other.version
     }
 }
 

--- a/server/data_model/src/lib.rs
+++ b/server/data_model/src/lib.rs
@@ -6,6 +6,7 @@ use std::{
     error::Error,
     fmt::{self, Display},
     hash::{DefaultHasher, Hash, Hasher},
+    str,
     time::{SystemTime, UNIX_EPOCH},
     vec,
 };
@@ -748,6 +749,17 @@ impl From<TaskOutcome> for GraphInvocationOutcome {
             TaskOutcome::Failure => GraphInvocationOutcome::Failure,
             TaskOutcome::Unknown => GraphInvocationOutcome::Undefined,
         }
+    }
+}
+
+impl Display for GraphInvocationOutcome {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let str_val = match self {
+            GraphInvocationOutcome::Success => "Success",
+            GraphInvocationOutcome::Failure => "Failure",
+            GraphInvocationOutcome::Undefined => "Undefined",
+        };
+        write!(f, "{}", str_val)
     }
 }
 

--- a/server/data_model/src/lib.rs
+++ b/server/data_model/src/lib.rs
@@ -1303,6 +1303,7 @@ pub struct ExecutorMetadata {
     pub host_resources: HostResources,
     pub state: ExecutorState,
     pub tombstoned: bool,
+    pub state_hash: String,
 }
 
 impl ExecutorMetadataBuilder {
@@ -1327,6 +1328,10 @@ impl ExecutorMetadataBuilder {
             .clone()
             .ok_or(anyhow!("host_resources is required"))?;
         let state = self.state.clone().ok_or(anyhow!("state is required"))?;
+        let state_hash = self
+            .state_hash
+            .clone()
+            .ok_or(anyhow!("state_hash is required"))?;
         let tombstoned = self.tombstoned.unwrap_or(false);
         Ok(ExecutorMetadata {
             id,
@@ -1338,6 +1343,7 @@ impl ExecutorMetadataBuilder {
             host_resources,
             state,
             tombstoned,
+            state_hash,
         })
     }
 }

--- a/server/data_model/src/test_objects.rs
+++ b/server/data_model/src/test_objects.rs
@@ -320,6 +320,7 @@ pub mod tests {
             state: Default::default(),
             function_executors: Default::default(),
             tombstoned: false,
+            state_hash: "state_hash".to_string(),
         }
     }
 }

--- a/server/data_model/src/test_objects.rs
+++ b/server/data_model/src/test_objects.rs
@@ -313,6 +313,7 @@ pub mod tests {
         ExecutorMetadata {
             id: mock_executor_id(),
             executor_version: "1.0.0".to_string(),
+            development_mode: true,
             function_allowlist: None,
             addr: "".to_string(),
             labels: Default::default(),

--- a/server/data_model/src/test_objects.rs
+++ b/server/data_model/src/test_objects.rs
@@ -309,9 +309,9 @@ pub mod tests {
         ExecutorId::new(TEST_EXECUTOR_ID.to_string())
     }
 
-    pub fn mock_executor() -> ExecutorMetadata {
+    pub fn mock_dev_executor(id: ExecutorId) -> ExecutorMetadata {
         ExecutorMetadata {
-            id: mock_executor_id(),
+            id,
             executor_version: "1.0.0".to_string(),
             development_mode: true,
             function_allowlist: None,

--- a/server/metrics/src/lib.rs
+++ b/server/metrics/src/lib.rs
@@ -322,16 +322,6 @@ impl Display for FnMetricsId {
     }
 }
 
-/*
- * StateStoreMetrics is a struct that holds metrics for the state store.
- * It keeps track of the number of tasks completed, the number of tasks
- * completed with errors, the number of assigned tasks, and the number of
- * unassigned tasks. Currently metrics are not persisted across restarts.
- *
- * TODO: When the server starts up, we should scan the database for assigned
- * and unassigned tasks. But for now, it's fine to just emit metrics which
- * reflect the current state of the system since starting the server.
- */
 #[derive(Clone, Debug)]
 pub struct StateStoreMetrics {
     pub state_write: Histogram<f64>,

--- a/server/processor/src/graph_processor.rs
+++ b/server/processor/src/graph_processor.rs
@@ -233,7 +233,7 @@ impl GraphProcessor {
                     })
                 }
             }
-            ChangeType::ExecutorAdded(_) |
+            ChangeType::ExecutorUpserted(_) |
             ChangeType::ExecutorRemoved(_) |
             ChangeType::TombStoneExecutor(_) => {
                 let scheduler_update = self

--- a/server/processor/src/task_allocator.rs
+++ b/server/processor/src/task_allocator.rs
@@ -531,7 +531,7 @@ impl TaskAllocationProcessor {
 
         // Create an array of indices and shuffle them
         let mut indices: Vec<usize> = (0..candidates.len()).collect();
-        indices.shuffle(&mut rand::thread_rng());
+        indices.shuffle(&mut rand::rng());
 
         // Use these indices to iterate through candidates in a random order
         // ensuring that we select the one with the least allocation count

--- a/server/src/executor_api.rs
+++ b/server/src/executor_api.rs
@@ -109,6 +109,9 @@ impl TryFrom<ExecutorState> for ExecutorMetadata {
 
     fn try_from(executor_state: ExecutorState) -> Result<Self, Self::Error> {
         let mut executor_metadata = ExecutorMetadataBuilder::default();
+        if let Some(state_hash) = executor_state.state_hash.clone() {
+            executor_metadata.state_hash(state_hash);
+        }
         executor_metadata.state(executor_state.status().into());
         if let Some(executor_id) = executor_state.executor_id {
             executor_metadata.id(ExecutorId::new(executor_id));

--- a/server/src/executors.rs
+++ b/server/src/executors.rs
@@ -246,17 +246,23 @@ impl ExecutorManager {
                 lapsed_after_s = (deadline - now).as_secs_f64(),
                 "Deregistering lapsed executor"
             );
-
-            let sm_req = StateMachineUpdateRequest {
-                payload: RequestPayload::DeregisterExecutor(DeregisterExecutorRequest {
-                    executor_id: executor_id.clone(),
-                }),
-                processed_state_changes: vec![],
-            };
-
-            self.indexify_state.write(sm_req).await?;
+            self.deregister_lapsed_executor(executor_id).await?;
         }
 
+        Ok(())
+    }
+
+    async fn deregister_lapsed_executor(
+        &self,
+        executor_id: ExecutorId,
+    ) -> Result<(), anyhow::Error> {
+        let sm_req = StateMachineUpdateRequest {
+            payload: RequestPayload::DeregisterExecutor(DeregisterExecutorRequest {
+                executor_id: executor_id.clone(),
+            }),
+            processed_state_changes: vec![],
+        };
+        self.indexify_state.write(sm_req).await?;
         Ok(())
     }
 

--- a/server/src/executors.rs
+++ b/server/src/executors.rs
@@ -147,6 +147,11 @@ impl ExecutorManager {
             .map(|stored_hash| stored_hash == &executor.state_hash)
             .unwrap_or(false)
         {
+            trace!(
+                executor_id = executor.id.get(),
+                state_hash = executor.state_hash,
+                "Executor state hash changed, registering executor"
+            );
             // TODO: Add clock check only act on the heartbeat for the latest state change
             if let Err(e) = self.register_executor(executor.clone()).await {
                 error!(
@@ -294,6 +299,8 @@ impl ExecutorManager {
                     // Get the function URI string
                     let fn_uri = function_executor.fn_uri_str();
 
+                    function_allocations.entry(fn_uri.clone()).or_default();
+
                     // Find allocations for this function executor if they exist
                     if let Some(executor_allocations) = allocations_by_executor.get(executor_id) {
                         if let Some(fe_allocations) =
@@ -306,8 +313,7 @@ impl ExecutorManager {
                             // Merge with existing allocations for this function URI
                             function_allocations
                                 .entry(fn_uri)
-                                .and_modify(|existing| existing.extend(allocation_vec.clone()))
-                                .or_insert(allocation_vec);
+                                .and_modify(|existing| existing.extend(allocation_vec.clone()));
                         }
                     }
                 }

--- a/server/src/http_objects.rs
+++ b/server/src/http_objects.rs
@@ -740,7 +740,7 @@ pub struct UnallocatedTasks {
 }
 
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
-pub struct ExecutorFns {
+pub struct FnExecutor {
     pub count: usize,
     pub fn_name: String,
     pub allocations: Vec<Allocation>,
@@ -749,7 +749,7 @@ pub struct ExecutorFns {
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
 pub struct ExecutorAllocations {
     pub total: usize,
-    pub executor_fns: Vec<ExecutorFns>,
+    pub function_executors: Vec<FnExecutor>,
 }
 
 #[derive(Debug, Serialize, Deserialize, ToSchema)]

--- a/server/src/integration_test.rs
+++ b/server/src/integration_test.rs
@@ -5,7 +5,7 @@ mod tests {
     use anyhow::Result;
     use data_model::{
         test_objects::tests::{
-            mock_executor,
+            mock_dev_executor,
             mock_executor_id,
             mock_graph_a,
             mock_invocation_ctx,
@@ -112,7 +112,9 @@ mod tests {
 
         // register executor
         let executor = {
-            let executor = test_srv.register_executor(mock_executor_id()).await?;
+            let executor = test_srv
+                .create_executor(mock_dev_executor(mock_executor_id()))
+                .await?;
 
             test_srv.process_all_state_changes().await?;
 
@@ -236,7 +238,9 @@ mod tests {
 
         // register executor
         {
-            let executor = test_srv.register_executor(mock_executor_id()).await?;
+            let executor = test_srv
+                .create_executor(mock_dev_executor(mock_executor_id()))
+                .await?;
 
             test_srv.process_all_state_changes().await?;
 
@@ -312,7 +316,9 @@ mod tests {
 
         // register executor
         let executor = {
-            let executor = test_srv.register_executor(mock_executor_id()).await?;
+            let executor = test_srv
+                .create_executor(mock_dev_executor(mock_executor_id()))
+                .await?;
 
             test_srv.process_all_state_changes().await?;
 
@@ -475,7 +481,9 @@ mod tests {
 
         // register executor1
         {
-            let executor = test_srv.register_executor(mock_executor_id()).await?;
+            let executor = test_srv
+                .create_executor(mock_dev_executor(mock_executor_id()))
+                .await?;
 
             test_srv.process_all_state_changes().await?;
 
@@ -493,7 +501,7 @@ mod tests {
         // register executor2
         {
             let executor = test_srv
-                .register_executor(ExecutorId::new("executor_2".to_string()))
+                .create_executor(mock_dev_executor(ExecutorId::new("executor_2".to_string())))
                 .await?;
 
             test_srv.process_all_state_changes().await?;
@@ -528,7 +536,9 @@ mod tests {
 
         // register executor
         let executor = {
-            let executor = test_srv.register_executor(mock_executor_id()).await?;
+            let executor = test_srv
+                .create_executor(mock_dev_executor(mock_executor_id()))
+                .await?;
 
             test_srv.process_all_state_changes().await?;
 
@@ -591,7 +601,7 @@ mod tests {
         // register executor1, task assigned to it
         let executor1 = {
             let executor1 = test_srv
-                .register_executor(ExecutorId::new("executor_1".to_string()))
+                .create_executor(mock_dev_executor(ExecutorId::new("executor_1".to_string())))
                 .await?;
 
             test_srv.process_all_state_changes().await?;
@@ -607,7 +617,7 @@ mod tests {
         // register executor2, no tasks assigned to it
         let executor2 = {
             let executor2 = test_srv
-                .register_executor(ExecutorId::new("executor_2".to_string()))
+                .create_executor(mock_dev_executor(ExecutorId::new("executor_2".to_string())))
                 .await?;
 
             test_srv.process_all_state_changes().await?;
@@ -1838,7 +1848,7 @@ mod tests {
         indexify_state
             .write(StateMachineUpdateRequest {
                 payload: RequestPayload::UpsertExecutor(UpsertExecutorRequest {
-                    executor: mock_executor(),
+                    executor: mock_dev_executor(mock_executor_id()),
                 }),
                 processed_state_changes: vec![],
             })

--- a/server/src/integration_test.rs
+++ b/server/src/integration_test.rs
@@ -1850,7 +1850,7 @@ mod tests {
             .in_memory_state
             .read()
             .await
-            .active_tasks_for_executor(mock_executor_id().get());
+            .active_tasks_for_executor(&mock_executor_id());
         assert_eq!(res.len(), 1);
 
         let mut stream = task_stream(indexify_state.clone(), mock_executor_id().clone());

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -23,6 +23,7 @@ mod executors;
 mod gc_test;
 mod http_objects;
 mod integration_test;
+mod reconciliation_test;
 mod routes;
 mod service;
 #[cfg(test)]

--- a/server/src/reconciliation_test.rs
+++ b/server/src/reconciliation_test.rs
@@ -1,0 +1,195 @@
+#[cfg(test)]
+mod tests {
+    use anyhow::Result;
+    use data_model::{
+        test_objects::tests::{mock_dev_executor, mock_executor_id, TEST_NAMESPACE},
+        FunctionExecutorId,
+        FunctionURI,
+        GraphVersion,
+        TaskOutcome,
+    };
+    use state_store::test_state_store;
+
+    use crate::{
+        service::Service,
+        testing::{self, FinalizeTaskArgs},
+    };
+
+    #[tokio::test]
+    async fn test_reconciliation() -> Result<()> {
+        let test_srv = testing::TestService::new().await?;
+        let Service { indexify_state, .. } = test_srv.service.clone();
+
+        // register executor
+        let mut executor = {
+            let executor = test_srv
+                .create_executor(mock_dev_executor(mock_executor_id()))
+                .await?;
+            test_srv.process_all_state_changes().await?;
+            executor
+        };
+
+        test_srv.assert_task_states(0, 0, 0, 0).await?;
+        executor.assert_state(0, 0).await?;
+
+        // create a task
+        {
+            test_state_store::with_simple_graph(&indexify_state).await;
+            test_srv.process_all_state_changes().await?;
+        }
+
+        test_srv.assert_task_states(1, 1, 0, 0).await?;
+        executor.assert_state(1, 1).await?;
+
+        // Toggle dev mode to false
+        {
+            executor.update_config(Some(false), None).await?;
+            test_srv.process_all_state_changes().await?;
+        }
+
+        test_srv.assert_task_states(1, 0, 1, 0).await?;
+        executor.assert_state(0, 0).await?;
+
+        // Add Allowlist
+        {
+            executor
+                .update_config(
+                    Some(false),
+                    Some(Some(vec![FunctionURI {
+                        namespace: TEST_NAMESPACE.to_string(),
+                        compute_graph_name: "graph_A".to_string(),
+                        compute_fn_name: "fn_a".to_string(),
+                        version: None,
+                    }])),
+                )
+                .await?;
+            test_srv.process_all_state_changes().await?;
+        }
+
+        test_srv.assert_task_states(1, 1, 0, 0).await?;
+        executor.assert_state(1, 1).await?;
+
+        // Change Allowlist to different version
+        {
+            executor
+                .update_config(
+                    Some(false),
+                    Some(Some(vec![FunctionURI {
+                        namespace: TEST_NAMESPACE.to_string(),
+                        compute_graph_name: "graph_A".to_string(),
+                        compute_fn_name: "fn_a".to_string(),
+                        version: Some(GraphVersion("2".to_string())),
+                    }])),
+                )
+                .await?;
+            test_srv.process_all_state_changes().await?;
+        }
+
+        test_srv.assert_task_states(1, 0, 1, 0).await?;
+        executor.assert_state(0, 0).await?;
+
+        // Change Allowlist to current version
+        {
+            executor
+                .update_config(
+                    Some(false),
+                    Some(Some(vec![FunctionURI {
+                        namespace: TEST_NAMESPACE.to_string(),
+                        compute_graph_name: "graph_A".to_string(),
+                        compute_fn_name: "fn_a".to_string(),
+                        version: Some(GraphVersion("1".to_string())),
+                    }])),
+                )
+                .await?;
+            test_srv.process_all_state_changes().await?;
+        }
+
+        test_srv.assert_task_states(1, 1, 0, 0).await?;
+        executor.assert_state(1, 1).await?;
+
+        // Change Allowlist to any version and support fn_b
+        {
+            executor
+                .update_config(
+                    Some(false),
+                    Some(Some(vec![
+                        FunctionURI {
+                            namespace: TEST_NAMESPACE.to_string(),
+                            compute_graph_name: "graph_A".to_string(),
+                            compute_fn_name: "fn_a".to_string(),
+                            version: None,
+                        },
+                        FunctionURI {
+                            namespace: TEST_NAMESPACE.to_string(),
+                            compute_graph_name: "graph_A".to_string(),
+                            compute_fn_name: "fn_b".to_string(),
+                            version: None,
+                        },
+                        FunctionURI {
+                            namespace: TEST_NAMESPACE.to_string(),
+                            compute_graph_name: "graph_A".to_string(),
+                            compute_fn_name: "fn_c".to_string(),
+                            version: None,
+                        },
+                    ])),
+                )
+                .await?;
+            test_srv.process_all_state_changes().await?;
+        }
+
+        test_srv.assert_task_states(1, 1, 0, 0).await?;
+        executor.assert_state(1, 1).await?;
+
+        // Finalize Task (create 2 more)
+        {
+            let executor_tasks = executor.get_tasks().await?;
+            executor
+                .finalize_task(
+                    executor_tasks.first().unwrap(),
+                    FinalizeTaskArgs::new().task_outcome(TaskOutcome::Success),
+                )
+                .await?;
+            test_srv.process_all_state_changes().await?;
+        }
+
+        test_srv.assert_task_states(3, 2, 0, 1).await?;
+        executor.assert_state(3, 2).await?;
+
+        // Remove fn_a from FunctionExecutors
+        {
+            let fes = executor
+                .get_function_executors()
+                .await?
+                .into_iter()
+                // Remove fn_a from the list
+                .filter(|fe| fe.compute_fn_name != "fn_a")
+                .collect();
+            executor.update_function_executors(fes).await?;
+            test_srv.process_all_state_changes().await?;
+        }
+
+        test_srv.assert_task_states(3, 2, 0, 1).await?;
+        executor.assert_state(2, 2).await?;
+
+        // Support non versioned function executors
+        {
+            let fes = executor
+                .get_function_executors()
+                .await?
+                .into_iter()
+                .map(|mut fe| {
+                    // change ID to not versioned
+                    fe.id = FunctionExecutorId::new(format!("{}/{}", "not_versioned", fe.id.get()));
+                    fe
+                })
+                .collect();
+            executor.update_function_executors(fes).await?;
+            test_srv.process_all_state_changes().await?;
+        }
+
+        test_srv.assert_task_states(3, 2, 0, 1).await?;
+        executor.assert_state(2, 2).await?;
+
+        Ok(())
+    }
+}

--- a/server/src/routes.rs
+++ b/server/src/routes.rs
@@ -722,7 +722,7 @@ async fn list_allocations(
             .into_iter()
             .map(|(executor_id, fns)| {
                 (
-                    executor_id.clone(),
+                    executor_id.get().to_string(),
                     ExecutorAllocations {
                         total: fns.iter().map(|(_, allocations)| allocations.len()).sum(),
                         executor_fns: fns

--- a/server/src/routes.rs
+++ b/server/src/routes.rs
@@ -8,8 +8,7 @@ use axum::{
     middleware::{self, Next},
     response::{sse::Event, Html, IntoResponse},
     routing::{delete, get, post},
-    Json,
-    Router,
+    Json, Router,
 };
 use axum_tracing_opentelemetry::{
     self,
@@ -27,12 +26,8 @@ use prometheus::Encoder;
 use state_store::{
     kv::{ReadContextData, WriteContextData, KVS},
     requests::{
-        CreateOrUpdateComputeGraphRequest,
-        DeleteComputeGraphRequest,
-        DeleteInvocationRequest,
-        NamespaceRequest,
-        RequestPayload,
-        StateMachineUpdateRequest,
+        CreateOrUpdateComputeGraphRequest, DeleteComputeGraphRequest, DeleteInvocationRequest,
+        NamespaceRequest, RequestPayload, StateMachineUpdateRequest,
     },
     IndexifyState,
 };
@@ -42,11 +37,7 @@ use utoipa::{OpenApi, ToSchema};
 use utoipa_swagger_ui::SwaggerUi;
 
 use crate::http_objects::{
-    ExecutorAllocations,
-    ExecutorFns,
-    Invocation,
-    InvocationStatus,
-    StateChangesResponse,
+    ExecutorAllocations, FnExecutor, Invocation, InvocationStatus, StateChangesResponse,
     UnallocatedTasks,
 };
 
@@ -55,9 +46,7 @@ mod internal_ingest;
 mod invoke;
 mod logs;
 use download::{
-    download_fn_output_by_key,
-    download_fn_output_payload,
-    download_invocation_payload,
+    download_fn_output_by_key, download_fn_output_payload, download_invocation_payload,
 };
 use internal_ingest::{ingest_files_from_executor, ingest_fn_outputs};
 use invoke::{invoke_with_file, invoke_with_object, wait_until_invocation_completed};
@@ -66,28 +55,10 @@ use logs::download_task_logs;
 use crate::{
     executors::ExecutorManager,
     http_objects::{
-        Allocation,
-        ComputeFn,
-        ComputeGraph,
-        ComputeGraphsList,
-        CreateNamespace,
-        CursorDirection,
-        DynamicRouter,
-        ExecutorMetadata,
-        ExecutorsAllocationsResponse,
-        FnOutputs,
-        GraphInvocations,
-        GraphVersion,
-        ImageInformation,
-        IndexifyAPIError,
-        ListParams,
-        Namespace,
-        NamespaceList,
-        Node,
-        RuntimeInformation,
-        Task,
-        TaskOutcome,
-        Tasks,
+        Allocation, ComputeFn, ComputeGraph, ComputeGraphsList, CreateNamespace, CursorDirection,
+        DynamicRouter, ExecutorMetadata, ExecutorsAllocationsResponse, FnOutputs, GraphInvocations,
+        GraphVersion, ImageInformation, IndexifyAPIError, ListParams, Namespace, NamespaceList,
+        Node, RuntimeInformation, Task, TaskOutcome, Tasks,
     },
 };
 
@@ -725,9 +696,9 @@ async fn list_allocations(
                     executor_id.get().to_string(),
                     ExecutorAllocations {
                         total: fns.iter().map(|(_, allocations)| allocations.len()).sum(),
-                        executor_fns: fns
+                        function_executors: fns
                             .iter()
-                            .map(|(fn_name, allocations)| ExecutorFns {
+                            .map(|(fn_name, allocations)| FnExecutor {
                                 count: allocations.len(),
                                 fn_name: fn_name.clone(),
                                 allocations: allocations.iter().map(|a| a.clone().into()).collect(),

--- a/server/src/routes.rs
+++ b/server/src/routes.rs
@@ -8,7 +8,8 @@ use axum::{
     middleware::{self, Next},
     response::{sse::Event, Html, IntoResponse},
     routing::{delete, get, post},
-    Json, Router,
+    Json,
+    Router,
 };
 use axum_tracing_opentelemetry::{
     self,
@@ -26,8 +27,12 @@ use prometheus::Encoder;
 use state_store::{
     kv::{ReadContextData, WriteContextData, KVS},
     requests::{
-        CreateOrUpdateComputeGraphRequest, DeleteComputeGraphRequest, DeleteInvocationRequest,
-        NamespaceRequest, RequestPayload, StateMachineUpdateRequest,
+        CreateOrUpdateComputeGraphRequest,
+        DeleteComputeGraphRequest,
+        DeleteInvocationRequest,
+        NamespaceRequest,
+        RequestPayload,
+        StateMachineUpdateRequest,
     },
     IndexifyState,
 };
@@ -37,7 +42,11 @@ use utoipa::{OpenApi, ToSchema};
 use utoipa_swagger_ui::SwaggerUi;
 
 use crate::http_objects::{
-    ExecutorAllocations, FnExecutor, Invocation, InvocationStatus, StateChangesResponse,
+    ExecutorAllocations,
+    FnExecutor,
+    Invocation,
+    InvocationStatus,
+    StateChangesResponse,
     UnallocatedTasks,
 };
 
@@ -46,7 +55,9 @@ mod internal_ingest;
 mod invoke;
 mod logs;
 use download::{
-    download_fn_output_by_key, download_fn_output_payload, download_invocation_payload,
+    download_fn_output_by_key,
+    download_fn_output_payload,
+    download_invocation_payload,
 };
 use internal_ingest::{ingest_files_from_executor, ingest_fn_outputs};
 use invoke::{invoke_with_file, invoke_with_object, wait_until_invocation_completed};
@@ -55,10 +66,28 @@ use logs::download_task_logs;
 use crate::{
     executors::ExecutorManager,
     http_objects::{
-        Allocation, ComputeFn, ComputeGraph, ComputeGraphsList, CreateNamespace, CursorDirection,
-        DynamicRouter, ExecutorMetadata, ExecutorsAllocationsResponse, FnOutputs, GraphInvocations,
-        GraphVersion, ImageInformation, IndexifyAPIError, ListParams, Namespace, NamespaceList,
-        Node, RuntimeInformation, Task, TaskOutcome, Tasks,
+        Allocation,
+        ComputeFn,
+        ComputeGraph,
+        ComputeGraphsList,
+        CreateNamespace,
+        CursorDirection,
+        DynamicRouter,
+        ExecutorMetadata,
+        ExecutorsAllocationsResponse,
+        FnOutputs,
+        GraphInvocations,
+        GraphVersion,
+        ImageInformation,
+        IndexifyAPIError,
+        ListParams,
+        Namespace,
+        NamespaceList,
+        Node,
+        RuntimeInformation,
+        Task,
+        TaskOutcome,
+        Tasks,
     },
 };
 

--- a/server/src/testing.rs
+++ b/server/src/testing.rs
@@ -281,7 +281,7 @@ impl TestExecutor<'_> {
             .in_memory_state
             .read()
             .await
-            .active_tasks_for_executor(&self.executor.id.get());
+            .active_tasks_for_executor(&self.executor.id);
 
         Ok(tasks.into_iter().map(|task| (*task).clone()).collect())
     }

--- a/server/state_store/src/invocation_events.rs
+++ b/server/state_store/src/invocation_events.rs
@@ -7,12 +7,10 @@ use crate::requests::IngestTaskOutputsRequest;
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum InvocationStateChangeEvent {
-    AsyncInvocation(InvocationStarted),
     TaskCreated(TaskCreated),
     TaskAssigned(TaskAssigned),
     TaskCompleted(TaskCompleted),
     InvocationFinished(InvocationFinishedEvent),
-    DiagnosticMessage(DiagnosticMessage),
 }
 
 impl InvocationStateChangeEvent {
@@ -27,7 +25,6 @@ impl InvocationStateChangeEvent {
 
     pub fn invocation_id(&self) -> String {
         match self {
-            InvocationStateChangeEvent::AsyncInvocation(InvocationStarted { id }) => id.clone(),
             InvocationStateChangeEvent::InvocationFinished(InvocationFinishedEvent { id }) => {
                 id.clone()
             }
@@ -40,21 +37,12 @@ impl InvocationStateChangeEvent {
             InvocationStateChangeEvent::TaskCompleted(TaskCompleted { invocation_id, .. }) => {
                 invocation_id.clone()
             }
-            InvocationStateChangeEvent::DiagnosticMessage(DiagnosticMessage {
-                invocation_id,
-                ..
-            }) => invocation_id.clone(),
         }
     }
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct InvocationFinishedEvent {
-    pub id: String,
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct InvocationStarted {
     pub id: String,
 }
 

--- a/server/state_store/src/lib.rs
+++ b/server/state_store/src/lib.rs
@@ -292,20 +292,8 @@ impl IndexifyState {
                     .entry(request.executor.id.clone())
                     .or_default();
 
-                // Only trigger a state change if the executor is newly registered as opposed to
-                // an update of metadata.
-                if !self
-                    .in_memory_state
-                    .read()
-                    .await
-                    .executors
-                    .contains_key(&request.executor.id)
-                {
-                    state_changes::register_executor(&self.last_state_change_id, &request)
-                        .map_err(|e| anyhow!("error getting state changes {}", e))?
-                } else {
-                    vec![]
-                }
+                state_changes::register_executor(&self.last_state_change_id, &request)
+                    .map_err(|e| anyhow!("error getting state changes {}", e))?
             }
             RequestPayload::DeregisterExecutor(request) => {
                 self.executor_states

--- a/server/state_store/src/lib.rs
+++ b/server/state_store/src/lib.rs
@@ -299,7 +299,7 @@ impl IndexifyState {
                     .read()
                     .await
                     .executors
-                    .contains_key(&request.executor.id.get().to_string())
+                    .contains_key(&request.executor.id)
                 {
                     state_changes::register_executor(&self.last_state_change_id, &request)
                         .map_err(|e| anyhow!("error getting state changes {}", e))?
@@ -443,7 +443,7 @@ pub fn task_stream(state: Arc<IndexifyState>, executor_id: ExecutorId) -> TaskSt
             let task_ids_sent = state.executor_states.read().await.get(&executor_id).map(|s| {
                 s.task_ids_sent.clone()
             }).unwrap_or_default();
-            let active_tasks = state.in_memory_state.read().await.active_tasks_for_executor(&executor_id.to_string());
+            let active_tasks = state.in_memory_state.read().await.active_tasks_for_executor(&executor_id);
             if active_tasks.len() > 0 {
                 let state = state.clone();
                 let mut filtered_tasks = vec![];

--- a/server/state_store/src/lib.rs
+++ b/server/state_store/src/lib.rs
@@ -461,7 +461,8 @@ pub fn task_stream(state: Arc<IndexifyState>, executor_id: ExecutorId) -> TaskSt
 mod tests {
     use data_model::{
         test_objects::tests::{
-            mock_executor,
+            mock_dev_executor,
+            mock_executor_id,
             mock_graph_a,
             mock_invocation_payload,
             TEST_NAMESPACE,
@@ -591,7 +592,7 @@ mod tests {
         let state_change_2 = state_changes::register_executor(
             &indexify_state.last_state_change_id,
             &UpsertExecutorRequest {
-                executor: mock_executor(),
+                executor: mock_dev_executor(mock_executor_id()),
             },
         )
         .unwrap();

--- a/server/state_store/src/requests.rs
+++ b/server/state_store/src/requests.rs
@@ -5,10 +5,7 @@ use data_model::{
     ComputeGraph,
     ExecutorId,
     ExecutorMetadata,
-<<<<<<< HEAD
-=======
     FunctionExecutor,
->>>>>>> f501d85f (feat: creating and removing function executors)
     FunctionExecutorId,
     GraphInvocationCtx,
     InvocationPayload,

--- a/server/state_store/src/requests.rs
+++ b/server/state_store/src/requests.rs
@@ -5,6 +5,10 @@ use data_model::{
     ComputeGraph,
     ExecutorId,
     ExecutorMetadata,
+<<<<<<< HEAD
+=======
+    FunctionExecutor,
+>>>>>>> f501d85f (feat: creating and removing function executors)
     FunctionExecutorId,
     GraphInvocationCtx,
     InvocationPayload,
@@ -44,6 +48,15 @@ pub struct FunctionExecutorIdWithExecutionId {
     pub executor_id: ExecutorId,
 }
 
+impl FunctionExecutorIdWithExecutionId {
+    pub fn new(function_executor_id: FunctionExecutorId, executor_id: ExecutorId) -> Self {
+        Self {
+            function_executor_id,
+            executor_id,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Default)]
 pub struct SchedulerUpdateRequest {
     pub new_allocations: Vec<Allocation>,
@@ -52,6 +65,7 @@ pub struct SchedulerUpdateRequest {
     pub updated_invocations_states: Vec<GraphInvocationCtx>,
     pub reduction_tasks: ReductionTasks,
     pub remove_executors: Vec<ExecutorId>,
+    pub new_function_executors: Vec<FunctionExecutor>,
     pub remove_function_executors: Vec<FunctionExecutorIdWithExecutionId>,
 }
 
@@ -60,11 +74,9 @@ impl SchedulerUpdateRequest {
     pub fn extend(&mut self, other: SchedulerUpdateRequest) {
         self.new_allocations.extend(other.new_allocations);
         self.remove_allocations.extend(other.remove_allocations);
+        self.updated_tasks.extend(other.updated_tasks);
         self.updated_invocations_states
             .extend(other.updated_invocations_states);
-        self.remove_executors.extend(other.remove_executors);
-
-        self.updated_tasks.extend(other.updated_tasks);
 
         self.reduction_tasks
             .new_reduction_tasks
@@ -72,6 +84,12 @@ impl SchedulerUpdateRequest {
         self.reduction_tasks
             .processed_reduction_tasks
             .extend(other.reduction_tasks.processed_reduction_tasks);
+
+        self.remove_executors.extend(other.remove_executors);
+        self.new_function_executors
+            .extend(other.new_function_executors);
+        self.remove_function_executors
+            .extend(other.remove_function_executors);
     }
 }
 

--- a/server/state_store/src/requests.rs
+++ b/server/state_store/src/requests.rs
@@ -5,6 +5,7 @@ use data_model::{
     ComputeGraph,
     ExecutorId,
     ExecutorMetadata,
+    FunctionExecutorId,
     GraphInvocationCtx,
     InvocationPayload,
     NodeOutput,
@@ -37,6 +38,12 @@ pub enum RequestPayload {
     Noop,
 }
 
+#[derive(Debug, Clone)]
+pub struct FunctionExecutorIdWithExecutionId {
+    pub function_executor_id: FunctionExecutorId,
+    pub executor_id: ExecutorId,
+}
+
 #[derive(Debug, Clone, Default)]
 pub struct SchedulerUpdateRequest {
     pub new_allocations: Vec<Allocation>,
@@ -45,6 +52,27 @@ pub struct SchedulerUpdateRequest {
     pub updated_invocations_states: Vec<GraphInvocationCtx>,
     pub reduction_tasks: ReductionTasks,
     pub remove_executors: Vec<ExecutorId>,
+    pub remove_function_executors: Vec<FunctionExecutorIdWithExecutionId>,
+}
+
+impl SchedulerUpdateRequest {
+    /// Extends this SchedulerUpdateRequest with contents from another one
+    pub fn extend(&mut self, other: SchedulerUpdateRequest) {
+        self.new_allocations.extend(other.new_allocations);
+        self.remove_allocations.extend(other.remove_allocations);
+        self.updated_invocations_states
+            .extend(other.updated_invocations_states);
+        self.remove_executors.extend(other.remove_executors);
+
+        self.updated_tasks.extend(other.updated_tasks);
+
+        self.reduction_tasks
+            .new_reduction_tasks
+            .extend(other.reduction_tasks.new_reduction_tasks);
+        self.reduction_tasks
+            .processed_reduction_tasks
+            .extend(other.reduction_tasks.processed_reduction_tasks);
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/server/state_store/src/state_changes.rs
+++ b/server/state_store/src/state_changes.rs
@@ -167,7 +167,7 @@ pub fn register_executor(
 ) -> Result<Vec<StateChange>> {
     let last_change_id = last_state_change_id.fetch_add(1, atomic::Ordering::Relaxed);
     let state_change = StateChangeBuilder::default()
-        .change_type(ChangeType::ExecutorAdded(ExecutorAddedEvent {
+        .change_type(ChangeType::ExecutorUpserted(ExecutorAddedEvent {
             executor_id: request.executor.id.clone(),
         }))
         .created_at(get_epoch_time_in_ms())

--- a/server/state_store/src/state_machine.rs
+++ b/server/state_store/src/state_machine.rs
@@ -704,6 +704,7 @@ pub(crate) fn handle_scheduler_update(
             invocation_id = task.invocation_id,
             function_name = task.compute_fn_name,
             task_id = task.id.to_string(),
+            outcome = task.outcome.to_string(),
             "updated task",
         );
         let serialized_task = JsonEncoder::encode(&task)?;
@@ -717,6 +718,15 @@ pub(crate) fn handle_scheduler_update(
     processed_reduction_tasks(db.clone(), txn, &request.reduction_tasks)?;
 
     for invocation_ctx in &request.updated_invocations_states {
+        if invocation_ctx.completed {
+            info!(
+                invocation_id = invocation_ctx.invocation_id.to_string(),
+                namespace = invocation_ctx.namespace,
+                compute_graph = invocation_ctx.compute_graph_name,
+                outcome = invocation_ctx.outcome.to_string(),
+                "invocation completed"
+            );
+        }
         let serialized_graph_ctx = JsonEncoder::encode(&invocation_ctx)?;
         txn.put_cf(
             &IndexifyObjectsColumns::GraphInvocationCtx.cf_db(&db),

--- a/server/state_store/src/state_machine.rs
+++ b/server/state_store/src/state_machine.rs
@@ -15,7 +15,7 @@ use data_model::{
     Task,
     TaskOutputsIngestionStatus,
 };
-use indexify_utils::{get_epoch_time_in_ms, OptionInspectNone};
+use indexify_utils::{get_elapsed_time, get_epoch_time_in_ms, OptionInspectNone, TimeUnit};
 use rocksdb::{
     AsColumnFamilyRef,
     ColumnFamily,
@@ -704,7 +704,9 @@ pub(crate) fn handle_scheduler_update(
             invocation_id = task.invocation_id,
             function_name = task.compute_fn_name,
             task_id = task.id.to_string(),
+            status = task.status.to_string(),
             outcome = task.outcome.to_string(),
+            duration_secs = get_elapsed_time(task.creation_time_ns, TimeUnit::Nanoseconds),
             "updated task",
         );
         let serialized_task = JsonEncoder::encode(&task)?;
@@ -724,6 +726,8 @@ pub(crate) fn handle_scheduler_update(
                 namespace = invocation_ctx.namespace,
                 compute_graph = invocation_ctx.compute_graph_name,
                 outcome = invocation_ctx.outcome.to_string(),
+                duration_secs =
+                    get_elapsed_time(invocation_ctx.created_at.into(), TimeUnit::Milliseconds),
                 "invocation completed"
             );
         }


### PR DESCRIPTION
## Context

<!--
In a few sentences or less, please explain the context behind this change to help answer why this change is needed.

If this is a bug fix, make sure to include "fixes #xxxx", or
"closes #xxxx".

Screenshots, logs, code or other visual aids are greatly appreciated.
 -->
 
 As part of moving responsibilities from the executors to the server, we need to make the server aware of function executors.

## What

<!--
In a few sentences, please summarize the change to help reviewers.

Consider providing screenshots, logs, code or other visual aids to help the reviewer understand the approach taken.
-->

This PR replaces the `allocations_by_fn` indexes by `function_executors_by_executor` and `allocations_by_executor`.

Details:
- Metrics and /internal/allocations are function executor aware
- ExecutorMetadata only gets upserted if the heartbeat state hash changes.
- ExecutorUpserted state change now triggers reconcilation in the graph processor
- Current executor reconciliation does two things: 1) ensure all current FE respect current dev + allow list + 2) remove any FE that has been removed on the executors. We also reallocate immediately any tasks that gets deallocated.
- Task Allocation now is structured differently: 
  - 1. get_executor_candidates
  - 2. select_executor 
  - 3. ensure function executor
  - 4. create allocation
- A new migration reallocates any existing allocation in order to make sure all allocations have a function executor ID associated to them

## Testing

- [x] Test Executor upsert + reconciliation logic
- [x] Test allocation leveraging different function executors

<!--
Please include steps used to verify the change.

Consider providing screenshots, logs, code or other visual aids to help the reviewer in their testing.
-->

## Contribution Checklist

- [x] If a Python package was changed, please run `make fmt` in the package directory.
- [x] If the server was changed, please run `make fmt` in `server/`.
- [x] Make sure all PR Checks are passing.
<!--
Notes:

Tests of a Python package can be run manually. Start a Server and an Executor then
run `make test` in the Python package directory.

To test if changes to the server are backward compatible with the latest
release, label the PR with `ci_compat_test`. This might report failures
unrelated to your change if previous incompatible changes were pushed without
being released yet
-->
