### PR TITLE
Use data payloads for inputs and outputs in Executor gRPC protocol definitions

### DIFF
--- a/server/proto/executor_api.proto
+++ b/server/proto/executor_api.proto
@@ -4,6 +4,28 @@ syntax = "proto3";
 // Existing clients won't find the service if the package name changes.
 package executor_api_pb;
 
+// ===== DataPayload =====
+enum DataPayloadEncoding {
+    DATA_PAYLOAD_ENCODING_UNKNOWN = 0;
+    // These encodings are currently mapping 1:1 to mime types.
+    // TODO: use SDK specific encodings becase 1:1 mapping might not work in the future.
+    DATA_PAYLOAD_ENCODING_UTF8_JSON = 1;
+    DATA_PAYLOAD_ENCODING_UTF8_TEXT = 2;
+    DATA_PAYLOAD_ENCODING_BINARY_PICKLE = 3;
+}
+
+message DataPayload {
+    optional string path = 1; // deprecated, TODO: remove when URI us used everywhere
+    optional uint64 size = 2;
+    optional string sha256_hash = 3;
+    // URI of the data.
+    // S3 URI if the data is stored in S3.
+    // Starts with "file://"" prefix if the data is stored on a local file system.
+    optional string uri = 4;
+    optional DataPayloadEncoding encoding = 5;
+    optional uint64 encoding_version = 6;
+}
+
 // ===== report_executor_state RPC =====
 
 enum GPUModel {
@@ -72,6 +94,7 @@ message FunctionExecutorDescription {
     optional HostResources resource_limits = 8;
     // Timeout for customer code duration during FE creation.
     optional uint32 customer_code_timeout_ms = 9;
+    optional DataPayload graph = 10;
 }
 
 message FunctionExecutorState {
@@ -134,9 +157,15 @@ message Task {
     optional string graph_version = 4;
     optional string function_name = 5;
     optional string graph_invocation_id = 6;
-    optional string input_key = 8;
-    optional string reducer_output_key = 9;
+    optional string input_key = 8; // deprecated. TODO: remove when input is used everywhere
+    optional string reducer_output_key = 9; // deprecated. TODO: remove when reducer_input is used everywhere
     optional uint32 timeout_ms = 10;
+    optional DataPayload input = 11;
+    optional DataPayload reducer_input = 12;
+    // URI prefix for the output payloads.
+    // S3 URI if the data is stored in S3.
+    // Starts with "file://"" prefix followed by an absolute directory path if the data is stored on a local file system.
+    optional string output_payload_uri_prefix = 13;
 }
 
 message TaskAllocation {
@@ -166,12 +195,6 @@ enum TaskOutcome {
     TASK_OUTCOME_FAILURE = 2;
 }
 
-message DataPayload {
-    optional string path = 1;
-    optional uint64 size = 2;
-    optional string sha256_hash = 3;
-}
-
 enum OutputEncoding {
     OUTPUT_ENCODING_UNKNOWN = 0;
     OUTPUT_ENCODING_JSON = 1;
@@ -186,7 +209,7 @@ message ReportTaskOutcomeRequest {
     optional string function_name = 4;
     optional string graph_invocation_id = 6;
     optional TaskOutcome outcome = 7;
-    optional string invocation_id = 8;
+    optional string invocation_id = 8; // deprecated. TODO: remove when graph_invocation_id is used everywhere
     optional string executor_id = 9;
     optional bool reducer = 10;
 
@@ -199,10 +222,10 @@ message ReportTaskOutcomeRequest {
     optional DataPayload stdout = 14;
     optional DataPayload stderr = 15;
     // Output encoding of all the outputs of a function have to be same.
-    optional OutputEncoding output_encoding = 13;
+    optional OutputEncoding output_encoding = 13; // deprecated. TODO: remove when DataPayload.encoding is used everywhere
     // This allows us to change how we encode the output from functions
     // and serialize them into storage.
-    optional uint64 output_encoding_version = 5;
+    optional uint64 output_encoding_version = 5;  // deprecated. TODO: remove when DataPayload.encoding_version is used everywhere
 }
 
 message ReportTaskOutcomeResponse {

--- a/server/src/executor_api.rs
+++ b/server/src/executor_api.rs
@@ -26,6 +26,7 @@ use data_model::{
 use executor_api_pb::{
     executor_api_server::ExecutorApi,
     AllowedFunction,
+    DataPayloadEncoding,
     DesiredExecutorState,
     ExecutorState,
     ExecutorStatus,
@@ -334,9 +335,9 @@ impl ExecutorApi for ExecutorAPIService {
             .ok_or(Status::invalid_argument("compute_fn is required"))?;
         let invocation_id = request
             .get_ref()
-            .invocation_id
+            .graph_invocation_id
             .clone()
-            .ok_or(Status::invalid_argument("invocation_id is required"))?;
+            .ok_or(Status::invalid_argument("graph_invocation_id is required"))?;
         let task = self
             .indexify_state
             .reader()
@@ -348,22 +349,10 @@ impl ExecutorApi for ExecutorAPIService {
                 &task_id,
             )
             .map_err(|e| Status::internal(e.to_string()))?;
-        let output_encoding = request
-            .get_ref()
-            .output_encoding
-            .ok_or(Status::invalid_argument("output_encoding is required"))?;
         if task.is_none() {
             warn!("Task not found for task_id: {}", task_id);
             return Ok(Response::new(ReportTaskOutcomeResponse {}));
         }
-        let encoding = OutputEncoding::try_from(output_encoding)
-            .map_err(|e| Status::invalid_argument(e.to_string()))?;
-        let encoding_str = match encoding {
-            OutputEncoding::Json => "application/json",
-            OutputEncoding::Pickle => "application/octet-stream",
-            OutputEncoding::Binary => "application/octet-stream",
-            OutputEncoding::Unknown => "unknown",
-        };
         let mut task = task.unwrap();
         match task_outcome {
             executor_api_pb::TaskOutcome::Success => {
@@ -383,7 +372,8 @@ impl ExecutorApi for ExecutorAPIService {
         for output in request.get_ref().fn_outputs.clone() {
             let path = output
                 .path
-                .ok_or(Status::invalid_argument("path is required"))?;
+                .or(output.uri)
+                .ok_or(Status::invalid_argument("path or uri is required"))?;
             let size = output
                 .size
                 .ok_or(Status::invalid_argument("size is required"))?;
@@ -395,6 +385,39 @@ impl ExecutorApi for ExecutorAPIService {
                 size,
                 sha256_hash,
             };
+            let encoding_str = match output.encoding {
+                Some(value) => {
+                    let output_encoding = DataPayloadEncoding::try_from(value)
+                        .map_err(|e| Status::invalid_argument(e.to_string()))?;
+                    match output_encoding {
+                        DataPayloadEncoding::Utf8Json => Ok("application/json"),
+                        DataPayloadEncoding::BinaryPickle => Ok("application/octet-stream"),
+                        DataPayloadEncoding::Utf8Text => Ok("text/plain"),
+                        DataPayloadEncoding::Unknown => {
+                            Err(Status::invalid_argument("unknown data payload encoding"))
+                        }
+                    }
+                }
+                // Fallback to the deprecated request encoding if not set
+                None => match request.get_ref().output_encoding {
+                    Some(value) => {
+                        let output_encoding = OutputEncoding::try_from(value)
+                            .map_err(|e| Status::invalid_argument(e.to_string()))?;
+                        match output_encoding {
+                            OutputEncoding::Json => Ok("application/json"),
+                            OutputEncoding::Pickle => Ok("application/octet-stream"),
+                            OutputEncoding::Binary => Ok("application/octet-stream"),
+                            OutputEncoding::Unknown => {
+                                Err(Status::invalid_argument("unknown request output encoding"))
+                            }
+                        }
+                    }
+                    None => Err(Status::invalid_argument(
+                        "data payload encoding or request output encoding is required",
+                    )),
+                },
+            }?;
+
             let node_output = NodeOutputBuilder::default()
                 .namespace(namespace.to_string())
                 .compute_graph_name(compute_graph.to_string())
@@ -454,18 +477,20 @@ fn prepare_data_payload(
     if msg.is_none() {
         return None;
     }
-    if msg.as_ref().unwrap().path.as_ref().is_none() {
-        return None;
-    }
-    if msg.as_ref().unwrap().size.as_ref().is_none() {
-        return None;
-    }
-    if msg.as_ref().unwrap().sha256_hash.as_ref().is_none() {
-        return None;
-    }
     let msg = msg.unwrap();
+    if msg.uri.is_none() && msg.path.is_none() {
+        return None;
+    }
+    if msg.size.as_ref().is_none() {
+        return None;
+    }
+    if msg.sha256_hash.as_ref().is_none() {
+        return None;
+    }
+
     Some(data_model::DataPayload {
-        path: msg.path.unwrap(),
+        // Fallback to deprecated path if uri is not set.
+        path: msg.uri.or(msg.path).unwrap(),
         size: msg.size.unwrap(),
         sha256_hash: msg.sha256_hash.unwrap(),
     })


### PR DESCRIPTION
The changes in this PR define how Executor is going to directly upload and download to/from S3.

The idea is to use the same DataPayload message for task inputs and outputs. The new Task field output_payload_uri_prefix tells Executor under which S3 path or filesystem dir to put output files.

Server side report task outcome RPC is updated to work with previous and new Executor behaviors when calling this RPC. The passing integration tests prove this because there are no Executor changes in this PR.