### PR TITLE
Executor side blob store download of graph and task inputs

### DIFF
--- a/indexify/poetry.lock
+++ b/indexify/poetry.lock
@@ -274,6 +274,49 @@ jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
 uvloop = ["uvloop (>=0.15.2)"]
 
 [[package]]
+name = "boto3"
+version = "1.37.30"
+description = "The AWS SDK for Python"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "boto3-1.37.30-py3-none-any.whl", hash = "sha256:c75d78013eb43b354662cbd5f30bf537ab06641d3ed37aaad6fcf55a529d2991"},
+    {file = "boto3-1.37.30.tar.gz", hash = "sha256:beea13db5a5f5eaacecfa905cd1e4e933c13802f776198264eef229d6dffcc42"},
+]
+
+[package.dependencies]
+botocore = ">=1.37.30,<1.38.0"
+jmespath = ">=0.7.1,<2.0.0"
+s3transfer = ">=0.11.0,<0.12.0"
+
+[package.extras]
+crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
+
+[[package]]
+name = "botocore"
+version = "1.37.30"
+description = "Low-level, data-driven core of boto 3."
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "botocore-1.37.30-py3-none-any.whl", hash = "sha256:d8ca899962d2079acd52483581f607322513910337a69bdae697766404b85b7d"},
+    {file = "botocore-1.37.30.tar.gz", hash = "sha256:2f43b61e0231abbb4fbe8917acb1af98cb83dbab8c264c0d1f5ca0f16fdbf219"},
+]
+
+[package.dependencies]
+jmespath = ">=0.7.1,<2.0.0"
+python-dateutil = ">=2.1,<3.0.0"
+urllib3 = [
+    {version = ">=1.25.4,<1.27", markers = "python_version < \"3.10\""},
+    {version = ">=1.25.4,<2.2.0 || >2.2.0,<3", markers = "python_version >= \"3.10\""},
+]
+
+[package.extras]
+crt = ["awscrt (==0.23.8)"]
+
+[[package]]
 name = "certifi"
 version = "2025.1.31"
 description = "Python package for providing Mozilla's CA Bundle."
@@ -879,6 +922,18 @@ colors = ["colorama"]
 plugins = ["setuptools"]
 
 [[package]]
+name = "jmespath"
+version = "1.0.1"
+description = "JSON Matching Expressions"
+optional = false
+python-versions = ">=3.7"
+groups = ["main"]
+files = [
+    {file = "jmespath-1.0.1-py3-none-any.whl", hash = "sha256:02e2e4cc71b5bcab88332eebf907519190dd9e6e82107fa7f83b1003a6252980"},
+    {file = "jmespath-1.0.1.tar.gz", hash = "sha256:90261b206d6defd58fdd5e85f478bf633a2901798906be2ad389150c5c60edbe"},
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "3.0.0"
 description = "Python port of markdown-it. Markdown parsing, done right!"
@@ -1433,6 +1488,21 @@ spelling = ["pyenchant (>=3.2,<4.0)"]
 testutils = ["gitpython (>3)"]
 
 [[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+description = "Extensions to the standard Python datetime module"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
+groups = ["main"]
+files = [
+    {file = "python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3"},
+    {file = "python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427"},
+]
+
+[package.dependencies]
+six = ">=1.5"
+
+[[package]]
 name = "python-magic"
 version = "0.4.27"
 description = "File type identification using libmagic"
@@ -1595,6 +1665,24 @@ typing-extensions = {version = ">=4.0.0,<5.0", markers = "python_version < \"3.1
 jupyter = ["ipywidgets (>=7.5.1,<9)"]
 
 [[package]]
+name = "s3transfer"
+version = "0.11.4"
+description = "An Amazon S3 Transfer Manager"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "s3transfer-0.11.4-py3-none-any.whl", hash = "sha256:ac265fa68318763a03bf2dc4f39d5cbd6a9e178d81cc9483ad27da33637e320d"},
+    {file = "s3transfer-0.11.4.tar.gz", hash = "sha256:559f161658e1cf0a911f45940552c696735f5c74e64362e515f333ebed87d679"},
+]
+
+[package.dependencies]
+botocore = ">=1.37.4,<2.0a.0"
+
+[package.extras]
+crt = ["botocore[crt] (>=1.37.4,<2.0a.0)"]
+
+[[package]]
 name = "setuptools"
 version = "75.8.0"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
@@ -1625,6 +1713,18 @@ groups = ["main"]
 files = [
     {file = "shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686"},
     {file = "shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de"},
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+description = "Python 2 and 3 compatibility utilities"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
+groups = ["main"]
+files = [
+    {file = "six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274"},
+    {file = "six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81"},
 ]
 
 [[package]]
@@ -1797,11 +1897,30 @@ markers = {dev = "python_version < \"3.11\""}
 
 [[package]]
 name = "urllib3"
+version = "1.26.20"
+description = "HTTP library with thread-safe connection pooling, file post, and more."
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,>=2.7"
+groups = ["main"]
+markers = "python_version < \"3.10\""
+files = [
+    {file = "urllib3-1.26.20-py2.py3-none-any.whl", hash = "sha256:0ed14ccfbf1c30a9072c7ca157e4319b70d65f623e91e7b32fadb2853431016e"},
+    {file = "urllib3-1.26.20.tar.gz", hash = "sha256:40c2dc0c681e47eb8f90e7e27bf6ff7df2e677421fd46756da1161c39ca70d32"},
+]
+
+[package.extras]
+brotli = ["brotli (==1.0.9)", "brotli (>=1.0.9)", "brotlicffi (>=0.8.0)", "brotlipy (>=0.6.0)"]
+secure = ["certifi", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "ipaddress", "pyOpenSSL (>=0.14)", "urllib3-secure-extra"]
+socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
+
+[[package]]
+name = "urllib3"
 version = "2.3.0"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
+markers = "python_version >= \"3.10\""
 files = [
     {file = "urllib3-2.3.0-py3-none-any.whl", hash = "sha256:1cee9ad369867bfdbbb48b7dd50374c0967a0bb7710050facf0dd6911440e3df"},
     {file = "urllib3-2.3.0.tar.gz", hash = "sha256:f8c5449b3cf0861679ce7e0503c7b44b5ec981bec0d1d3795a07f1ba96f0204d"},
@@ -1913,4 +2032,4 @@ propcache = ">=0.2.0"
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.9"
-content-hash = "f6b0f2cf55e77b3fe0b1652cc201775c86098f7c7d29b6ea41f2252e9a8376bb"
+content-hash = "f7fb84f4e86aa9e9b307eff4a485c2a7d87751e3e220660503032d1c7dafa022"

--- a/indexify/pyproject.toml
+++ b/indexify/pyproject.toml
@@ -35,6 +35,7 @@ tensorlake = ">=0.1"
 rich = "^13.9.2"
 typer = "^0.12"
 # nanoid is provided by tensorlake
+boto3 = "^1.37.30"
 
 [tool.poetry.group.dev.dependencies]
 black = "^24.10.0"

--- a/indexify/src/indexify/executor/blob_store/blob_store.py
+++ b/indexify/src/indexify/executor/blob_store/blob_store.py
@@ -1,0 +1,69 @@
+from typing import Any, Optional
+
+from .local_fs_blob_store import LocalFSBLOBStore
+from .metrics.blob_store import (
+    metric_get_blob_errors,
+    metric_get_blob_latency,
+    metric_get_blob_requests,
+    metric_put_blob_errors,
+    metric_put_blob_latency,
+    metric_put_blob_requests,
+)
+from .s3_blob_store import S3BLOBStore
+
+
+class BLOBStore:
+    """Dispatches generic BLOB store calls to their real backends."""
+
+    def __init__(
+        self, local: Optional[LocalFSBLOBStore] = None, s3: Optional[S3BLOBStore] = None
+    ):
+        """Creates a BLOB store that uses the supplied BLOB stores."""
+        self._local: Optional[LocalFSBLOBStore] = local
+        self._s3: Optional[S3BLOBStore] = s3
+
+    async def get(self, uri: str, logger: Any) -> bytes:
+        """Returns binary value stored in BLOB with the supplied URI.
+
+        Raises Exception on error. Raises KeyError if the BLOB doesn't exist.
+        """
+        with (
+            metric_get_blob_errors.count_exceptions(),
+            metric_get_blob_latency.time(),
+        ):
+            metric_get_blob_requests.inc()
+            if _is_file_uri(uri):
+                self._check_local_is_available()
+                return await self._local.get(uri, logger)
+            else:
+                self._check_s3_is_available()
+                return await self._s3.get(uri, logger)
+
+    async def put(self, uri: str, value: bytes, logger: Any) -> None:
+        """Stores the supplied binary value in a BLOB with the supplied URI.
+
+        Overwrites existing BLOB. Raises Exception on error.
+        """
+        with (
+            metric_put_blob_errors.count_exceptions(),
+            metric_put_blob_latency.time(),
+        ):
+            metric_put_blob_requests.inc()
+            if _is_file_uri(uri):
+                self._check_local_is_available()
+                await self._local.put(uri, value, logger)
+            else:
+                self._check_s3_is_available()
+                await self._s3.put(uri, value, logger)
+
+    def _check_local_is_available(self):
+        if self._local is None:
+            raise RuntimeError("Local file system BLOB store is not available")
+
+    def _check_s3_is_available(self):
+        if self._s3 is None:
+            raise RuntimeError("S3 BLOB store is not available")
+
+
+def _is_file_uri(uri: str) -> bool:
+    return uri.startswith("file://")

--- a/indexify/src/indexify/executor/blob_store/local_fs_blob_store.py
+++ b/indexify/src/indexify/executor/blob_store/local_fs_blob_store.py
@@ -1,0 +1,48 @@
+import asyncio
+import os
+import os.path
+from typing import Any
+
+
+class LocalFSBLOBStore:
+    """BLOB store that stores BLOBs in local file system."""
+
+    async def get(self, uri: str, logger: Any) -> bytes:
+        """Returns binary value stored in file at the supplied URI.
+
+        The URI must be a file URI (starts with "file://"). The path must be absolute.
+        Raises Exception on error. Raises KeyError if the file doesn't exist.
+        """
+        # Run synchronous code in a thread to not block the event loop.
+        return await asyncio.to_thread(self._sync_get, _path_from_file_uri(uri))
+
+    async def put(self, uri: str, value: bytes, logger: Any) -> None:
+        """Stores the supplied binary value in a file at the supplied URI.
+
+        The URI must be a file URI (starts with "file://"). The path must be absolute.
+        Overwrites existing file. Raises Exception on error.
+        """
+        # Run synchronous code in a thread to not block the event loop.
+        return await asyncio.to_thread(self._sync_put, _path_from_file_uri(uri), value)
+
+    def _sync_get(self, path: str) -> bytes:
+        if not os.path.isabs(path):
+            raise ValueError(f"Path {path} is not absolute")
+
+        if os.path.exists(path):
+            with open(path, mode="rb") as blob_file:
+                return blob_file.read()
+        else:
+            raise KeyError(f"File at {path} does not exist")
+
+    def _sync_put(self, path: str, value: bytes) -> None:
+        if not os.path.isabs(path):
+            raise ValueError(f"Path {path} is not absolute")
+
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, mode="wb") as blob_file:
+            blob_file.write(value)
+
+
+def _path_from_file_uri(uri: str) -> str:
+    return uri[7:]  # strip "file://" prefix

--- a/indexify/src/indexify/executor/blob_store/metrics/blob_store.py
+++ b/indexify/src/indexify/executor/blob_store/metrics/blob_store.py
@@ -1,0 +1,33 @@
+import prometheus_client
+
+from ...monitoring.metrics import latency_metric_for_fast_operation
+
+metric_get_blob_requests: prometheus_client.Counter = prometheus_client.Counter(
+    "get_blob_requests",
+    "Number of get blob requests",
+)
+metric_get_blob_errors: prometheus_client.Counter = prometheus_client.Counter(
+    "get_blob_request_errors",
+    "Number of get blob request errors",
+)
+metric_get_blob_latency: prometheus_client.Histogram = (
+    latency_metric_for_fast_operation(
+        "get_blob_request",
+        "get blob request",
+    )
+)
+
+metric_put_blob_requests: prometheus_client.Counter = prometheus_client.Counter(
+    "put_blob_requests",
+    "Number of put blob requests",
+)
+metric_put_blob_errors: prometheus_client.Counter = prometheus_client.Counter(
+    "put_blob_request_errors",
+    "Number of put blob request errors",
+)
+metric_put_blob_latency: prometheus_client.Histogram = (
+    latency_metric_for_fast_operation(
+        "put_blob_request",
+        "put blob request",
+    )
+)

--- a/indexify/src/indexify/executor/blob_store/s3_blob_store.py
+++ b/indexify/src/indexify/executor/blob_store/s3_blob_store.py
@@ -1,0 +1,85 @@
+import asyncio
+from typing import Any, Optional
+
+import boto3
+from botocore.config import Config as BotoConfig
+from botocore.exceptions import ClientError as BotoClientError
+
+_MAX_RETRIES = 3
+
+
+class S3BLOBStore:
+    def __init__(self):
+        self._s3_client: Optional[Any] = None
+
+    def _lazy_create_client(self):
+        """Creates S3 client if it doesn't exist.
+
+        We create the client lazily only if S3 is used.
+        This is because S3 BLOB store is always created by Executor
+        and the creation will fail if user didn't configure S3 credentials and etc.
+        """
+        if self._s3_client is not None:
+            return
+
+        # The credentials and etc are fetched by boto3 library automatically following
+        # https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html#configuring-credentials
+        # This provides a lot of flexibility for the user and follows a well-known and documented logic.
+        self._s3_client = boto3.client(
+            "s3",
+            config=BotoConfig(
+                # https://boto3.amazonaws.com/v1/documentation/api/latest/guide/retries.html#standard-retry-mode
+                retries={
+                    "max_attempts": _MAX_RETRIES,
+                    "mode": "standard",
+                }
+            ),
+        )
+
+    async def get(self, uri: str, logger: Any) -> bytes:
+        """Returns binary value stored in S3 object at the supplied URI.
+
+        The URI must be S3 URI (starts with "s3://").
+        Raises Exception on error. Raises KeyError if the object doesn't exist.
+        """
+        try:
+            self._lazy_create_client()
+            bucket_name, key = _bucket_name_and_object_key_from_uri(uri)
+            response = await asyncio.to_thread(
+                self._s3_client.get_object, Bucket=bucket_name, Key=key
+            )
+            return response["Body"].read()
+        except BotoClientError as e:
+            logger.error("failed to get S3 object", uri=uri, exc_info=e)
+
+            if e.response["Error"]["Code"] == "NoSuchKey":
+                raise KeyError(f"Object {key} does not exist in bucket {bucket_name}")
+            raise
+        except Exception as e:
+            logger.error("failed to get S3 object", uri=uri, exc_info=e)
+            raise
+
+    async def put(self, uri: str, value: bytes, logger: Any) -> None:
+        """Stores the supplied binary value in a S3 object at the supplied URI.
+
+        The URI must be S3 URI (starts with "s3://").
+        Overwrites existing object. Raises Exception on error.
+        """
+        try:
+            self._lazy_create_client()
+            bucket_name, key = _bucket_name_and_object_key_from_uri(uri)
+            await asyncio.to_thread(
+                self._s3_client.put_object, Bucket=bucket_name, Key=key, Body=value
+            )
+        except Exception as e:
+            logger.error("failed to set S3 object", uri=uri, exc_info=e)
+            raise
+
+
+def _bucket_name_and_object_key_from_uri(uri: str) -> tuple[str, str]:
+    if not uri.startswith("s3://"):
+        raise ValueError(f"S3 URI '{uri}' is missing 's3://' prefix")
+    parts = uri[5:].split("/", 1)
+    if len(parts) != 2:
+        raise ValueError(f"Failed parsing bucket name from S3 URI '{uri}'")
+    return parts[0], parts[1]  # bucket_name, key

--- a/indexify/src/indexify/executor/grpc/function_executor_controller.py
+++ b/indexify/src/indexify/executor/grpc/function_executor_controller.py
@@ -17,9 +17,6 @@ from indexify.proto.executor_api_pb2 import (
 from ..downloader import Downloader
 from ..function_executor.function_executor import CustomerError, FunctionExecutor
 from ..function_executor.function_executor_state import FunctionExecutorState
-from ..function_executor.function_executor_states_container import (
-    FunctionExecutorStatesContainer,
-)
 from ..function_executor.function_executor_status import FunctionExecutorStatus
 from ..function_executor.health_checker import HealthCheckResult
 from ..function_executor.server.function_executor_server_factory import (
@@ -41,6 +38,7 @@ def validate_function_executor_description(
     validator.required_field("graph_name")
     validator.required_field("graph_version")
     validator.required_field("function_name")
+    # TODO: Make graph required after we migrate to direct S3 downloads.
     # image_uri is optional.
     # secret_names can be empty.
     # resource_limits is optional.
@@ -324,6 +322,11 @@ async def _create_function_executor(
         graph_name=function_executor_description.graph_name,
         graph_version=function_executor_description.graph_version,
         logger=logger,
+        data_payload=(
+            function_executor_description.graph
+            if function_executor_description.HasField("graph")
+            else None
+        ),
     )
 
     config: FunctionExecutorServerConfiguration = FunctionExecutorServerConfiguration(

--- a/indexify/src/indexify/executor/grpc/state_reconciler.py
+++ b/indexify/src/indexify/executor/grpc/state_reconciler.py
@@ -6,11 +6,6 @@ from tensorlake.function_executor.proto.message_validator import MessageValidato
 from indexify.proto.executor_api_pb2 import (
     DesiredExecutorState,
     FunctionExecutorDescription,
-)
-from indexify.proto.executor_api_pb2 import (
-    FunctionExecutorStatus as FunctionExecutorStatusProto,
-)
-from indexify.proto.executor_api_pb2 import (
     GetDesiredExecutorStatesRequest,
     TaskAllocation,
 )


### PR DESCRIPTION
The downloads are only working in gRPC mode.
gRPC mode + local FS blob store is tested via state reconciler unite tests.
S3 blob store was tested manually with credentials provided in env vars.