### PR TITLE
Server support for Executor side blob upload and download in HTTP mode

### DIFF
--- a/server/blob_store/src/lib.rs
+++ b/server/blob_store/src/lib.rs
@@ -58,6 +58,8 @@ pub struct PutResult {
 
 pub struct BlobStorage {
     object_store: Arc<dyn ObjectStore>,
+    url_scheme: String,
+    url: String,
     path: Path,
     metrics: blob_storage::Metrics,
 }
@@ -69,6 +71,8 @@ impl BlobStorage {
         let (object_store, path) = Self::build_object_store(url)?;
         Ok(Self {
             object_store: Arc::new(object_store),
+            url_scheme: url.parse::<Url>()?.scheme().to_string(),
+            url: url.clone(),
             path,
             metrics: blob_storage::Metrics::new(),
         })
@@ -95,6 +99,14 @@ impl BlobStorage {
 
     pub fn get_object_store(&self) -> Arc<dyn ObjectStore> {
         self.object_store.clone()
+    }
+
+    pub fn get_url(&self) -> String {
+        self.url.clone()
+    }
+
+    pub fn get_url_scheme(&self) -> String {
+        self.url_scheme.clone()
     }
 
     pub fn get_path(&self) -> Path {

--- a/server/src/service.rs
+++ b/server/src/service.rs
@@ -152,6 +152,7 @@ impl Service {
         let mut shutdown_rx = self.shutdown_rx.clone();
         let indexify_state = self.indexify_state.clone();
         let executor_manager = self.executor_manager.clone();
+        let blob_storage = self.blob_storage.clone();
         tokio::spawn(async move {
             info!("server grpc listening on {}", addr_grpc);
             let reflection_service = tonic_reflection::server::Builder::configure()
@@ -163,6 +164,7 @@ impl Service {
                     indexify_state,
                     executor_manager,
                     api_metrics,
+                    blob_storage,
                 )))
                 .add_service(reflection_service)
                 .serve_with_shutdown(addr_grpc, async move {


### PR DESCRIPTION
One notable difference is that Server has to convert its internal blob paths
into full blob URIs when sending data payloads to Executor and Server.
Server also has to strip full blob URIs it gets from Executor to get blob paths.
The paths depends on blob store driver used by Server. This is documented
in code comments.

I tested this with Executor side changes and all tests are passing
both with S3 and local FS blob stores.

Sending this in a separate PR from Executor changes to ensure that
Executor still works withouts its changes. This is to ensure
backward compatibility.