### PR TITLE
Use data payloads supplied by Server to download and upload blobs on Executor

### DIFF
--- a/indexify/src/indexify/executor/api_objects.py
+++ b/indexify/src/indexify/executor/api_objects.py
@@ -3,6 +3,13 @@ from typing import Any, Dict, List, Optional
 from pydantic import BaseModel
 
 
+class DataPayload(BaseModel):
+    path: str
+    size: int
+    sha256_hash: str
+    content_type: Optional[str] = None
+
+
 class Task(BaseModel):
     id: str
     namespace: str
@@ -16,6 +23,10 @@ class Task(BaseModel):
     "image_uri defines the URI of the image of this task. Optional since some executors do not require it."
     secret_names: Optional[List[str]] = None
     "secret_names defines the names of the secrets to set on function executor. Optional for backward compatibility."
+    graph_payload: Optional[DataPayload] = None
+    input_payload: Optional[DataPayload] = None
+    reducer_input_payload: Optional[DataPayload] = None
+    output_payload_uri_prefix: Optional[str] = None
 
 
 class FunctionURI(BaseModel):
@@ -47,12 +58,6 @@ class TaskResult(BaseModel):
     executor_id: str
     task_id: str
     reducer: bool = False
-
-
-class DataPayload(BaseModel):
-    path: str
-    size: int
-    sha256_hash: str
 
 
 class IngestFnOutputsResponse(BaseModel):

--- a/indexify/src/indexify/executor/blob_store/local_fs_blob_store.py
+++ b/indexify/src/indexify/executor/blob_store/local_fs_blob_store.py
@@ -27,7 +27,7 @@ class LocalFSBLOBStore:
 
     def _sync_get(self, path: str) -> bytes:
         if not os.path.isabs(path):
-            raise ValueError(f"Path {path} is not absolute")
+            raise ValueError(f"Path {path} must be absolute")
 
         if os.path.exists(path):
             with open(path, mode="rb") as blob_file:
@@ -37,7 +37,7 @@ class LocalFSBLOBStore:
 
     def _sync_put(self, path: str, value: bytes) -> None:
         if not os.path.isabs(path):
-            raise ValueError(f"Path {path} is not absolute")
+            raise ValueError(f"Path {path} must be absolute")
 
         os.makedirs(os.path.dirname(path), exist_ok=True)
         with open(path, mode="wb") as blob_file:

--- a/indexify/src/indexify/executor/blob_store/s3_blob_store.py
+++ b/indexify/src/indexify/executor/blob_store/s3_blob_store.py
@@ -77,8 +77,11 @@ class S3BLOBStore:
 
 
 def _bucket_name_and_object_key_from_uri(uri: str) -> tuple[str, str]:
+    # Example S3 object URI:
+    # s3://test-indexify-server-blob-store-eugene-20250411/225b83f4-2aed-40a7-adee-b7a681f817f2
     if not uri.startswith("s3://"):
         raise ValueError(f"S3 URI '{uri}' is missing 's3://' prefix")
+
     parts = uri[5:].split("/", 1)
     if len(parts) != 2:
         raise ValueError(f"Failed parsing bucket name from S3 URI '{uri}'")

--- a/indexify/src/indexify/executor/executor.py
+++ b/indexify/src/indexify/executor/executor.py
@@ -128,6 +128,7 @@ class Executor:
             executor_id=id,
             config_path=config_path,
             channel_manager=self._channel_manager,
+            blob_store=blob_store,
         )
 
         # HTTP mode task runner
@@ -261,6 +262,7 @@ class Executor:
                 function_name=task.compute_fn,
                 graph_version=task.graph_version,
                 graph_invocation_id=task.invocation_id,
+                output_payload_uri_prefix=task.output_payload_uri_prefix,
             )
             logger.error("task execution failed", exc_info=e)
 
@@ -304,19 +306,19 @@ class Executor:
             graph_name=task.compute_graph,
             graph_version=task.graph_version,
             logger=logger,
-            data_payload=None,
+            data_payload=task.graph_payload,
         )
         input: SerializedObject = await self._downloader.download_input(
             namespace=task.namespace,
             graph_name=task.compute_graph,
             graph_invocation_id=task.invocation_id,
             input_key=task.input_key,
-            data_payload=None,
+            data_payload=task.input_payload,
             logger=logger,
         )
         init_value: Optional[SerializedObject] = (
             None
-            if task.reducer_output_id is None
+            if task.reducer_output_id is None and task.reducer_input_payload is None
             else (
                 await self._downloader.download_init_value(
                     namespace=task.namespace,
@@ -324,7 +326,7 @@ class Executor:
                     function_name=task.compute_fn,
                     graph_invocation_id=task.invocation_id,
                     reducer_output_key=task.reducer_output_id,
-                    data_payload=None,
+                    data_payload=task.reducer_input_payload,
                     logger=logger,
                 )
             )

--- a/indexify/src/indexify/executor/function_executor/single_task_runner.py
+++ b/indexify/src/indexify/executor/function_executor/single_task_runner.py
@@ -96,6 +96,7 @@ class SingleTaskRunner:
                     graph_invocation_id=self._task_input.task.invocation_id,
                     stderr=str(e),
                     success=False,
+                    output_payload_uri_prefix=self._task_input.task.output_payload_uri_prefix,
                 )
 
         try:
@@ -311,6 +312,7 @@ def _task_output(task: Task, response: RunTaskResponse) -> TaskOutput:
         reducer=response.is_reducer,
         success=response.success,
         metrics=metrics,
+        output_payload_uri_prefix=task.output_payload_uri_prefix,
     )
 
     if response.HasField("function_output"):

--- a/indexify/src/indexify/executor/function_executor/task_output.py
+++ b/indexify/src/indexify/executor/function_executor/task_output.py
@@ -25,6 +25,7 @@ class TaskOutput:
         function_name: str,
         graph_version: str,
         graph_invocation_id: str,
+        output_payload_uri_prefix: Optional[str],
         output_encoding: Optional[str] = None,
         function_output: Optional[FunctionOutput] = None,
         router_output: Optional[RouterOutput] = None,
@@ -50,6 +51,7 @@ class TaskOutput:
         self.is_internal_error = is_internal_error
         self.metrics = metrics
         self.output_encoding = output_encoding
+        self.output_payload_uri_prefix = output_payload_uri_prefix
 
     @classmethod
     def internal_error(
@@ -60,6 +62,7 @@ class TaskOutput:
         function_name: str,
         graph_version: str,
         graph_invocation_id: str,
+        output_payload_uri_prefix: Optional[str],
     ) -> "TaskOutput":
         """Creates a TaskOutput for an internal error."""
         # We are not sharing internal error messages with the customer.
@@ -72,6 +75,7 @@ class TaskOutput:
             graph_invocation_id=graph_invocation_id,
             stderr="Platform failed to execute the function.",
             is_internal_error=True,
+            output_payload_uri_prefix=output_payload_uri_prefix,
         )
 
     @classmethod
@@ -84,6 +88,7 @@ class TaskOutput:
         graph_version: str,
         graph_invocation_id: str,
         timeout_sec: float,
+        output_payload_uri_prefix: Optional[str],
     ) -> "TaskOutput":
         """Creates a TaskOutput for an function timeout error."""
         # Task stdout, stderr is not available.
@@ -96,4 +101,5 @@ class TaskOutput:
             graph_invocation_id=graph_invocation_id,
             stderr=f"Function exceeded its configured timeout of {timeout_sec:.3f} sec.",
             is_internal_error=False,
+            output_payload_uri_prefix=output_payload_uri_prefix,
         )

--- a/indexify/src/indexify/executor/grpc/task_controller.py
+++ b/indexify/src/indexify/executor/grpc/task_controller.py
@@ -396,6 +396,11 @@ class TaskController:
             function_name=self._task.function_name,
             graph_version=self._task.graph_version,
             graph_invocation_id=self._task.graph_invocation_id,
+            output_payload_uri_prefix=(
+                self._task.output_payload_uri_prefix
+                if self._task.HasField("output_payload_uri_prefix")
+                else None
+            ),
         )
 
     def _function_timeout_output(self, timeout_sec: float) -> TaskOutput:
@@ -407,6 +412,11 @@ class TaskController:
             graph_version=self._task.graph_version,
             graph_invocation_id=self._task.graph_invocation_id,
             timeout_sec=timeout_sec,
+            output_payload_uri_prefix=(
+                self._task.output_payload_uri_prefix
+                if self._task.HasField("output_payload_uri_prefix")
+                else None
+            ),
         )
 
 
@@ -437,6 +447,11 @@ def _task_output_from_function_executor_response(
         reducer=response.is_reducer,
         success=response.success,
         metrics=metrics,
+        output_payload_uri_prefix=(
+            task.output_payload_uri_prefix
+            if task.HasField("output_payload_uri_prefix")
+            else None
+        ),
     )
 
     if response.HasField("function_output"):

--- a/indexify/src/indexify/executor/metrics/task_reporter.py
+++ b/indexify/src/indexify/executor/metrics/task_reporter.py
@@ -21,6 +21,23 @@ metric_server_ingest_files_latency: prometheus_client.Histogram = (
     )
 )
 
+metric_task_output_blob_store_uploads: prometheus_client.Counter = (
+    prometheus_client.Counter(
+        "task_output_blob_store_uploads", "Number of task output uploads to blob store"
+    )
+)
+metric_task_output_blob_store_upload_errors: prometheus_client.Counter = (
+    prometheus_client.Counter(
+        "task_output_blob_store_upload_errors",
+        "Number of failed task output uploads to blob store",
+    )
+)
+metric_task_output_blob_store_upload_latency: prometheus_client.Histogram = (
+    latency_metric_for_fast_operation(
+        "task_output_blob_store_upload", "Upload task output to blob store"
+    )
+)
+
 metric_report_task_outcome_rpcs = prometheus_client.Counter(
     "report_task_outcome_rpcs",
     "Number of report task outcome RPCs to Server",

--- a/indexify/src/indexify/executor/task_runner.py
+++ b/indexify/src/indexify/executor/task_runner.py
@@ -85,6 +85,7 @@ class TaskRunner:
                 function_name=task_input.task.compute_fn,
                 graph_version=task_input.task.graph_version,
                 graph_invocation_id=task_input.task.invocation_id,
+                output_payload_uri_prefix=task_input.task.output_payload_uri_prefix,
             )
         finally:
             if state is not None:

--- a/indexify/tests/executor/test_metrics.py
+++ b/indexify/tests/executor/test_metrics.py
@@ -195,11 +195,11 @@ class TestMetrics(unittest.TestCase):
             "task_outcome_report_latency_seconds_count",
             "task_outcome_report_latency_seconds_sum",
             "tasks_outcome_report_retries_total",
-            #
-            "server_ingest_files_requests_total",
-            "server_ingest_files_request_errors_total",
-            "server_ingest_files_request_latency_seconds_count",
-            "server_ingest_files_request_latency_seconds_sum",
+            # TODO: Add task output blob store upload metrics once we stop uploading to Server.
+            # "server_ingest_files_requests_total",
+            # "server_ingest_files_request_errors_total",
+            # "server_ingest_files_request_latency_seconds_count",
+            # "server_ingest_files_request_latency_seconds_sum",
             # Running a task
             "task_policy_runs_total",
             "task_policy_errors_total",
@@ -425,10 +425,10 @@ class TestMetrics(unittest.TestCase):
             SampleSpec("tasks_reporting_outcome", {}, 0.0),
             SampleSpec("task_outcome_report_latency_seconds_count", {}, 1.0),
             SampleSpec("tasks_outcome_report_retries_total", {}, 0.0),
-            #
-            SampleSpec("server_ingest_files_requests_total", {}, 1.0),
-            SampleSpec("server_ingest_files_request_errors_total", {}, 0.0),
-            SampleSpec("server_ingest_files_request_latency_seconds_count", {}, 1.0),
+            # # TODO: Add task output blob store upload metrics once we stop uploading to Server.
+            # SampleSpec("server_ingest_files_requests_total", {}, 1.0),
+            # SampleSpec("server_ingest_files_request_errors_total", {}, 0.0),
+            # SampleSpec("server_ingest_files_request_latency_seconds_count", {}, 1.0),
             # Running a task
             SampleSpec("task_policy_runs_total", {}, 1.0),
             SampleSpec("task_policy_errors_total", {}, 0.0),


### PR DESCRIPTION
In this PR we process data payloads sent by Server on HTTP (SSE task stream) path.
gRPC path is already doing that.

For both gRPC and HTTP paths we also upload task outputs to blob store if task output blob store URI prefix is supplied by Server.

Both gRPC and SSE task stream modes support direct blob store downloads and uploads now.

Tested these changes with and without Server supplied data payloads in S3 and local FS blob store modes. They changes are fully backward compatible.