### PR TITLE
Remove --executor-id Executor CLI argument

### DIFF
--- a/indexify/src/indexify/cli/cli.py
+++ b/indexify/src/indexify/cli/cli.py
@@ -102,9 +102,6 @@ def executor(
     executor_cache: Optional[str] = typer.Option(
         "~/.indexify/executor_cache", help="Path to the executor cache directory"
     ),
-    executor_id: Optional[str] = typer.Option(
-        None, help="ID of the executor, if not provided, a random ID will be generated"
-    ),
     # Registred ports range ends at 49151.
     ports: Tuple[int, int] = typer.Option(
         (50000, 51000),
@@ -153,18 +150,12 @@ def executor(
                 "At least one function must be specified when not running in development mode"
             )
 
-    if executor_id is None:
-        executor_id = nanoid.generate()
-    elif not re.compile(r"^[a-zA-Z0-9_-]{10,}$").match(executor_id):
-        raise typer.BadParameter(
-            "--executor-id should be at least 10 characters long and only include characters _-[0-9][a-z][A-Z]"
-        )
-
     kv_labels: Dict[str, str] = {}
     for label in labels:
         key, value = label.split("=")
         kv_labels[key] = value
 
+    executor_id: str = nanoid.generate()
     executor_version = version("indexify")
     logger = structlog.get_logger(module=__name__, executor_id=executor_id)
 

--- a/indexify/tests/cli/test_metrics.py
+++ b/indexify/tests/cli/test_metrics.py
@@ -45,7 +45,7 @@ class TestMetrics(unittest.TestCase):
         self.assertEqual(cli_info_sample.labels, {"package": "indexify"})
         self.assertEqual(cli_info_sample.value, 1.0)
 
-    def test_executor_id_argument_valid_characters(self):
+    def test_executor_info(self):
         with ExecutorProcessContextManager(
             [
                 "--dev",
@@ -54,8 +54,6 @@ class TestMetrics(unittest.TestCase):
                 "60001",
                 "--monitoring-server-port",
                 "7001",
-                "--executor-id",
-                "-test_executor_id",
             ]
         ) as executor_a:
             executor_a: subprocess.Popen
@@ -68,30 +66,6 @@ class TestMetrics(unittest.TestCase):
             self.assertEqual(len(info_metric.samples), 1)
             info_sample: Sample = info_metric.samples[0]
             self.assertIn("id", info_sample.labels)
-            self.assertEqual(info_sample.labels["id"], "-test_executor_id")
-
-    def test_executor_id_argument_invalid_character(self):
-        with ExecutorProcessContextManager(
-            [
-                "--dev",
-                "--ports",
-                "60001",
-                "60002",
-                "--monitoring-server-port",
-                "7002",
-                "--executor-id",
-                "@-test_executor_id",
-            ]
-        ) as executor_a:
-            executor_a: subprocess.Popen
-            print(f"Started Executor A with PID: {executor_a.pid}")
-            try:
-                wait_executor_startup(7002)
-                self.fail(
-                    "Executor should not have started with the invalid executor ID."
-                )
-            except Exception:
-                pass
 
     def test_expected_function_executor_infos(self):
         graph = Graph(


### PR DESCRIPTION
This argument is prone to operator errors like:
- Creating two Executors with the same ID.
- Changing function allows list between Executor restarts.

To remove this class of errors and not handle them in Server code we're removing the argument.