### PR TITLE
Don't import SDK enum that is going to get deleted

### DIFF
--- a/indexify/pyproject.toml
+++ b/indexify/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "indexify"
 # Incremented if any of the components provided in this packages are updated.
-version = "0.3.26"
+version = "0.3.27"
 description = "Open Source Indexify components and helper tools"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 license = "Apache 2.0"

--- a/indexify/src/indexify/executor/host_resources/nvidia_gpu.py
+++ b/indexify/src/indexify/executor/host_resources/nvidia_gpu.py
@@ -3,7 +3,6 @@ from enum import Enum
 from typing import Any, List
 
 from pydantic import BaseModel
-from tensorlake.functions_sdk.resources import GPU_MODEL
 
 
 # Only NVIDIA GPUs currently supported in Tensorlake SDK are listed here.


### PR DESCRIPTION
Don't import SDK enum that is going to get deleted