### PR TITLE
Accept list of function gpu configurations on Server

### DIFF
--- a/indexify/poetry.lock
+++ b/indexify/poetry.lock
@@ -1759,14 +1759,14 @@ typing = ["mypy (>=1.4)", "rich", "twisted"]
 
 [[package]]
 name = "tensorlake"
-version = "0.1.61"
+version = "0.1.65"
 description = "Tensorlake SDK for Document Ingestion API and Serverless Workflows"
 optional = false
 python-versions = "<4.0,>=3.9"
 groups = ["main"]
 files = [
-    {file = "tensorlake-0.1.61-py3-none-any.whl", hash = "sha256:b45762ae48535009a97c5fc817ed46d1f95ba0e660ee6da325483f8020c236d5"},
-    {file = "tensorlake-0.1.61.tar.gz", hash = "sha256:319828b53cf16a67a83c066bc3a2c321c8f4055bfe101badeca3b4851e7ed6a5"},
+    {file = "tensorlake-0.1.65-py3-none-any.whl", hash = "sha256:df511884101237921b99cde2bddc9c955c683966f9efe87013d73a8ecff2c2fd"},
+    {file = "tensorlake-0.1.65.tar.gz", hash = "sha256:9ce216c2699b19a365dbad6605e6ac4ce037fa95834725f15335e624609ad26a"},
 ]
 
 [package.dependencies]

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -1549,7 +1549,7 @@ dependencies = [
 
 [[package]]
 name = "indexify-server"
-version = "0.2.59"
+version = "0.2.60"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "indexify-server"
-version = "0.2.59"
+version = "0.2.60"
 edition = "2021"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 license = "Apache-2.0"

--- a/server/data_model/src/lib.rs
+++ b/server/data_model/src/lib.rs
@@ -257,7 +257,7 @@ impl Default for NodeTimeoutMS {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct NodeGPUs {
+pub struct NodeGPUConfig {
     pub count: u32,
     pub model: String,
 }
@@ -269,7 +269,8 @@ pub struct NodeResources {
     pub cpu_ms_per_sec: u32,
     pub memory_mb: u32,
     pub ephemeral_disk_mb: u32,
-    pub gpu: Option<NodeGPUs>,
+    // The list is ordered from most to least preferred GPU configuration.
+    pub gpu_configs: Vec<NodeGPUConfig>,
 }
 
 impl Default for NodeResources {
@@ -278,7 +279,7 @@ impl Default for NodeResources {
             cpu_ms_per_sec: 125,
             memory_mb: 128,
             ephemeral_disk_mb: 100 * 1024, // 100 GB
-            gpu: None,                     // No GPU by default
+            gpu_configs: vec![],           // No GPUs by default
         }
     }
 }


### PR DESCRIPTION
The list is ordered from higher priority to lower priority allowed GPU configurations for the function. This allows flexibility in placing functions on Executors which results in better economy and avialability.

Not keeping the existing GPU field as it's not being used yet in prod/dev.