### PR TITLE
Implement task output caching in Indexify

### DIFF
--- a/server/data_model/src/lib.rs
+++ b/server/data_model/src/lib.rs
@@ -1859,7 +1859,6 @@ pub struct InvokeComputeGraphEvent {
     pub invocation_id: String,
     pub namespace: String,
     pub compute_graph: String,
-    pub invocation_data_sha256_hash: String,
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]

--- a/server/processor/src/lib.rs
+++ b/server/processor/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod gc;
 pub mod graph_processor;
 pub mod task_allocator;
+pub mod task_cache;
 pub mod task_creator;

--- a/server/processor/src/task_cache.rs
+++ b/server/processor/src/task_cache.rs
@@ -1,0 +1,204 @@
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex, RwLock},
+};
+
+use data_model::{
+    CacheKey,
+    DataPayload,
+    NodeOutput,
+    OutputPayload,
+    Task,
+    TaskOutcome,
+    TaskOutputsIngestedEvent,
+    TaskOutputsIngestionStatus,
+    TaskStatus,
+};
+use state_store::{
+    in_memory_state::{InMemoryState, UnallocatedTaskId},
+    requests::{CachedTaskOutput, SchedulerUpdateRequest},
+    IndexifyState,
+};
+use tracing::{debug, span};
+
+pub struct CacheState {
+    indexify_state: Arc<IndexifyState>,
+    outputs_ingested: usize,
+    cache_checks: usize,
+    cache_hits: usize,
+    map: HashMap<String, HashMap<(CacheKey, String), Vec<NodeOutput>>>,
+}
+
+pub struct TaskCache {
+    mutex: Mutex<CacheState>,
+}
+
+fn task_input_hash(task: &Task, indexify_state: &IndexifyState) -> Option<String> {
+    if task.invocation_id == task.input_node_output_key.split("|").last().unwrap_or("") {
+        // This is an invocation task; we look up its input hash via the invocation
+        // payload.
+        indexify_state
+            .reader()
+            .invocation_payload(
+                &task.namespace,
+                &task.compute_graph_name,
+                &task.invocation_id,
+            )
+            .ok()
+            .map(|ip| ip.payload.sha256_hash)
+    } else {
+        // Otherwise, we look up the input hash via the task's input_node_output_key.
+        indexify_state
+            .reader()
+            .fn_output_payload_by_key(&task.input_node_output_key)
+            .ok()
+            .and_then(|no| match no.payload {
+                OutputPayload::Fn(DataPayload {
+                    sha256_hash: input_hash,
+                    ..
+                }) => Some(input_hash),
+                _ => None,
+            })
+    }
+}
+
+impl TaskCache {
+    pub fn new(indexify_state: Arc<IndexifyState>) -> Self {
+        Self {
+            mutex: Mutex::new(CacheState {
+                indexify_state,
+                outputs_ingested: 0,
+                cache_checks: 0,
+                cache_hits: 0,
+                map: HashMap::new(),
+            }),
+        }
+    }
+
+    pub fn handle_task_outputs(
+        &self,
+        event: &TaskOutputsIngestedEvent,
+        indexes: Arc<RwLock<InMemoryState>>,
+    ) {
+        let _span = span!(tracing::Level::DEBUG, "cache_write").entered();
+
+        let mut state = self.mutex.lock().unwrap();
+        state.outputs_ingested += 1;
+
+        let indexes = indexes.read().unwrap();
+
+        let Some(task) = indexes.tasks.get(&Task::key_from(
+            &event.namespace,
+            &event.compute_graph,
+            &event.invocation_id,
+            &event.compute_fn,
+            &event.task_id.to_string(),
+        )) else {
+            return;
+        };
+        let Some(cache_key) = &task.cache_key else {
+            return;
+        };
+
+        let Some(input_hash) = task_input_hash(&task, &mut state.indexify_state) else {
+            return;
+        };
+
+        let Ok(outputs) = state
+            .indexify_state
+            .reader()
+            .get_task_outputs(&task.namespace, &task.id.to_string())
+        else {
+            return;
+        };
+
+        let namespace = event.namespace.clone();
+
+        debug!("Caching the output of {namespace}/{cache_key:?}/{input_hash}");
+
+        for node_output in &outputs {
+            if let OutputPayload::Fn(DataPayload { sha256_hash, .. }) = &node_output.payload {
+                debug!(output_hash = sha256_hash);
+            }
+        }
+
+        state
+            .map
+            .entry(namespace)
+            .or_default()
+            .insert((cache_key.clone(), input_hash.clone()), outputs);
+    }
+
+    pub fn try_allocate(&self, indexes: Arc<RwLock<InMemoryState>>) -> SchedulerUpdateRequest {
+        let _span = span!(tracing::Level::DEBUG, "cache_check").entered();
+
+        let mut state = self.mutex.lock().unwrap();
+
+        let mut to_remove: Vec<UnallocatedTaskId> = Vec::new();
+        let mut result = SchedulerUpdateRequest::default();
+
+        let mut indexes = indexes.write().unwrap();
+
+        for task_id in &indexes.unallocated_tasks {
+            debug!(task = ?task_id);
+            state.cache_checks += 1;
+
+            let Some(task) = indexes.tasks.get(&task_id.task_key) else {
+                continue;
+            };
+
+            let Some(cache_key) = &task.cache_key else {
+                continue;
+            };
+
+            let Some(input_hash) = task_input_hash(&task, &mut state.indexify_state) else {
+                continue;
+            };
+
+            debug!(namespace = task.namespace);
+            debug!(task_key = ?cache_key);
+            debug!(input_hash = ?input_hash);
+
+            let Some(submap) = state.map.get(&task.namespace) else {
+                debug!("No cache namespace entry found");
+                continue;
+            };
+
+            let submap_key = (cache_key.clone(), input_hash);
+
+            let Some(outputs) = submap.get(&submap_key) else {
+                debug!("No cache entry found");
+                continue;
+            };
+
+            // TODO: We need to handle the case where the previous
+            // outputs have been deleted.  It's unclear that there's a
+            // great place to do that, though (at least, not without a
+            // race condition).  We should probably migrate towards
+            // holding our knowledge of the blobstore state as part of
+            // our state, allowing Indexify to manage it explicitly.
+
+            debug!("Cache entry found; ingesting previous outputs");
+            to_remove.push(task_id.clone());
+            let mut task = *(task.clone());
+            task.status = TaskStatus::Completed;
+            task.outcome = TaskOutcome::Success;
+            task.output_status = TaskOutputsIngestionStatus::Ingested;
+            result.cached_task_outputs.insert(
+                task.id.clone(),
+                CachedTaskOutput {
+                    task: task.clone(),
+                    node_outputs: outputs.clone(),
+                },
+            );
+            result.updated_tasks.insert(task.id.clone(), task);
+            state.cache_hits += 1;
+        }
+
+        for task_id in &to_remove {
+            indexes.unallocated_tasks.remove(task_id);
+        }
+
+        result
+    }
+}

--- a/server/processor/src/task_creator.rs
+++ b/server/processor/src/task_creator.rs
@@ -554,7 +554,6 @@ impl TaskCreator {
                         }
                         let prev_reducer_output = prev_reducer_outputs.first().unwrap();
 
-                        let output = outputs.first().unwrap();
                         let new_task = compute_node.create_task(
                             &task.namespace,
                             &task.compute_graph_name,

--- a/server/src/http_objects.rs
+++ b/server/src/http_objects.rs
@@ -366,6 +366,33 @@ fn default_encoder() -> String {
 }
 
 #[derive(Debug, Serialize, Deserialize, ToSchema, Clone)]
+pub struct CacheKey(String);
+
+impl CacheKey {
+    pub fn get(&self) -> &str {
+        &self.0
+    }
+}
+
+impl From<CacheKey> for data_model::CacheKey {
+    fn from(val: CacheKey) -> Self {
+        data_model::CacheKey::from(val.get())
+    }
+}
+
+impl From<&str> for CacheKey {
+    fn from(value: &str) -> Self {
+        Self(value.to_string())
+    }
+}
+
+impl From<data_model::CacheKey> for CacheKey {
+    fn from(val: data_model::CacheKey) -> Self {
+        CacheKey::from(val.get())
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema, Clone)]
 pub struct ComputeFn {
     pub name: String,
     pub fn_name: String,
@@ -384,6 +411,8 @@ pub struct ComputeFn {
     pub resources: NodeResources,
     #[serde(default)]
     pub retry_policy: NodeRetryPolicy,
+    #[serde(rename = "cache_key")]
+    pub cache_key: Option<CacheKey>,
 }
 
 impl From<ComputeFn> for data_model::ComputeFn {
@@ -401,6 +430,7 @@ impl From<ComputeFn> for data_model::ComputeFn {
             timeout: val.timeout.into(),
             resources: val.resources.into(),
             retry_policy: val.retry_policy.into(),
+            cache_key: val.cache_key.and_then(|v| Some(v.into())),
         }
     }
 }
@@ -419,6 +449,7 @@ impl From<data_model::ComputeFn> for ComputeFn {
             timeout: c.timeout.into(),
             resources: c.resources.into(),
             retry_policy: c.retry_policy.into(),
+            cache_key: c.cache_key.and_then(|v| Some(v.into())),
         }
     }
 }

--- a/server/src/routes.rs
+++ b/server/src/routes.rs
@@ -61,6 +61,7 @@ use crate::{
     executors::ExecutorManager,
     http_objects::{
         Allocation,
+        CacheKey,
         ComputeFn,
         ComputeGraph,
         ComputeGraphsList,
@@ -116,6 +117,7 @@ use crate::{
                 ComputeGraph,
                 Node,
                 DynamicRouter,
+		CacheKey,
                 ComputeFn,
                 ListParams,
                 ComputeGraphCreateType,

--- a/server/state_store/src/invocation_events.rs
+++ b/server/state_store/src/invocation_events.rs
@@ -10,6 +10,7 @@ pub enum InvocationStateChangeEvent {
     TaskCreated(TaskCreated),
     TaskAssigned(TaskAssigned),
     TaskCompleted(TaskCompleted),
+    TaskMatchedCache(TaskMatchedCache),
     InvocationFinished(InvocationFinishedEvent),
 }
 
@@ -37,6 +38,10 @@ impl InvocationStateChangeEvent {
             InvocationStateChangeEvent::TaskCompleted(TaskCompleted { invocation_id, .. }) => {
                 invocation_id.clone()
             }
+            InvocationStateChangeEvent::TaskMatchedCache(TaskMatchedCache {
+                invocation_id,
+                ..
+            }) => invocation_id.clone(),
         }
     }
 }
@@ -73,6 +78,13 @@ pub struct TaskCompleted {
     pub fn_name: String,
     pub task_id: String,
     pub outcome: TaskOutcome,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct TaskMatchedCache {
+    pub invocation_id: String,
+    pub fn_name: String,
+    pub task_id: String,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/server/state_store/src/lib.rs
+++ b/server/state_store/src/lib.rs
@@ -187,10 +187,12 @@ impl IndexifyState {
                 )?;
                 state_changes
             }
-            RequestPayload::SchedulerUpdate(request) => {
-                state_machine::handle_scheduler_update(self.db.clone(), &txn, request)?;
-                vec![]
-            }
+            RequestPayload::SchedulerUpdate(request) => state_machine::handle_scheduler_update(
+                self.db.clone(),
+                &txn,
+                request,
+                &self.last_state_change_id,
+            )?,
             RequestPayload::IngestTaskOutputs(task_outputs) => {
                 let ingested = state_machine::ingest_task_outputs(
                     self.db.clone(),
@@ -337,15 +339,27 @@ impl IndexifyState {
                 }
 
                 for (_, task) in &sched_update.updated_tasks {
-                    let _ = self
-                        .task_event_tx
-                        .send(InvocationStateChangeEvent::TaskCreated(
-                            invocation_events::TaskCreated {
-                                invocation_id: task.invocation_id.clone(),
-                                fn_name: task.compute_fn_name.clone(),
-                                task_id: task.id.to_string(),
-                            },
-                        ));
+                    if sched_update.cached_task_outputs.contains_key(&task.id) {
+                        let _ =
+                            self.task_event_tx
+                                .send(InvocationStateChangeEvent::TaskMatchedCache(
+                                    invocation_events::TaskMatchedCache {
+                                        invocation_id: task.invocation_id.clone(),
+                                        fn_name: task.compute_fn_name.clone(),
+                                        task_id: task.id.to_string(),
+                                    },
+                                ));
+                    } else {
+                        let _ = self
+                            .task_event_tx
+                            .send(InvocationStateChangeEvent::TaskCreated(
+                                invocation_events::TaskCreated {
+                                    invocation_id: task.invocation_id.clone(),
+                                    fn_name: task.compute_fn_name.clone(),
+                                    task_id: task.id.to_string(),
+                                },
+                            ));
+                    }
                 }
 
                 for invocation_ctx in &sched_update.updated_invocations_states {

--- a/server/state_store/src/requests.rs
+++ b/server/state_store/src/requests.rs
@@ -55,11 +55,18 @@ impl FunctionExecutorIdWithExecutionId {
     }
 }
 
+#[derive(Debug, Clone)]
+pub struct CachedTaskOutput {
+    pub task: Task,
+    pub node_outputs: Vec<NodeOutput>,
+}
+
 #[derive(Debug, Clone, Default)]
 pub struct SchedulerUpdateRequest {
     pub new_allocations: Vec<Allocation>,
     pub remove_allocations: Vec<Allocation>,
     pub updated_tasks: HashMap<TaskId, Task>,
+    pub cached_task_outputs: HashMap<TaskId, CachedTaskOutput>,
     pub updated_invocations_states: Vec<GraphInvocationCtx>,
     pub reduction_tasks: ReductionTasks,
     pub remove_executors: Vec<ExecutorId>,
@@ -74,6 +81,7 @@ impl SchedulerUpdateRequest {
         self.new_allocations.extend(other.new_allocations);
         self.remove_allocations.extend(other.remove_allocations);
         self.updated_tasks.extend(other.updated_tasks);
+        self.cached_task_outputs.extend(other.cached_task_outputs);
         self.updated_invocations_states
             .extend(other.updated_invocations_states);
 

--- a/server/state_store/src/state_changes.rs
+++ b/server/state_store/src/state_changes.rs
@@ -41,7 +41,6 @@ pub fn invoke_compute_graph(
             namespace: request.namespace.clone(),
             invocation_id: request.invocation_payload.id.clone(),
             compute_graph: request.compute_graph_name.clone(),
-            invocation_data_sha256_hash: request.invocation_payload.payload.sha256_hash.clone(),
         }))
         .created_at(get_epoch_time_in_ms())
         .object_id(request.invocation_payload.id.clone())

--- a/server/state_store/src/state_changes.rs
+++ b/server/state_store/src/state_changes.rs
@@ -41,6 +41,7 @@ pub fn invoke_compute_graph(
             namespace: request.namespace.clone(),
             invocation_id: request.invocation_payload.id.clone(),
             compute_graph: request.compute_graph_name.clone(),
+            invocation_data_sha256_hash: request.invocation_payload.payload.sha256_hash.clone(),
         }))
         .created_at(get_epoch_time_in_ms())
         .object_id(request.invocation_payload.id.clone())


### PR DESCRIPTION
## Context

The idea here is to cache function outputs and reuse them in subsequent function calls iff requested.

Fixes #1339 

## What

This PR allows the client to specify a caching key when specifying graph functions; this indicates to the server that it's allowed to cache the function applications.  A new TaskCache component observes output ingestion (creating cache entries), and intercepts tasks between creation and executor allocation; when it sees a cache hit, it skips the allocation, and augments the scheduler update with the cached task outputs; when the state machine observes the augmented scheduler update, it resolves the task as though it had just completed, generating output ingestion events to release downstream tasks.

## Testing

Currently, fairly basic: running a workload multiple times.  This PR needs further tests before it lands.

## Contribution Checklist

- [x] If a Python package was changed, please run `make fmt` in the package directory.
- [x] If the server was changed, please run `make fmt` in `server/`.
- [x] Make sure all PR Checks are passing.