### PR TITLE
Fix and extend CI test runner

### DIFF
--- a/indexify/tests/.gitignore
+++ b/indexify/tests/.gitignore
@@ -1,0 +1,1 @@
+.run_tests_summary.txt

--- a/indexify/tests/executor/test_metrics.py
+++ b/indexify/tests/executor/test_metrics.py
@@ -401,7 +401,7 @@ class TestMetrics(unittest.TestCase):
             SampleSpec("function_executors_with_status", {"status": "UNHEALTHY"}, 0.0),
             SampleSpec("function_executors_with_status", {"status": "DESTROYING"}, 0.0),
             SampleSpec("function_executors_with_status", {"status": "DESTROYED"}, 0.0),
-            SampleSpec("function_executors_with_status", {"status": "SHUTDOWN"}, 0.0),
+            # SampleSpec("function_executors_with_status", {"status": "SHUTDOWN"} is either 0 or 1 - depends if there was an FE for the graph before the test run or not.
             # Executor
             SampleSpec("executor_state", {"executor_state": "starting"}, 0.0),
             SampleSpec("executor_state", {"executor_state": "running"}, 0.0),

--- a/indexify/tests/run_tests.sh
+++ b/indexify/tests/run_tests.sh
@@ -7,28 +7,32 @@ if [[ -z "$INDEXIFY_URL" ]]; then
     exit 1
 fi
 
+tests_exit_code=0
+
 run_test_suite() {
   local test_files=$1
   local test_suite_name=$2
+  local test_suite_exit_code=0
 
-  # Run each test file one by one sequentially. Returns non zero status
-  # code if any of the test commands return non zero status code. Doesn't
+  # Run each test file one by one sequentially. Set $tests_exit_code to non zero
+  # value if any of the test commands return non zero status code. Don't
   # stop if a test command fails.
-  #
-  # Run the tests from Indexify pyenv so Executor and SDK client are in the same pyenv.
   for test_file in $test_files; do
     echo "Running $test_file for $test_suite_name test suite"
     poetry run python $test_file
-    test_suite_exit_code=$?
-    if [ $test_suite_exit_code -ne 0 ]; then
-      echo "One or more tests failed in $test_file for ${test_suite_name} test suite. Please check output log for details."
+    local test_file_exit_code=$?
+    if [ $test_file_exit_code -ne 0 ]; then
+      echo "One or more tests failed in $test_file for $test_suite_name test suite." | tee -a $summary_file
     fi
+    tests_exit_code=$((tests_exit_code || test_file_exit_code))
   done
-  return $test_suite_exit_code
 }
 
 # cd to the script's directory.
 cd "$(dirname "$0")"
+
+summary_file=".run_tests_summary.txt"
+rm -f $summary_file
 
 # Indexify tests.
 indexify_test_files=$(find . -name 'test_*.py')
@@ -36,14 +40,13 @@ indexify_test_files=$(find . -name 'test_*.py')
 tensorlake_sdk_test_files=$(find ../../tensorlake/tests/tensorlake -name 'test_*.py')
 
 run_test_suite "$indexify_test_files" "Indexify"
-tests_exit_code=$?
 run_test_suite "$tensorlake_sdk_test_files" "Tensorlake SDK"
-tests_exit_code=$((tests_exit_code || $?))
 
 if [ $tests_exit_code -eq 0 ]; then
-  echo "All tests passed!"
+  echo "All tests passed!" >> $summary_file
 else
-  echo "One or more tests failed. Please check output log for details."
+  echo "One or more tests failed. Please check output log for details." >> $summary_file
 fi
 
+cat $summary_file
 exit $tests_exit_code


### PR DESCRIPTION
Fix and extend CI test runner

Fix bug: now we again return non zero exit code if any test failed.

Now the summary of failed tests is outputted in the end of test output also each a notice is printed at each failed test in the log.

Example end of test log:

```
One or more tests failed in ./cli/test_server_task_distribution.py for Indexify test suite.
One or more tests failed in ./cli/test_function_allowlist.py for Indexify test suite.
One or more tests failed. Please check output log for details.
```