### PR TITLE
Bring back --enable-grpc-state-reconciler Executor CLI flag (False by default)

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -127,7 +127,7 @@ jobs:
         with:
           run: |
             cd indexify
-            poetry run indexify-cli executor --grpc-server-addr localhost:8901 --dev &
+            poetry run indexify-cli executor --grpc-server-addr localhost:8901 --dev --enable-grpc-state-reconciler &
             echo $! > /tmp/indexify-executor.pid &
 
           wait-on: |

--- a/indexify/src/indexify/cli/cli.py
+++ b/indexify/src/indexify/cli/cli.py
@@ -131,6 +131,16 @@ def executor(
             "Specified as <key>=<value>",
         ),
     ] = [],
+    enable_grpc_state_reconciler: Annotated[
+        bool,
+        typer.Option(
+            "--enable-grpc-state-reconciler",
+            help=(
+                "(exprimental) Enable gRPC state reconciler that will reconcile the state of the Function Executors and Task Allocations\n"
+                "with the desired state provided by Server. Required --grpc-server-addr to be set."
+            ),
+        ),
+    ] = False,
 ):
     if dev:
         compact_tracebacks: bool = os.getenv("INDEXIFY_COMPACT_TRACEBACKS", "1") == "1"
@@ -165,7 +175,7 @@ def executor(
         dev_mode=dev,
         monitoring_server_host=monitoring_server_host,
         monitoring_server_port=monitoring_server_port,
-        enable_grpc_state_reconciler=True,
+        enable_grpc_state_reconciler=enable_grpc_state_reconciler,
     )
 
     executor_cache = Path(executor_cache).expanduser().absolute()
@@ -225,7 +235,7 @@ def executor(
         config_path=config_path,
         monitoring_server_host=monitoring_server_host,
         monitoring_server_port=monitoring_server_port,
-        enable_grpc_state_reconciler=True,
+        enable_grpc_state_reconciler=enable_grpc_state_reconciler,
         blob_store=blob_store,
         host_resources_provider=host_resources_provider,
     ).run()

--- a/indexify/tests/cli/test_function_allowlist.py
+++ b/indexify/tests/cli/test_function_allowlist.py
@@ -196,6 +196,7 @@ class TestFunctionAllowlist(unittest.TestCase):
             for _ in range(total_invokes):
                 invocation_ids.append(graph.run(block_until_done=False))
 
+            print("Waiting for all invocations to finish...")
             for invocation_id in invocation_ids:
                 # Check outputs for each function
                 for func_name in [

--- a/indexify/tests/cli/test_server_task_distribution.py
+++ b/indexify/tests/cli/test_server_task_distribution.py
@@ -69,6 +69,7 @@ class TestServerTaskDistribution(unittest.TestCase):
                 invocation_id = graph.run(block_until_done=False, sleep_secs=0)
                 invocation_ids.append(invocation_id)
 
+            print("Waiting for all invocations to finish...")
             for invocation_id in invocation_ids:
                 output = wait_function_output(graph, invocation_id, "get_executor_pid")
                 self.assertEqual(len(output), 1)
@@ -124,6 +125,7 @@ class TestServerTaskDistribution(unittest.TestCase):
             print(f"Started Executor A with PID: {executor_a.pid}")
             wait_executor_startup(7001)
 
+            print("Waiting for all invocations to finish...")
             for invocation_id in invocation_ids:
                 output = wait_function_output(graph, invocation_id, "get_executor_pid")
                 self.assertEqual(len(output), 1)
@@ -178,6 +180,7 @@ class TestServerTaskDistribution(unittest.TestCase):
                 invocation_id = graph.run(block_until_done=False, sleep_secs=0.1)
                 invocation_ids.append(invocation_id)
 
+        print("Waiting for all invocations to finish...")
         for invocation_id in invocation_ids:
             output = wait_function_output(graph, invocation_id, "success_func")
             self.assertEqual(len(output), 1)

--- a/indexify/tests/cli/testing.py
+++ b/indexify/tests/cli/testing.py
@@ -43,6 +43,7 @@ class ExecutorProcessContextManager:
     ):
         self._args = ["indexify-cli", "executor"]
         self._args.extend(args)
+        self._args.extend(["--enable-grpc-state-reconciler"])
         self._with_dedicated_executor_cache = with_dedicated_executor_cache
         self._keep_std_outputs = keep_std_outputs
         self._extra_env = extra_env


### PR DESCRIPTION
By default this flag is False which means that we'll use SSE stream by default. We need to be able to use the legacy SSE stream mode to run with the stable published Server that doesn't use gRPC yet and still uses SSE stream mode.

--enable-grpc-state-reconciler was originally removed in https://github.com/tensorlakeai/indexify/pull/1362/files#diff-e207854b655720e9130572ef90eb931ffe8460c318ddd8f3c916a8756a29c066 we're bringing it back here.