### PR TITLE
Bump indexify package version to 0.3.29

### DIFF
--- a/indexify/pyproject.toml
+++ b/indexify/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "indexify"
 # Incremented if any of the components provided in this packages are updated.
-version = "0.3.28"
+version = "0.3.29"
 description = "Open Source Indexify components and helper tools"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 license = "Apache 2.0"


### PR DESCRIPTION
The deleted 0.3.28 version fails to release to PyPi so we can't use it to release the fix and we need to bump the version.