### PR TITLE
Bump Server package version in server-sse-stream-stable branch

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -1549,7 +1549,7 @@ dependencies = [
 
 [[package]]
 name = "indexify-server"
-version = "0.2.60"
+version = "0.2.61"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "indexify-server"
-version = "0.2.60"
+version = "0.2.61"
 edition = "2021"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 license = "Apache-2.0"


### PR DESCRIPTION
This is to release the Server from the branch to prod to get the GPU lists feature available in prod.