### PR TITLE
Start a new versioning cycle in Server package with dynamic scheduling

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -1520,7 +1520,7 @@ dependencies = [
 
 [[package]]
 name = "indexify-server"
-version = "0.2.60"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "indexify-server"
-version = "0.2.60"
+version = "0.3.1"
 edition = "2021"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 license = "Apache-2.0"


### PR DESCRIPTION
Setting the version to 0.3.1.
This is to distinguish the mainline Server where we work on dynamic scheduling from stable legacy Server package version with SSE stream support which uses 0.2.x versions.