### PR TITLE
Allow absent gpu_configs value in deserialized node resources

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -1549,7 +1549,7 @@ dependencies = [
 
 [[package]]
 name = "indexify-server"
-version = "0.2.61"
+version = "0.2.62"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "indexify-server"
-version = "0.2.61"
+version = "0.2.62"
 edition = "2021"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 license = "Apache-2.0"

--- a/server/data_model/src/lib.rs
+++ b/server/data_model/src/lib.rs
@@ -270,6 +270,8 @@ pub struct NodeResources {
     pub memory_mb: u32,
     pub ephemeral_disk_mb: u32,
     // The list is ordered from most to least preferred GPU configuration.
+    // Use serde default to support migration from gpu field to gpu_configs.
+    #[serde(default)]
     pub gpu_configs: Vec<NodeGPUConfig>,
 }
 


### PR DESCRIPTION
This fixes Server startup error:

```
{"timestamp":"2025-05-07T10:50:13.757318Z","level":"ERROR","message":"Error creating service: error deserializing from json bytes, missing field `gpu_configs` at line 1 column 1015, value: \"data_model::ComputeGraph\"\n\nStack backtrace:\n   0: anyhow::kind::Adhoc::new\n   1: state_store::scanner::StateReader::list_compute_graphs\n   2: state_store::in_memory_state::InMemoryState::new\n   3: indexify_server::service::Service::new::{{closure}}\n   4: indexify_server::main::{{closure}}\n   5: tokio::runtime::park::CachedParkThread::block_on\n   6: tokio::runtime::context::runtime::enter_runtime\n   7: indexify_server::main\n   8: std::sys::backtrace::__rust_begin_short_backtrace\n   9: std::rt::lang_start::{{closure}}\n  10: std::rt::lang_start_internal\n  11: main\n  12: <unknown>\n  13: __libc_start_main\n  14: _start","target":"indexify_server"}
```

This is because previously deployed graphs stored gpu info in `gpu` field of node resources. So previously stored node resources are coming without gpu_configs field so they are not deserializable if we don't set serde default on gpu_configs.

We're not deserializing the old gpu field because we only need to know node gpu spec when we start doing dynamic scheduling. Before this happens we'll re-deploy graphs and store their gpu_configs in state store.