### PR TITLE
feat: CLI target for Cloud OpenAPI spec generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,4 @@ sqlite*
 
 # Miscellaneous
 /executor-py/~
+openapi.yaml

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -1554,6 +1554,7 @@ dependencies = [
  "rocksdb",
  "serde",
  "serde_json",
+ "serde_yaml",
  "sha2",
  "state_store",
  "strum",
@@ -3892,6 +3893,7 @@ dependencies = [
  "indexmap 2.9.0",
  "serde",
  "serde_json",
+ "serde_yaml",
  "utoipa-gen",
 ]
 

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -38,12 +38,12 @@ rand = "0.9.1"
 tokio = { version = "1.44.2", features = ["full"] }
 once_cell = "1.21.3"
 itertools = "0.14.0"
-serde_yml = "0.0.12"
+serde_yaml = "0.9.34"
 figment = { version = "0.10.19", features = ["yaml"] }
 axum = { version = "0.8.3", features = ["multipart", "macros", "tokio"] }
 axum-server = "0.7.2"
 tempfile = "3.19.1"
-utoipa = { version = "5.3.1", features = ["axum_extras"] }
+utoipa = { version = "5.3.1", features = ["axum_extras", "yaml"] }
 utoipa-swagger-ui = { version = "9.0.1", features = ["axum"] }
 object_store = { version="0.12.0", features = ["aws"] }
 futures = "0.3.31"
@@ -103,6 +103,7 @@ processor = { path = "processor" }
 blob_store = { path = "blob_store" }
 serde = { workspace = true }
 serde_json = { workspace = true }
+serde_yaml = { workspace = true }
 anyhow = { workspace = true }
 figment = { workspace = true }
 clap = { workspace = true }

--- a/server/Makefile
+++ b/server/Makefile
@@ -73,3 +73,7 @@ install: build-release ## Build the application and install it to the system
 package-ui:
 	cd ui && npm install && npm run build
 
+generate-cloud-openapi:
+	@echo "Generating OpenAPI spec for cloud deployment..."
+	@cargo run -- --gen-public-openapi
+

--- a/server/src/openapi.rs
+++ b/server/src/openapi.rs
@@ -1,0 +1,107 @@
+use serde_yaml::{Mapping, Value};
+use std::fs;
+
+pub fn generate_cloud_openapi(api_docs_yaml: String) {
+    let openapi = api_docs_yaml.replace("/namespaces/{namespace}", "/workflows");
+
+    let mut yaml_value: Value = serde_yaml::from_str(&openapi).expect("Failed to parse YAML");
+    let root = yaml_value.as_mapping_mut().expect("Root is not a mapping");
+
+    let mut new_root = Mapping::new();
+
+    if let Some(v) = root.get(&Value::String("openapi".into())) {
+        new_root.insert(Value::String("openapi".into()), v.clone());
+    }
+
+    let servers = vec![{
+        let mut map = Mapping::new();
+        map.insert("url".into(), "https://api.tensorlake.ai/".into());
+        Value::Mapping(map)
+    }];
+    new_root.insert("servers".into(), Value::Sequence(servers));
+
+    let mut info_map = Mapping::new();
+    info_map.insert("title".into(), "Tensorlake API".into());
+    info_map.insert(
+        "description".into(),
+        "Tensorlake Cloud APIs for Document Ingestion and Serverless Workflows".into(),
+    );
+    if let Some(Value::Mapping(existing)) = root.get(&Value::String("info".into())) {
+        for (k, v) in existing {
+            if k.as_str() != Some("title") && k.as_str() != Some("description") {
+                info_map.insert(k.clone(), v.clone());
+            }
+        }
+    }
+    new_root.insert("info".into(), Value::Mapping(info_map));
+
+    let mut sec_map = Mapping::new();
+    sec_map.insert("bearerAuth".into(), Value::Sequence(vec![]));
+    new_root.insert(
+        "security".into(),
+        Value::Sequence(vec![Value::Mapping(sec_map)]),
+    );
+
+    for (k, v) in root.iter() {
+        match k.as_str() {
+            Some("openapi") | Some("info") | Some("components") | Some("paths") => {}
+            _ => {
+                new_root.insert(k.clone(), v.clone());
+            }
+        }
+    }
+
+    if let Some(Value::Mapping(orig_paths)) = root.get(&Value::String("paths".into())) {
+        let mut filtered = Mapping::new();
+        for (path_key, path_value) in orig_paths {
+            if let Some(s) = path_key.as_str() {
+                if s.starts_with("/internal") || s == "/namespaces" {
+                    // skip
+                    continue;
+                }
+            }
+            filtered.insert(path_key.clone(), path_value.clone());
+        }
+        new_root.insert("paths".into(), Value::Mapping(filtered));
+    }
+
+    let mut tags_map = Mapping::new();
+    tags_map.insert("name".into(), "Tensorlake Cloud API".into());
+    tags_map.insert(
+        "description".into(),
+        "Tensorlake Cloud APIs for Serverless Workflows".into(),
+    );
+    new_root.insert(
+        "tags".into(),
+        Value::Sequence(vec![Value::Mapping(tags_map)]),
+    );
+
+    let mut components_map =
+        if let Some(Value::Mapping(existing)) = root.get(&Value::String("components".into())) {
+            existing.clone()
+        } else {
+            Mapping::new()
+        };
+
+    let mut bearer = Mapping::new();
+    bearer.insert("type".into(), "http".into());
+    bearer.insert("scheme".into(), "bearer".into());
+    let mut sec_schemes = Mapping::new();
+    sec_schemes.insert("bearerAuth".into(), Value::Mapping(bearer));
+    components_map.insert("securitySchemes".into(), Value::Mapping(sec_schemes));
+
+    let mut unauth = Mapping::new();
+    unauth.insert(
+        "description".into(),
+        "Access token is missing or invalid".into(),
+    );
+    let mut responses = Mapping::new();
+    responses.insert("UnauthorizedError".into(), Value::Mapping(unauth));
+    components_map.insert("responses".into(), Value::Mapping(responses));
+
+    new_root.insert("components".into(), Value::Mapping(components_map));
+
+    let updated_yaml =
+        serde_yaml::to_string(&Value::Mapping(new_root)).expect("Failed to serialize YAML");
+    fs::write("./openapi.yaml", updated_yaml).unwrap();
+}

--- a/server/src/openapi.rs
+++ b/server/src/openapi.rs
@@ -1,5 +1,6 @@
-use serde_yaml::{Mapping, Value};
 use std::fs;
+
+use serde_yaml::{Mapping, Value};
 
 pub fn generate_cloud_openapi(api_docs_yaml: String) {
     let openapi = api_docs_yaml.replace("/namespaces/{namespace}", "/workflows");

--- a/server/src/routes.rs
+++ b/server/src/routes.rs
@@ -8,7 +8,8 @@ use axum::{
     middleware::{self, Next},
     response::{sse::Event, Html, IntoResponse},
     routing::{delete, get, post},
-    Json, Router,
+    Json,
+    Router,
 };
 use axum_tracing_opentelemetry::{
     self,
@@ -26,8 +27,12 @@ use prometheus::Encoder;
 use state_store::{
     kv::{ReadContextData, WriteContextData, KVS},
     requests::{
-        CreateOrUpdateComputeGraphRequest, DeleteComputeGraphRequest, DeleteInvocationRequest,
-        NamespaceRequest, RequestPayload, StateMachineUpdateRequest,
+        CreateOrUpdateComputeGraphRequest,
+        DeleteComputeGraphRequest,
+        DeleteInvocationRequest,
+        NamespaceRequest,
+        RequestPayload,
+        StateMachineUpdateRequest,
     },
     IndexifyState,
 };
@@ -43,7 +48,9 @@ mod internal_ingest;
 mod invoke;
 mod logs;
 use download::{
-    download_fn_output_by_key, download_fn_output_payload, download_invocation_payload,
+    download_fn_output_by_key,
+    download_fn_output_payload,
+    download_invocation_payload,
 };
 use internal_ingest::{ingest_files_from_executor, ingest_fn_outputs};
 use invoke::{invoke_with_file, invoke_with_object, wait_until_invocation_completed};
@@ -53,10 +60,29 @@ use crate::{
     config::ServerConfig,
     executors::ExecutorManager,
     http_objects::{
-        Allocation, CacheKey, ComputeFn, ComputeGraph, ComputeGraphsList, CreateNamespace,
-        CursorDirection, DynamicRouter, ExecutorMetadata, ExecutorsAllocationsResponse, FnOutputs,
-        GraphInvocations, GraphVersion, ImageInformation, IndexifyAPIError, ListParams, Namespace,
-        NamespaceList, Node, RuntimeInformation, Task, TaskOutcome, Tasks,
+        Allocation,
+        CacheKey,
+        ComputeFn,
+        ComputeGraph,
+        ComputeGraphsList,
+        CreateNamespace,
+        CursorDirection,
+        DynamicRouter,
+        ExecutorMetadata,
+        ExecutorsAllocationsResponse,
+        FnOutputs,
+        GraphInvocations,
+        GraphVersion,
+        ImageInformation,
+        IndexifyAPIError,
+        ListParams,
+        Namespace,
+        NamespaceList,
+        Node,
+        RuntimeInformation,
+        Task,
+        TaskOutcome,
+        Tasks,
     },
 };
 

--- a/server/src/routes.rs
+++ b/server/src/routes.rs
@@ -8,8 +8,7 @@ use axum::{
     middleware::{self, Next},
     response::{sse::Event, Html, IntoResponse},
     routing::{delete, get, post},
-    Json,
-    Router,
+    Json, Router,
 };
 use axum_tracing_opentelemetry::{
     self,
@@ -27,12 +26,8 @@ use prometheus::Encoder;
 use state_store::{
     kv::{ReadContextData, WriteContextData, KVS},
     requests::{
-        CreateOrUpdateComputeGraphRequest,
-        DeleteComputeGraphRequest,
-        DeleteInvocationRequest,
-        NamespaceRequest,
-        RequestPayload,
-        StateMachineUpdateRequest,
+        CreateOrUpdateComputeGraphRequest, DeleteComputeGraphRequest, DeleteInvocationRequest,
+        NamespaceRequest, RequestPayload, StateMachineUpdateRequest,
     },
     IndexifyState,
 };
@@ -48,9 +43,7 @@ mod internal_ingest;
 mod invoke;
 mod logs;
 use download::{
-    download_fn_output_by_key,
-    download_fn_output_payload,
-    download_invocation_payload,
+    download_fn_output_by_key, download_fn_output_payload, download_invocation_payload,
 };
 use internal_ingest::{ingest_files_from_executor, ingest_fn_outputs};
 use invoke::{invoke_with_file, invoke_with_object, wait_until_invocation_completed};
@@ -60,29 +53,10 @@ use crate::{
     config::ServerConfig,
     executors::ExecutorManager,
     http_objects::{
-        Allocation,
-        CacheKey,
-        ComputeFn,
-        ComputeGraph,
-        ComputeGraphsList,
-        CreateNamespace,
-        CursorDirection,
-        DynamicRouter,
-        ExecutorMetadata,
-        ExecutorsAllocationsResponse,
-        FnOutputs,
-        GraphInvocations,
-        GraphVersion,
-        ImageInformation,
-        IndexifyAPIError,
-        ListParams,
-        Namespace,
-        NamespaceList,
-        Node,
-        RuntimeInformation,
-        Task,
-        TaskOutcome,
-        Tasks,
+        Allocation, CacheKey, ComputeFn, ComputeGraph, ComputeGraphsList, CreateNamespace,
+        CursorDirection, DynamicRouter, ExecutorMetadata, ExecutorsAllocationsResponse, FnOutputs,
+        GraphInvocations, GraphVersion, ImageInformation, IndexifyAPIError, ListParams, Namespace,
+        NamespaceList, Node, RuntimeInformation, Task, TaskOutcome, Tasks,
     },
 };
 
@@ -141,7 +115,7 @@ use crate::{
         )
     )]
 
-struct ApiDoc;
+pub struct ApiDoc;
 
 #[derive(Clone)]
 pub struct RouteState {


### PR DESCRIPTION
## Context

For Tensorlake Cloud development, we require a different set of RESTful paths that comply with how the Tensorlake Ingress enriches requests.

This PR does not affect production, OSS, or other runtime execution.

## What

Adds a new CLI target to be used by the `cargo run` command. This CLI target generates an OpenAPI YAML with the following modifications:

1. `/internal` paths are removed. These are not available outside of other in-cluster services.
2. `/namespaces/{namespace}` gets renamed to `/workflows`, as the Tensorlake Ingress design dictates.
3. `/namespaces` path gets removed. These operations (create and list namespaces) are not public.
4. Add security schemes, descriptions, etc.

## Testing

1. Run locally with `cargo run -- --gen-public-openapi` or `make generate-cloud-openapi`

## Contribution Checklist

- [x] If the server was changed, please run `make fmt` in `server/`.
- [ ] Make sure all PR Checks are passing.
