### PR TITLE
Add missing support for A10 and A6000 GPU models

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -1549,7 +1549,7 @@ dependencies = [
 
 [[package]]
 name = "indexify-server"
-version = "0.2.62"
+version = "0.2.63"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "indexify-server"
-version = "0.2.62"
+version = "0.2.63"
 edition = "2021"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 license = "Apache-2.0"

--- a/server/data_model/src/lib.rs
+++ b/server/data_model/src/lib.rs
@@ -1330,11 +1330,15 @@ pub const GPU_MODEL_NVIDIA_H100_80GB: &str = "H100";
 pub const GPU_MODEL_NVIDIA_A100_40GB: &str = "A100-40GB";
 pub const GPU_MODEL_NVIDIA_A100_80GB: &str = "A100-80GB";
 pub const GPU_MODEL_NVIDIA_TESLA_T4: &str = "T4";
-pub const ALL_GPU_MODELS: [&str; 4] = [
+pub const GPU_MODEL_NVIDIA_A6000: &str = "A6000";
+pub const GPU_MODEL_NVIDIA_A10: &str = "A10";
+pub const ALL_GPU_MODELS: [&str; 6] = [
     GPU_MODEL_NVIDIA_H100_80GB,
     GPU_MODEL_NVIDIA_A100_40GB,
     GPU_MODEL_NVIDIA_A100_80GB,
     GPU_MODEL_NVIDIA_TESLA_T4,
+    GPU_MODEL_NVIDIA_A6000,
+    GPU_MODEL_NVIDIA_A10,
 ];
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/server/proto/executor_api.proto
+++ b/server/proto/executor_api.proto
@@ -33,6 +33,8 @@ enum GPUModel {
     GPU_MODEL_NVIDIA_A100_80GB = 2;
     GPU_MODEL_NVIDIA_H100_80GB = 3;
     GPU_MODEL_NVIDIA_TESLA_T4 = 4;
+    GPU_MODEL_NVIDIA_A6000 = 5;
+    GPU_MODEL_NVIDIA_A10 = 6;
 }
 
 // Free GPUs available at the Executor.

--- a/server/src/executor_api.rs
+++ b/server/src/executor_api.rs
@@ -101,6 +101,8 @@ impl TryFrom<executor_api_pb::GpuResources> for data_model::GpuResources {
             executor_api_pb::GpuModel::NvidiaA10080gb => Ok(data_model::GPU_MODEL_NVIDIA_A100_80GB),
             executor_api_pb::GpuModel::NvidiaH10080gb => Ok(data_model::GPU_MODEL_NVIDIA_H100_80GB),
             executor_api_pb::GpuModel::NvidiaTeslaT4 => Ok(data_model::GPU_MODEL_NVIDIA_TESLA_T4),
+            executor_api_pb::GpuModel::NvidiaA6000 => Ok(data_model::GPU_MODEL_NVIDIA_A6000),
+            executor_api_pb::GpuModel::NvidiaA10 => Ok(data_model::GPU_MODEL_NVIDIA_A10),
         }?;
         Ok(data_model::GpuResources {
             count: gpu_resources.count(),


### PR DESCRIPTION
These are used by Tensorlake.
This is a backport of the corresponding mainline commit for server-sse-stream-stable branch. Thus only Server changes are included here.