### PR TITLE
Miscelenious fixes and getting ready for Retries 

### DIFF
--- a/server/processor/src/task_allocator.rs
+++ b/server/processor/src/task_allocator.rs
@@ -130,9 +130,14 @@ impl<'a> TaskAllocationProcessor<'a> {
         let function_executors_to_mark = self
             .in_memory_state
             .vacuum_function_executors_candidates()?;
-        debug!(
-            "vacuum phase identified {} function executors to mark for termination",
-            function_executors_to_mark.len()
+        let function_executor_ids = function_executors_to_mark
+            .iter()
+            .map(|fe| fe.function_executor.id.get())
+            .collect::<Vec<_>>();
+        info!(
+            function_executors = function_executor_ids.join(", "),
+            num_function_executors = function_executors_to_mark.len(),
+            "vacuum phase identified function executors to mark for termination",
         );
 
         // Mark FEs for termination (change desired state to Terminated)

--- a/server/processor/src/task_allocator.rs
+++ b/server/processor/src/task_allocator.rs
@@ -172,6 +172,7 @@ impl<'a> TaskAllocationProcessor<'a> {
             self.in_memory_state.update_state(
                 self.clock,
                 &RequestPayload::SchedulerUpdate(Box::new(update.clone())),
+                "task_allocator",
             )?;
             candidates = self.in_memory_state.candidate_executors(task)?;
         }
@@ -187,7 +188,7 @@ impl<'a> TaskAllocationProcessor<'a> {
         let Some(candidate) = candidates.choose(&mut rand::rng()) else {
             return Ok(update);
         };
-        let executor_id = candidate.id.clone();
+        let executor_id = candidate.executor_id.clone();
         // Create a new function executor
         let function_executor = FunctionExecutorBuilder::default()
             .namespace(task.namespace.clone())
@@ -217,10 +218,11 @@ impl<'a> TaskAllocationProcessor<'a> {
         // Consume resources from executor
         update
             .updated_executor_resources
-            .insert(executor_id.clone(), candidate.host_resources.clone());
+            .insert(executor_id.clone(), candidate.free_resources.clone());
         self.in_memory_state.update_state(
             self.clock,
             &RequestPayload::SchedulerUpdate(Box::new(update.clone())),
+            "task_allocator",
         )?;
         Ok(update)
     }
@@ -245,6 +247,7 @@ impl<'a> TaskAllocationProcessor<'a> {
             self.in_memory_state.update_state(
                 self.clock,
                 &RequestPayload::SchedulerUpdate(Box::new(update.clone())),
+                "task_allocator",
             )?;
             function_executors = self
                 .in_memory_state
@@ -295,6 +298,7 @@ impl<'a> TaskAllocationProcessor<'a> {
         self.in_memory_state.update_state(
             self.clock,
             &RequestPayload::SchedulerUpdate(Box::new(update.clone())),
+            "task_allocator",
         )?;
         Ok(update)
     }
@@ -383,6 +387,7 @@ impl<'a> TaskAllocationProcessor<'a> {
             self.in_memory_state.update_state(
                 self.clock,
                 &RequestPayload::SchedulerUpdate(Box::new(update.clone())),
+                "task_allocator",
             )?;
         }
 
@@ -463,6 +468,7 @@ impl<'a> TaskAllocationProcessor<'a> {
         self.in_memory_state.update_state(
             self.clock,
             &RequestPayload::SchedulerUpdate(Box::new(update.clone())),
+            "task_allocator",
         )?;
 
         Ok(update)
@@ -604,6 +610,7 @@ impl<'a> TaskAllocationProcessor<'a> {
                 self.in_memory_state.update_state(
                     self.clock,
                     &RequestPayload::SchedulerUpdate(Box::new(update.clone())),
+                    "task_allocator",
                 )?;
             }
         }
@@ -636,6 +643,7 @@ impl<'a> TaskAllocationProcessor<'a> {
         self.in_memory_state.update_state(
             self.clock,
             &RequestPayload::SchedulerUpdate(Box::new(update.clone())),
+            "task_allocator",
         )?;
 
         let allocation_update = self.allocate()?;
@@ -643,6 +651,7 @@ impl<'a> TaskAllocationProcessor<'a> {
         self.in_memory_state.update_state(
             self.clock,
             &RequestPayload::SchedulerUpdate(Box::new(update.clone())),
+            "task_allocator",
         )?;
 
         return Ok(update);

--- a/server/processor/src/task_allocator.rs
+++ b/server/processor/src/task_allocator.rs
@@ -261,6 +261,9 @@ impl<'a> TaskAllocationProcessor<'a> {
             return Ok(update);
         };
         let fe_id = candidate.function_executor.id.clone();
+        let mut updated_task = task.clone();
+        updated_task.status = TaskStatus::Running;
+        updated_task.retry_number = task.retry_number + 1;
         let allocation = AllocationBuilder::default()
             .namespace(task.namespace.clone())
             .compute_graph(task.compute_graph_name.clone())
@@ -269,6 +272,7 @@ impl<'a> TaskAllocationProcessor<'a> {
             .task_id(task.id.clone())
             .executor_id(candidate.executor_id.clone())
             .function_executor_id(fe_id.clone())
+            .retry_number(updated_task.retry_number)
             .build()?;
 
         info!(
@@ -279,8 +283,6 @@ impl<'a> TaskAllocationProcessor<'a> {
             allocation = allocation.id,
             "created allocation"
         );
-        let mut updated_task = task.clone();
-        updated_task.status = TaskStatus::Running;
         update
             .updated_tasks
             .insert(updated_task.id.clone(), updated_task.clone());

--- a/server/processor/src/task_creator.rs
+++ b/server/processor/src/task_creator.rs
@@ -76,6 +76,7 @@ impl TaskCreator {
                 self.in_memory_state.write().unwrap().update_state(
                     self.clock,
                     &RequestPayload::SchedulerUpdate(Box::new(scheduler_update.clone())),
+                    "task_creator",
                 )?;
                 Ok(scheduler_update)
             }
@@ -101,6 +102,7 @@ impl TaskCreator {
                 self.in_memory_state.write().unwrap().update_state(
                     self.clock,
                     &RequestPayload::SchedulerUpdate(Box::new(scheduler_update.clone())),
+                    "task_creator",
                 )?;
                 Ok(scheduler_update)
             }

--- a/server/src/http_objects.rs
+++ b/server/src/http_objects.rs
@@ -1051,43 +1051,46 @@ pub struct ExecutorMetadata {
     pub labels: HashMap<String, serde_json::Value>,
     pub function_executors: Vec<FunctionExecutorMetadata>,
     pub host_resources: HostResources,
+    pub free_resources: HostResources,
     pub state: String,
     pub tombstoned: bool,
     pub state_hash: String,
     pub clock: u64,
 }
 
-impl From<data_model::ExecutorMetadata> for ExecutorMetadata {
-    fn from(executor: data_model::ExecutorMetadata) -> Self {
-        let function_allowlist = executor.function_allowlist.map(|allowlist| {
-            allowlist
-                .iter()
-                .map(|fn_uri| FunctionAllowlist {
-                    namespace: fn_uri.namespace.clone(),
-                    compute_graph: fn_uri.compute_graph_name.clone(),
-                    compute_fn: fn_uri.compute_fn_name.clone(),
-                    version: fn_uri.version.clone().map(|v| v.into()),
-                })
-                .collect()
-        });
-        Self {
-            id: executor.id.to_string(),
-            executor_version: executor.executor_version,
-            addr: executor.addr,
-            function_allowlist,
-            labels: executor.labels,
-            function_executors: executor
-                .function_executors
-                .values()
-                .cloned()
-                .map(|v| v.into())
-                .collect(),
-            host_resources: executor.host_resources.into(),
-            state: executor.state.as_ref().to_string(),
-            tombstoned: executor.tombstoned,
-            state_hash: executor.state_hash,
-            clock: executor.clock,
-        }
+pub fn from_data_model_executor_metadata(
+    executor: data_model::ExecutorMetadata,
+    free_resources: data_model::HostResources,
+) -> ExecutorMetadata {
+    let function_allowlist = executor.function_allowlist.map(|allowlist| {
+        allowlist
+            .iter()
+            .map(|fn_uri| FunctionAllowlist {
+                namespace: fn_uri.namespace.clone(),
+                compute_graph: fn_uri.compute_graph_name.clone(),
+                compute_fn: fn_uri.compute_fn_name.clone(),
+                version: fn_uri.version.clone().map(|v| v.into()),
+            })
+            .collect()
+    });
+    ExecutorMetadata {
+        id: executor.id.to_string(),
+        executor_version: executor.executor_version,
+        addr: executor.addr,
+        function_allowlist,
+        labels: executor.labels,
+        function_executors: executor
+            .function_executors
+            .values()
+            .cloned()
+            .map(|v| v.into())
+            .collect(),
+        host_resources: executor.host_resources.into(),
+        free_resources: free_resources.into(),
+        state: executor.state.as_ref().to_string(),
+        tombstoned: executor.tombstoned,
+        state_hash: executor.state_hash,
+        clock: executor.clock,
     }
 }
 

--- a/server/state_store/src/lib.rs
+++ b/server/state_store/src/lib.rs
@@ -289,7 +289,7 @@ impl IndexifyState {
             .in_memory_state
             .write()
             .await
-            .update_state(current_state_id, &request.payload)
+            .update_state(current_state_id, &request.payload, "state_store")
             .map_err(|e| anyhow!("error updating in memory state: {:?}", e))?;
         // Notify the executors with state changes
         {

--- a/server/state_store/src/state_machine.rs
+++ b/server/state_store/src/state_machine.rs
@@ -858,9 +858,7 @@ pub fn ingest_task_outputs(
             &req.namespace,
             &req.compute_graph,
             &req.invocation_id,
-            &req.compute_fn,
-            &req.task.id,
-            &req.executor_id,
+            &req.allocation_id,
         ),
     )?;
 


### PR DESCRIPTION
* Fixed a scheduler bug which was not sending the right desired state changes to the executor 
* Added a scheduler integration test which checks wether we are shutting down executors properly when we have to vacuum.
* Added the retry fields in Task and Allocator 
* Added some fields in the HTTP API to expose free resources, function executors in executors, etc for UI to consume. 