### PR TITLE
Configure gRPC HTTP2 keep-alive PINGs

### DIFF
--- a/indexify/src/indexify/executor/channel_manager.py
+++ b/indexify/src/indexify/executor/channel_manager.py
@@ -1,4 +1,5 @@
 import asyncio
+import os
 from typing import Any, Dict, Optional
 
 import grpc.aio
@@ -17,6 +18,7 @@ _CONNECT_TIMEOUT_SEC = 5
 class ChannelManager:
     def __init__(self, server_address: str, config_path: Optional[str], logger: Any):
         self._logger: Any = logger.bind(module=__name__, server_address=server_address)
+        self._keep_alive_period_sec: int = _keep_alive_period_sec_from_env(logger)
         self._server_address: str = server_address
         self._channel_credentials: Optional[grpc.ChannelCredentials] = None
         # This lock protects the fields below.
@@ -97,12 +99,18 @@ class ChannelManager:
 
         The channel is not be ready to use. Raises an exception on failure.
         """
+        channel_options: list[tuple[str, int]] = _channel_options(
+            self._keep_alive_period_sec
+        )
         if self._channel_credentials is None:
-            return grpc.aio.insecure_channel(target=self._server_address)
+            return grpc.aio.insecure_channel(
+                target=self._server_address, options=channel_options
+            )
         else:
             return grpc.aio.secure_channel(
                 target=self._server_address,
                 credentials=self._channel_credentials,
+                options=channel_options,
             )
 
     async def _create_ready_channel(self) -> grpc.aio.Channel:
@@ -165,3 +173,45 @@ class ChannelManager:
         except Exception as e:
             self._logger.error("failed closing channel", exc_info=e)
         self._channel = None
+
+
+def _channel_options(keep_alive_period_sec: int) -> list[tuple[str, int]]:
+    """Returns the gRPC channel options."""
+    # See https://grpc.io/docs/guides/keepalive/.
+    #
+    # NB: Rust Tonic framework that we're using in Server is not using gRPC core and doesn't support
+    # these options. From https://github.com/hyperium/tonic/issues/258 it supports gRPC PINGs when
+    # there are in-flight RPCs (and streams) without any extra configuration.
+    return [
+        ("grpc.keepalive_time_ms", keep_alive_period_sec * 1000),
+        (
+            "grpc.http2.max_pings_without_data",
+            -1,
+        ),  # Allow any number of empty PING messages
+        (
+            "grpc.keepalive_permit_without_calls",
+            0,
+        ),  # Don't send PINGs when there are no in-flight RPCs (and streams)
+    ]
+
+
+def _keep_alive_period_sec_from_env(logger: Any) -> int:
+    """Returns the keep alive period in seconds."""
+    # We have to use gRPC keep alive (PING) to prevent proxies/load-balancers from closing underlying HTTP/2
+    # (TCP) connections due to periods of idleness in gRPC streams that we use between Executor and Server.
+    # If a proxy/load-balancer closes the connection, then we see it as gRPC stream errors which results in
+    # a lot of error logs noise.
+    #
+    # The default period of 50 sec is used for one of the standard proxy/load-balancer timeouts of 1 minute.
+    DEFAULT_KEEP_ALIVE_PERIOD_SEC = "50"
+    keep_alive_period_sec = int(
+        os.getenv(
+            "INDEXIFY_EXECUTOR_GRPC_KEEP_ALIVE_PERIOD_SEC",
+            DEFAULT_KEEP_ALIVE_PERIOD_SEC,
+        )
+    )
+    if keep_alive_period_sec != int(DEFAULT_KEEP_ALIVE_PERIOD_SEC):
+        logger.info(
+            f"gRPC keep alive (PING) period is set to {keep_alive_period_sec} sec"
+        )
+    return keep_alive_period_sec


### PR DESCRIPTION
This is to workaround proxies that break the HTTP2/TCP connection when there's no message on desires state channel. This happens for us every minute wh