### PR TITLE
Verify that cache-hit task is present in task DB

### DIFF
--- a/server/processor/src/task_cache.rs
+++ b/server/processor/src/task_cache.rs
@@ -14,7 +14,7 @@ use data_model::{
 };
 use state_store::{
     in_memory_state::{InMemoryState, UnallocatedTaskId},
-    requests::{CachedOutput, SchedulerUpdateRequest},
+    requests::SchedulerUpdateRequest,
     IndexifyState,
 };
 use tracing::{debug, span};
@@ -140,16 +140,9 @@ impl TaskCache {
             task.status = TaskStatus::Completed;
             task.outcome = TaskOutcome::Success;
             task.output_status = TaskOutputsIngestionStatus::Ingested;
-            result.cached_task_outputs.insert(
-                task.id.clone(),
-                CachedOutput {
-                    node_output: outputs.clone(),
-                    namespace: task.namespace.clone(),
-                    compute_graph_name: task.compute_graph_name.clone(),
-                    invocation_id: task.invocation_id.clone(),
-                    compute_fn_name: task.compute_fn_name.clone(),
-                },
-            );
+            result
+                .cached_task_outputs
+                .insert(task.key(), outputs.clone());
             result.updated_tasks.insert(task.id.clone(), task);
             state.cache_hits += 1;
         }

--- a/server/state_store/src/lib.rs
+++ b/server/state_store/src/lib.rs
@@ -339,7 +339,7 @@ impl IndexifyState {
                 }
 
                 for (_, task) in &sched_update.updated_tasks {
-                    if sched_update.cached_task_outputs.contains_key(&task.id) {
+                    if sched_update.cached_task_outputs.contains_key(&task.key()) {
                         let _ =
                             self.task_event_tx
                                 .send(InvocationStateChangeEvent::TaskMatchedCache(

--- a/server/state_store/src/requests.rs
+++ b/server/state_store/src/requests.rs
@@ -40,21 +40,12 @@ pub enum RequestPayload {
     Noop,
 }
 
-#[derive(Debug, Clone)]
-pub struct CachedOutput {
-    pub node_output: NodeOutput,
-    pub namespace: String,
-    pub compute_graph_name: String,
-    pub invocation_id: String,
-    pub compute_fn_name: String,
-}
-
 #[derive(Debug, Clone, Default)]
 pub struct SchedulerUpdateRequest {
     pub new_allocations: Vec<Allocation>,
     pub remove_allocations: Vec<Allocation>,
     pub updated_tasks: HashMap<TaskId, Task>,
-    pub cached_task_outputs: HashMap<TaskId, CachedOutput>,
+    pub cached_task_outputs: HashMap<String, NodeOutput>, // Keyed by task.key()
     pub updated_invocations_states: Vec<GraphInvocationCtx>,
     pub reduction_tasks: ReductionTasks,
     pub remove_executors: Vec<ExecutorId>,

--- a/server/state_store/src/state_machine.rs
+++ b/server/state_store/src/state_machine.rs
@@ -713,33 +713,42 @@ pub(crate) fn handle_scheduler_update(
 
     let mut state_changes = vec![];
 
-    for (task_id, cached_output) in &request.cached_task_outputs {
-        let serialized_output = JsonEncoder::encode(&cached_output.node_output)?;
+    for (task_key, node_output) in &request.cached_task_outputs {
+        let serialized_output = JsonEncoder::encode(&node_output)?;
         // Create an output key
-        let output_key = cached_output.node_output.key();
+        let output_key = node_output.key();
         txn.put_cf(
             &IndexifyObjectsColumns::FnOutputs.cf_db(&db),
             &output_key,
             serialized_output,
         )?;
 
+        let task = txn.get_cf(&IndexifyObjectsColumns::Tasks.cf_db(&db), task_key)?;
+
+        let Some(task) = task else {
+            error!(task_key = task_key, "Task not found in tasks database");
+            continue;
+        };
+
+        let task = JsonEncoder::decode::<Task>(&task)?;
+
         let last_change_id = last_state_change_id.fetch_add(1, atomic::Ordering::Relaxed);
         let event = StateChangeBuilder::default()
-            .namespace(Some(cached_output.namespace.clone()))
-            .compute_graph(Some(cached_output.compute_graph_name.clone()))
-            .invocation(Some(cached_output.invocation_id.clone()))
+            .namespace(Some(task.namespace.clone()))
+            .compute_graph(Some(task.compute_graph_name.clone()))
+            .invocation(Some(task.invocation_id.clone()))
             .change_type(data_model::ChangeType::AllocationOutputsIngested(
                 AllocationOutputIngestedEvent {
-                    namespace: cached_output.namespace.clone(),
-                    compute_graph: cached_output.compute_graph_name.clone(),
-                    compute_fn: cached_output.compute_fn_name.clone(),
-                    invocation_id: cached_output.invocation_id.clone(),
-                    task_id: task_id.clone(),
+                    namespace: task.namespace.clone(),
+                    compute_graph: task.compute_graph_name.clone(),
+                    compute_fn: task.compute_fn_name.clone(),
+                    invocation_id: task.invocation_id.clone(),
+                    task_id: task.id.clone(),
                     node_output_key: output_key,
                 },
             ))
             .created_at(get_epoch_time_in_ms())
-            .object_id(task_id.clone().to_string())
+            .object_id(task.id.clone().to_string())
             .id(StateChangeId::new(last_change_id))
             .processed_at(None)
             .build()?;


### PR DESCRIPTION
## Context

It's ungood to issue an AllocationOutputsIngestedEvent for a task that doesn't exist.

## What

With this change, in the state machine logic, we load the task from the task db, and bail out (calling error!) if we can't find it.

## Testing

Ran caching tests to make sure the code path was exercised.

## Contribution Checklist

- [ ] If a Python package was changed, please run `make fmt` in the package directory.
- [X] If the server was changed, please run `make fmt` in `server/`.
- [ ] Make sure all PR Checks are passing.
