### PR TITLE
Increment Server and Executor versions and update tensorlake

### DIFF
--- a/indexify/poetry.lock
+++ b/indexify/poetry.lock
@@ -842,14 +842,14 @@ trio = ["trio (>=0.22.0,<1.0)"]
 
 [[package]]
 name = "httpx"
-version = "0.28.1"
+version = "0.27.2"
 description = "The next generation HTTP client."
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
 files = [
-    {file = "httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad"},
-    {file = "httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc"},
+    {file = "httpx-0.27.2-py3-none-any.whl", hash = "sha256:7bb2708e112d8fdd7829cd4243970f0c223274051cb35ee80c03301ee29a3df0"},
+    {file = "httpx-0.27.2.tar.gz", hash = "sha256:f7c2be1d2f3c3c3160d441802406b206c2b76f5947b11115e6df10c6c65e66c2"},
 ]
 
 [package.dependencies]
@@ -858,6 +858,7 @@ certifi = "*"
 h2 = {version = ">=3,<5", optional = true, markers = "extra == \"http2\""}
 httpcore = "==1.*"
 idna = "*"
+sniffio = "*"
 
 [package.extras]
 brotli = ["brotli", "brotlicffi"]
@@ -1359,14 +1360,14 @@ files = [
 
 [[package]]
 name = "pydantic"
-version = "2.11.5"
+version = "2.11.6"
 description = "Data validation using Python type hints"
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "pydantic-2.11.5-py3-none-any.whl", hash = "sha256:f9c26ba06f9747749ca1e5c94d6a85cb84254577553c8785576fd38fa64dc0f7"},
-    {file = "pydantic-2.11.5.tar.gz", hash = "sha256:7f853db3d0ce78ce8bbb148c401c2cdd6431b3473c0cdff2755c7690952a7b7a"},
+    {file = "pydantic-2.11.6-py3-none-any.whl", hash = "sha256:a24478d2be1b91b6d3bc9597439f69ed5e87f68ebd285d86f7c7932a084b72e7"},
+    {file = "pydantic-2.11.6.tar.gz", hash = "sha256:12b45cfb4af17e555d3c6283d0b55271865fb0b43cc16dd0d52749dc7abf70e7"},
 ]
 
 [package.dependencies]
@@ -1791,14 +1792,14 @@ typing-extensions = {version = "*", markers = "python_version < \"3.11\""}
 
 [[package]]
 name = "tensorlake"
-version = "0.1.85"
+version = "0.1.88"
 description = "Tensorlake SDK for Document Ingestion API and Serverless Workflows"
 optional = false
 python-versions = "<4.0,>=3.10"
 groups = ["main"]
 files = [
-    {file = "tensorlake-0.1.85-py3-none-any.whl", hash = "sha256:3dea51200a7a29a374f6aaf8bb2d30281d6e3eb0f80be0373104d2b0e70cc73f"},
-    {file = "tensorlake-0.1.85.tar.gz", hash = "sha256:0e21bb0cfea9378e95d6cf2d0d705704f05f27df09c197a702999594c1fe04b7"},
+    {file = "tensorlake-0.1.88-py3-none-any.whl", hash = "sha256:2bb8b6506a15d388b3963d7c2a01a9561e7f917bae45753a724e12fd4604852c"},
+    {file = "tensorlake-0.1.88.tar.gz", hash = "sha256:9e47f714ebf58af1e0ee4e1d80dc1c500d6cf07364b94ed8acfe5084be10b0a8"},
 ]
 
 [package.dependencies]
@@ -1808,10 +1809,10 @@ cloudpickle = ">=3.1.0,<4.0.0"
 docker = ">=7.1.0,<8.0.0"
 grpcio = "1.73.0"
 grpcio-tools = "1.73.0"
-httpx = {version = "0.28.1", extras = ["http2"]}
+httpx = {version = "0.27.2", extras = ["http2"]}
 httpx-sse = ">=0.4.0,<0.5.0"
 nanoid = ">=2.0.0,<3.0.0"
-pydantic = "2.11.5"
+pydantic = "2.11.6"
 python-magic = ">=0.4.27,<0.5.0"
 pyyaml = ">=6.0.2,<7.0.0"
 retry = ">=0.9.2,<0.10.0"
@@ -2064,4 +2065,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "42e815141dad22c195409d7e5b06112a0d2c5b9ce2789ca5bd183bf17a28ddc6"
+content-hash = "9572805ea5df8c8a0bf3b6f94fab8f05707884d76ce92caee516491addbc5dcc"

--- a/indexify/pyproject.toml
+++ b/indexify/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "indexify"
 # Incremented if any of the components provided in this packages are updated.
-version = "0.4.4"
+version = "0.4.5"
 description = "Open Source Indexify components and helper tools"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 license = "Apache 2.0"
@@ -25,7 +25,7 @@ prometheus-client = "^0.21.1"
 psutil = "^7.0.0"
 # Adds function-executor binary, utils lib, sdk used in indexify-cli commands.
 # We need to specify the tensorlake version exactly because pip install doesn't respect poetry.lock files.
-tensorlake = "0.1.85"
+tensorlake = "0.1.88"
 # Uncomment the next line to use local tensorlake package (only for development!)
 # tensorlake = { path = "../tensorlake", develop = true }
 # pydantic is provided by tensorlake

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -1521,7 +1521,7 @@ dependencies = [
 
 [[package]]
 name = "indexify-server"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "indexify-server"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2021"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 license = "Apache-2.0"


### PR DESCRIPTION
This is mainly to make the latest Server and Executor available in Tensorlake CI for PR https://github.com/tensorlakeai/tensorlake/pull/179.

The CI tests in Indexify will fail because they require the Tensorlake PR to pass.