### PR TITLE
Fix node resource consumption

### DIFF
--- a/server/data_model/src/host_resources_tests.rs
+++ b/server/data_model/src/host_resources_tests.rs
@@ -5,9 +5,9 @@ mod tests {
 
     use crate::{
         FunctionExecutorResources,
+        FunctionResources,
         GPUResources,
         HostResources,
-        NodeResources,
         GPU_MODEL_NVIDIA_A10,
         GPU_MODEL_NVIDIA_A100_40GB,
     };
@@ -17,7 +17,7 @@ mod tests {
         struct Case {
             description: &'static str,
             host_resources: HostResources,
-            node_resources: NodeResources,
+            node_resources: FunctionResources,
             expected_can_handle: bool,
         }
         let cases = vec![
@@ -29,7 +29,7 @@ mod tests {
                     disk_bytes: 2 * 1024 * 1024 * 1024,
                     gpu: None,
                 },
-                node_resources: NodeResources {
+                node_resources: FunctionResources {
                     cpu_ms_per_sec: 1000,
                     memory_mb: 1024,
                     ephemeral_disk_mb: 1024,
@@ -45,7 +45,7 @@ mod tests {
                     disk_bytes: 2 * 1024 * 1024 * 1024,
                     gpu: None,
                 },
-                node_resources: NodeResources {
+                node_resources: FunctionResources {
                     cpu_ms_per_sec: 2000,
                     memory_mb: 2 * 1024,
                     ephemeral_disk_mb: 2 * 1024,
@@ -61,7 +61,7 @@ mod tests {
                     disk_bytes: 2 * 1024 * 1024 * 1024,
                     gpu: None,
                 },
-                node_resources: NodeResources {
+                node_resources: FunctionResources {
                     cpu_ms_per_sec: 501,
                     memory_mb: 1024,
                     ephemeral_disk_mb: 1024,
@@ -77,7 +77,7 @@ mod tests {
                     disk_bytes: 2 * 1024 * 1024 * 1024,
                     gpu: None,
                 },
-                node_resources: NodeResources {
+                node_resources: FunctionResources {
                     cpu_ms_per_sec: 1000,
                     memory_mb: 1024,
                     ephemeral_disk_mb: 1024,
@@ -93,7 +93,7 @@ mod tests {
                     disk_bytes: 512 * 1024 * 1024,
                     gpu: None,
                 },
-                node_resources: NodeResources {
+                node_resources: FunctionResources {
                     cpu_ms_per_sec: 1000,
                     memory_mb: 1024,
                     ephemeral_disk_mb: 1024,
@@ -112,7 +112,7 @@ mod tests {
                         model: GPU_MODEL_NVIDIA_A10.to_string(),
                     }),
                 },
-                node_resources: NodeResources {
+                node_resources: FunctionResources {
                     cpu_ms_per_sec: 1000,
                     memory_mb: 1024,
                     ephemeral_disk_mb: 1024,
@@ -137,7 +137,7 @@ mod tests {
                         model: GPU_MODEL_NVIDIA_A10.to_string(),
                     }),
                 },
-                node_resources: NodeResources {
+                node_resources: FunctionResources {
                     cpu_ms_per_sec: 2000,
                     memory_mb: 2 * 1024,
                     ephemeral_disk_mb: 2 * 1024,
@@ -163,7 +163,7 @@ mod tests {
                         model: GPU_MODEL_NVIDIA_A10.to_string(),
                     }),
                 },
-                node_resources: NodeResources {
+                node_resources: FunctionResources {
                     cpu_ms_per_sec: 2000,
                     memory_mb: 2 * 1024,
                     ephemeral_disk_mb: 2 * 1024,
@@ -182,7 +182,7 @@ mod tests {
                         model: GPU_MODEL_NVIDIA_A100_40GB.to_string(),
                     }),
                 },
-                node_resources: NodeResources {
+                node_resources: FunctionResources {
                     cpu_ms_per_sec: 1000,
                     memory_mb: 1024,
                     ephemeral_disk_mb: 1024,
@@ -204,7 +204,7 @@ mod tests {
                         model: GPU_MODEL_NVIDIA_A100_40GB.to_string(),
                     }),
                 },
-                node_resources: NodeResources {
+                node_resources: FunctionResources {
                     cpu_ms_per_sec: 1000,
                     memory_mb: 1024,
                     ephemeral_disk_mb: 1024,
@@ -232,7 +232,7 @@ mod tests {
         struct Case {
             description: &'static str,
             host_resources: HostResources,
-            node_resources: NodeResources,
+            node_resources: FunctionResources,
             expected_fe_resources: Option<FunctionExecutorResources>, // None means error expected
             expected_host_resources_after: Option<HostResources>,     /* None means no change
                                                                        * expected */
@@ -247,7 +247,7 @@ mod tests {
                     disk_bytes: 2 * 1024 * 1024 * 1024,
                     gpu: None,
                 },
-                node_resources: NodeResources {
+                node_resources: FunctionResources {
                     cpu_ms_per_sec: 1000,
                     memory_mb: 1024,
                     ephemeral_disk_mb: 1024,
@@ -274,7 +274,7 @@ mod tests {
                     disk_bytes: 2 * 1024 * 1024 * 1024,
                     gpu: None,
                 },
-                node_resources: NodeResources {
+                node_resources: FunctionResources {
                     cpu_ms_per_sec: 2000,
                     memory_mb: 2 * 1024,
                     ephemeral_disk_mb: 2 * 1024,
@@ -301,7 +301,7 @@ mod tests {
                     disk_bytes: 2 * 1024 * 1024 * 1024,
                     gpu: None,
                 },
-                node_resources: NodeResources {
+                node_resources: FunctionResources {
                     cpu_ms_per_sec: 501,
                     memory_mb: 1024,
                     ephemeral_disk_mb: 1024,
@@ -318,7 +318,7 @@ mod tests {
                     disk_bytes: 2 * 1024 * 1024 * 1024,
                     gpu: None,
                 },
-                node_resources: NodeResources {
+                node_resources: FunctionResources {
                     cpu_ms_per_sec: 1000,
                     memory_mb: 1024,
                     ephemeral_disk_mb: 1024,
@@ -335,7 +335,7 @@ mod tests {
                     disk_bytes: 512 * 1024 * 1024,
                     gpu: None,
                 },
-                node_resources: NodeResources {
+                node_resources: FunctionResources {
                     cpu_ms_per_sec: 1000,
                     memory_mb: 1024,
                     ephemeral_disk_mb: 1024,
@@ -355,7 +355,7 @@ mod tests {
                         model: GPU_MODEL_NVIDIA_A10.to_string(),
                     }),
                 },
-                node_resources: NodeResources {
+                node_resources: FunctionResources {
                     cpu_ms_per_sec: 1000,
                     memory_mb: 1024,
                     ephemeral_disk_mb: 1024,
@@ -397,7 +397,7 @@ mod tests {
                         model: GPU_MODEL_NVIDIA_A10.to_string(),
                     }),
                 },
-                node_resources: NodeResources {
+                node_resources: FunctionResources {
                     cpu_ms_per_sec: 2000,
                     memory_mb: 2 * 1024,
                     ephemeral_disk_mb: 2 * 1024,
@@ -440,7 +440,7 @@ mod tests {
                         model: GPU_MODEL_NVIDIA_A10.to_string(),
                     }),
                 },
-                node_resources: NodeResources {
+                node_resources: FunctionResources {
                     cpu_ms_per_sec: 2000,
                     memory_mb: 2 * 1024,
                     ephemeral_disk_mb: 2 * 1024,
@@ -473,7 +473,7 @@ mod tests {
                         model: GPU_MODEL_NVIDIA_A100_40GB.to_string(),
                     }),
                 },
-                node_resources: NodeResources {
+                node_resources: FunctionResources {
                     cpu_ms_per_sec: 1000,
                     memory_mb: 1024,
                     ephemeral_disk_mb: 1024,
@@ -496,7 +496,7 @@ mod tests {
                         model: GPU_MODEL_NVIDIA_A100_40GB.to_string(),
                     }),
                 },
-                node_resources: NodeResources {
+                node_resources: FunctionResources {
                     cpu_ms_per_sec: 1000,
                     memory_mb: 1024,
                     ephemeral_disk_mb: 1024,

--- a/server/src/executor_api.rs
+++ b/server/src/executor_api.rs
@@ -187,8 +187,8 @@ impl From<FunctionExecutorStatus> for data_model::FunctionExecutorState {
     }
 }
 
-impl From<data_model::NodeRetryPolicy> for executor_api_pb::TaskRetryPolicy {
-    fn from(from: data_model::NodeRetryPolicy) -> Self {
+impl From<data_model::FunctionRetryPolicy> for executor_api_pb::TaskRetryPolicy {
+    fn from(from: data_model::FunctionRetryPolicy) -> Self {
         executor_api_pb::TaskRetryPolicy {
             max_retries: Some(from.max_retries),
             initial_delay_ms: Some(from.initial_delay_ms),

--- a/server/src/http_objects.rs
+++ b/server/src/http_objects.rs
@@ -262,9 +262,9 @@ impl NodeResources {
     }
 }
 
-impl From<NodeResources> for data_model::NodeResources {
+impl From<NodeResources> for data_model::FunctionResources {
     fn from(value: NodeResources) -> Self {
-        data_model::NodeResources {
+        data_model::FunctionResources {
             cpu_ms_per_sec: (value.cpus * 1000.0).ceil() as u32,
             memory_mb: value.memory_mb,
             ephemeral_disk_mb: value.ephemeral_disk_mb,
@@ -280,8 +280,8 @@ impl From<NodeResources> for data_model::NodeResources {
     }
 }
 
-impl From<data_model::NodeResources> for NodeResources {
-    fn from(value: data_model::NodeResources) -> NodeResources {
+impl From<data_model::FunctionResources> for NodeResources {
+    fn from(value: data_model::FunctionResources) -> NodeResources {
         NodeResources {
             cpus: value.cpu_ms_per_sec as f64 / 1000.0,
             memory_mb: value.memory_mb,
@@ -300,7 +300,7 @@ impl From<data_model::NodeResources> for NodeResources {
 
 impl Default for NodeResources {
     fn default() -> Self {
-        data_model::NodeResources::default().into()
+        data_model::FunctionResources::default().into()
     }
 }
 
@@ -340,9 +340,9 @@ impl NodeRetryPolicy {
     }
 }
 
-impl From<NodeRetryPolicy> for data_model::NodeRetryPolicy {
+impl From<NodeRetryPolicy> for data_model::FunctionRetryPolicy {
     fn from(value: NodeRetryPolicy) -> Self {
-        data_model::NodeRetryPolicy {
+        data_model::FunctionRetryPolicy {
             max_retries: value.max_retries,
             initial_delay_ms: (value.initial_delay_sec * 1000.0).ceil() as u32,
             max_delay_ms: (value.max_delay_sec * 1000.0).ceil() as u32,
@@ -351,8 +351,8 @@ impl From<NodeRetryPolicy> for data_model::NodeRetryPolicy {
     }
 }
 
-impl From<data_model::NodeRetryPolicy> for NodeRetryPolicy {
-    fn from(value: data_model::NodeRetryPolicy) -> Self {
+impl From<data_model::FunctionRetryPolicy> for NodeRetryPolicy {
+    fn from(value: data_model::FunctionRetryPolicy) -> Self {
         NodeRetryPolicy {
             max_retries: value.max_retries,
             initial_delay_sec: value.initial_delay_ms as f64 / 1000.0,
@@ -364,7 +364,7 @@ impl From<data_model::NodeRetryPolicy> for NodeRetryPolicy {
 
 impl Default for NodeRetryPolicy {
     fn default() -> Self {
-        data_model::NodeRetryPolicy::default().into()
+        data_model::FunctionRetryPolicy::default().into()
     }
 }
 

--- a/server/state_store/src/in_memory_state.rs
+++ b/server/state_store/src/in_memory_state.rs
@@ -18,11 +18,11 @@ use data_model::{
     FunctionExecutorResources,
     FunctionExecutorServerMetadata,
     FunctionExecutorState,
+    FunctionResources,
+    FunctionRetryPolicy,
     FunctionURI,
     GraphInvocationCtx,
     GraphVersion,
-    NodeResources,
-    NodeRetryPolicy,
     ReduceTask,
     Task,
     TaskStatus,
@@ -47,7 +47,7 @@ pub struct DesiredStateTask {
     pub task: Box<Task>,
     pub allocation_id: String,
     pub timeout_ms: u32,
-    pub retry_policy: NodeRetryPolicy,
+    pub retry_policy: FunctionRetryPolicy,
 }
 
 pub struct DesiredStateFunctionExecutor {
@@ -1085,7 +1085,7 @@ impl InMemoryState {
         cg: &str,
         fn_name: &str,
         version: &GraphVersion,
-    ) -> Option<NodeResources> {
+    ) -> Option<FunctionResources> {
         let cg_version = self
             .compute_graph_versions
             .get(&ComputeGraphVersion::key_from(ns, cg, version))
@@ -1096,7 +1096,7 @@ impl InMemoryState {
             .map(|node| node.resources.clone())
     }
 
-    pub fn get_fe_resources(&self, fe: &FunctionExecutor) -> Option<NodeResources> {
+    pub fn get_fe_resources(&self, fe: &FunctionExecutor) -> Option<FunctionResources> {
         let cg_version = self
             .compute_graph_versions
             .get(&ComputeGraphVersion::key_from(


### PR DESCRIPTION
Renamed NodeResources to FunctionResources to make it clear these are requested resources of functions. 

The logic to consume GPUs was consuming CPUs and memory multiple times in case the requested resources was a list of different GPUs and the Node only had a GPU model. 