### PR TITLE
Decrement metric_function_executors_with_status on FE shutdown

### DIFF
--- a/indexify/src/indexify/executor/function_executor_controller/function_executor_controller.py
+++ b/indexify/src/indexify/executor/function_executor_controller/function_executor_controller.py
@@ -712,6 +712,9 @@ class FunctionExecutorController:
                     logger=self._logger,
                 )
             )
+        metric_function_executors_with_status.labels(
+            status=_to_fe_status_metric_label(self._status, self._logger)
+        ).dec()
 
         self._state_reporter.remove_function_executor_info(self.function_executor_id())
         self._state_reporter.schedule_state_report()


### PR DESCRIPTION
We inc/dec the metric value when FE status changes but never decremented it when FE get fully destroyed. Because of this metric_function_executors_with_status=Terminated became a counter instead of a gauge. Fix that.