### PR TITLE
feat: add compute_fn_name in FunctionExecutorsContent

### DIFF
--- a/server/ui/src/components/cards/FunctionExecutorsContent.tsx
+++ b/server/ui/src/components/cards/FunctionExecutorsContent.tsx
@@ -23,6 +23,10 @@ export function FunctionExecutorsContent({
             <strong>Compute Graph:</strong>{' '}
             {functionExecutor.compute_graph_name}
           </p>
+          <p>
+            <strong>Compute Function Name:</strong>{' '}
+            {functionExecutor.compute_fn_name}
+          </p>
         </TableCell>
         <TableCell
           sx={{ verticalAlign: 'top', fontSize: '0.90rem', width: '50%' }}


### PR DESCRIPTION
## Context

The compute function name is missing in the Function Executor metadata content.

## What

<img width="897" alt="Screenshot 2025-06-23 at 3 23 25 PM" src="https://github.com/user-attachments/assets/4f2d7712-bb8b-4f5f-a7e5-3e16ade30519" />

Added the `compute_fn_name` property.

## Testing

Tested by rendering the UI.
