### PR TITLE
Don't count platform issues against task attempts

### DIFF
--- a/server/data_model/src/lib.rs
+++ b/server/data_model/src/lib.rs
@@ -1104,6 +1104,15 @@ impl TaskFailureReason {
                 TaskFailureReason::FunctionExecutorTerminated
         )
     }
+
+    pub fn should_count_against_task_retry_attempts(&self) -> bool {
+        // Platform/infrastructure failures shouldn't count against retry attempts
+        // since they're not legitimate task execution failures
+        matches!(
+            self,
+            TaskFailureReason::FunctionError | TaskFailureReason::FunctionTimeout
+        )
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]

--- a/server/processor/src/task_creator.rs
+++ b/server/processor/src/task_creator.rs
@@ -205,7 +205,12 @@ impl TaskCreator {
                 allocation.failure_reason.is_retriable()
             {
                 task.status = TaskStatus::Pending;
-                task.attempt_number += 1;
+                if allocation
+                    .failure_reason
+                    .should_count_against_task_retry_attempts()
+                {
+                    task.attempt_number += 1;
+                }
                 scheduler_update.updated_tasks = HashMap::from([(task.id.clone(), *task.clone())]);
                 return Ok(scheduler_update);
             }


### PR DESCRIPTION
## Context

Tasks may be cancelled by the system for reasons outside the task's control; these shouldn't count against the task's retry attempts.

Fixes #1509

## What

Add a function to determine whether a `TaskFailureReason` should count against task retry attempts, and use it.

## Testing

No good tests for this yet -- we think we may have seen this come up when the desired state stream is disrupted, but if so it's tricky to reproduce.

## Contribution Checklist

- [ ] If a Python package was changed, please run `make fmt` in the package directory.
- [X] If the server was changed, please run `make fmt` in `server/`.
- [x] Make sure all PR Checks are passing.