### PR TITLE
Refactor integration tests & add task outcome tests

### DIFF
--- a/server/data_model/src/lib.rs
+++ b/server/data_model/src/lib.rs
@@ -765,8 +765,8 @@ impl Default for GraphInvocationOutcome {
     }
 }
 
-impl From<&TaskOutcome> for GraphInvocationOutcome {
-    fn from(outcome: &TaskOutcome) -> Self {
+impl From<TaskOutcome> for GraphInvocationOutcome {
+    fn from(outcome: TaskOutcome) -> Self {
         match outcome {
             TaskOutcome::Success => GraphInvocationOutcome::Success,
             TaskOutcome::Failure(failure_reason) => {
@@ -824,8 +824,8 @@ impl Default for GraphInvocationFailureReason {
     }
 }
 
-impl From<&TaskFailureReason> for GraphInvocationFailureReason {
-    fn from(failure_reason: &TaskFailureReason) -> Self {
+impl From<TaskFailureReason> for GraphInvocationFailureReason {
+    fn from(failure_reason: TaskFailureReason) -> Self {
         match failure_reason {
             TaskFailureReason::Unknown => GraphInvocationFailureReason::Unknown,
             TaskFailureReason::InternalError => GraphInvocationFailureReason::InternalError,
@@ -1042,7 +1042,7 @@ impl ReduceTask {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
 pub enum TaskOutcome {
     Unknown,
     Success,
@@ -1069,7 +1069,7 @@ impl Display for TaskOutcome {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
 pub enum TaskFailureReason {
     Unknown,
     // Internal error on Executor aka platform error.

--- a/server/data_model/src/lib.rs
+++ b/server/data_model/src/lib.rs
@@ -44,6 +44,12 @@ impl ExecutorId {
     }
 }
 
+impl From<&str> for ExecutorId {
+    fn from(value: &str) -> Self {
+        Self::new(value.to_string())
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct TaskId(String);
 

--- a/server/data_model/src/test_objects.rs
+++ b/server/data_model/src/test_objects.rs
@@ -299,7 +299,7 @@ pub mod tests {
     }
 
     pub fn mock_executor_id() -> ExecutorId {
-        ExecutorId::new(TEST_EXECUTOR_ID.to_string())
+        TEST_EXECUTOR_ID.into()
     }
 
     pub fn mock_executor(id: ExecutorId) -> ExecutorMetadata {

--- a/server/data_model/src/test_objects.rs
+++ b/server/data_model/src/test_objects.rs
@@ -298,10 +298,6 @@ pub mod tests {
         }
     }
 
-    pub fn mock_executor_id() -> ExecutorId {
-        TEST_EXECUTOR_ID.into()
-    }
-
     pub fn mock_executor(id: ExecutorId) -> ExecutorMetadata {
         ExecutorMetadata {
             id,

--- a/server/data_model/src/test_objects.rs
+++ b/server/data_model/src/test_objects.rs
@@ -61,14 +61,14 @@ pub mod tests {
         compute_fn
     }
 
-    pub fn mock_node_fn_output_fn_a(
+    pub fn test_node_fn_output_fn_a(
         invocation_id: &str,
         graph: &str,
         reducer_fn: Option<String>,
         num_outputs: usize,
         allocation_id: String,
     ) -> NodeOutput {
-        mock_node_fn_output(
+        test_node_fn_output(
             invocation_id,
             graph,
             "fn_a",
@@ -79,7 +79,7 @@ pub mod tests {
         )
     }
 
-    pub fn mock_node_fn_output(
+    pub fn test_node_fn_output(
         invocation_id: &str,
         graph: &str,
         compute_fn_name: &str,
@@ -117,7 +117,7 @@ pub mod tests {
             .unwrap()
     }
 
-    pub fn mock_invocation_payload() -> InvocationPayload {
+    pub fn test_invocation_payload_graph_a() -> InvocationPayload {
         InvocationPayloadBuilder::default()
             .namespace(TEST_NAMESPACE.to_string())
             .compute_graph_name("graph_A".to_string())
@@ -131,7 +131,7 @@ pub mod tests {
             .unwrap()
     }
 
-    pub fn mock_invocation_ctx(
+    pub fn test_invocation_ctx(
         namespace: &str,
         compute_graph: &ComputeGraph,
         invocation_payload: &InvocationPayload,
@@ -147,7 +147,7 @@ pub mod tests {
             .unwrap()
     }
 
-    pub fn mock_invocation_payload_graph_b() -> InvocationPayload {
+    pub fn test_invocation_payload_graph_b() -> InvocationPayload {
         InvocationPayloadBuilder::default()
             .namespace(TEST_NAMESPACE.to_string())
             .compute_graph_name("graph_B".to_string())
@@ -162,7 +162,7 @@ pub mod tests {
             .unwrap()
     }
 
-    pub fn mock_graph_a(image_hash: String) -> ComputeGraph {
+    pub fn test_graph_a(image_hash: String) -> ComputeGraph {
         let fn_a = test_compute_fn("fn_a", image_hash.clone());
         let fn_b = test_compute_fn("fn_b", image_hash.clone());
         let fn_c = test_compute_fn("fn_c", image_hash.clone());
@@ -202,7 +202,7 @@ pub mod tests {
         }
     }
 
-    pub fn mock_graph_b() -> ComputeGraph {
+    pub fn test_graph_b() -> ComputeGraph {
         let fn_a = test_compute_fn("fn_a", "image_hash".to_string());
         let router_x = ComputeFn {
             name: "router_x".to_string(),
@@ -259,7 +259,7 @@ pub mod tests {
         }
     }
 
-    pub fn mock_graph_with_reducer() -> ComputeGraph {
+    pub fn test_graph_with_reducer() -> ComputeGraph {
         let fn_a = test_compute_fn("fn_a", "image_hash".to_string());
         let fn_b = reducer_fn("fn_b");
         let fn_c = test_compute_fn("fn_c", "image_hash".to_string());
@@ -298,7 +298,7 @@ pub mod tests {
         }
     }
 
-    pub fn mock_executor(id: ExecutorId) -> ExecutorMetadata {
+    pub fn test_executor_metadata(id: ExecutorId) -> ExecutorMetadata {
         ExecutorMetadata {
             id,
             executor_version: "1.0.0".to_string(),

--- a/server/data_model/src/test_objects.rs
+++ b/server/data_model/src/test_objects.rs
@@ -8,6 +8,7 @@ pub mod tests {
         DataPayload,
         ExecutorId,
         ExecutorMetadata,
+        FunctionRetryPolicy,
         GraphInvocationCtx,
         GraphInvocationCtxBuilder,
         GraphVersion,
@@ -22,6 +23,7 @@ pub mod tests {
     pub const TEST_NAMESPACE: &str = "test_ns";
     pub const TEST_EXECUTOR_ID: &str = "test_executor_1";
     pub const TEST_EXECUTOR_IMAGE_NAME: &str = "test_image_name";
+    pub const TEST_FN_MAX_RETRIES: u32 = 3;
 
     pub fn create_mock_task(
         cg: &ComputeGraph,
@@ -51,6 +53,10 @@ pub mod tests {
             description: format!("description {}", name),
             fn_name: name.to_string(),
             image_information,
+            retry_policy: FunctionRetryPolicy {
+                max_retries: TEST_FN_MAX_RETRIES,
+                ..Default::default()
+            },
             ..Default::default()
         }
     }

--- a/server/processor/src/function_executor_manager.rs
+++ b/server/processor/src/function_executor_manager.rs
@@ -325,7 +325,7 @@ impl FunctionExecutorManager {
                     if task.status == TaskStatus::Completed {
                         let mut invocation_ctx = invocation_ctx.clone();
                         invocation_ctx.completed = true;
-                        invocation_ctx.outcome = (&task.outcome).into();
+                        invocation_ctx.outcome = task.outcome.into();
                         update.updated_invocations_states.push(*invocation_ctx);
                     }
                 }

--- a/server/processor/src/task_creator.rs
+++ b/server/processor/src/task_creator.rs
@@ -358,7 +358,7 @@ impl TaskCreator {
             .reader()
             .get_node_output_by_key(&node_output_key)?;
 
-        if let TaskOutcome::Failure(failure_reason) = &task.outcome {
+        if let TaskOutcome::Failure(failure_reason) = task.outcome {
             trace!("task failed, stopping scheduling of child tasks");
             if let Some(node_output) = &node_output {
                 if let Some(invocation_error_payload) = node_output.invocation_error_payload.clone()

--- a/server/src/gc_test.rs
+++ b/server/src/gc_test.rs
@@ -5,7 +5,7 @@ mod tests {
     use anyhow::Result;
     use bytes::Bytes;
     use data_model::{
-        test_objects::tests::{mock_graph_a, TEST_NAMESPACE},
+        test_objects::tests::{test_graph_a, TEST_NAMESPACE},
         GraphInvocationCtx,
         InvocationPayload,
         NodeOutput,
@@ -37,7 +37,7 @@ mod tests {
 
         // Create a compute graph
         let compute_graph = {
-            let mut compute_graph = mock_graph_a("image_hash".to_string()).clone();
+            let mut compute_graph = test_graph_a("image_hash".to_string()).clone();
             let data = "code";
             let path = format!("{}", &compute_graph.code.path);
 

--- a/server/src/integration_test.rs
+++ b/server/src/integration_test.rs
@@ -4,7 +4,7 @@ mod tests {
 
     use anyhow::Result;
     use data_model::{
-        test_objects::tests::{mock_executor, TEST_EXECUTOR_ID, TEST_NAMESPACE},
+        test_objects::tests::{test_executor_metadata, TEST_EXECUTOR_ID, TEST_NAMESPACE},
         Task,
         TaskFailureReason,
         TaskOutcome,
@@ -99,7 +99,7 @@ mod tests {
         // register executor
         let executor = {
             let executor = test_srv
-                .create_executor(mock_executor(TEST_EXECUTOR_ID.into()))
+                .create_executor(test_executor_metadata(TEST_EXECUTOR_ID.into()))
                 .await?;
 
             test_srv.process_all_state_changes().await?;
@@ -239,7 +239,7 @@ mod tests {
         // register executor
         {
             let executor = test_srv
-                .create_executor(mock_executor(TEST_EXECUTOR_ID.into()))
+                .create_executor(test_executor_metadata(TEST_EXECUTOR_ID.into()))
                 .await?;
 
             test_srv.process_all_state_changes().await?;
@@ -338,7 +338,7 @@ mod tests {
         // register executor
         let executor = {
             let executor = test_srv
-                .create_executor(mock_executor(TEST_EXECUTOR_ID.into()))
+                .create_executor(test_executor_metadata(TEST_EXECUTOR_ID.into()))
                 .await?;
 
             test_srv.process_all_state_changes().await?;
@@ -491,7 +491,7 @@ mod tests {
         // register executor
         let executor = {
             let executor = test_srv
-                .create_executor(mock_executor(TEST_EXECUTOR_ID.into()))
+                .create_executor(test_executor_metadata(TEST_EXECUTOR_ID.into()))
                 .await?;
 
             test_srv.process_all_state_changes().await?;
@@ -576,7 +576,7 @@ mod tests {
         // register executor1, task assigned to it
         let executor1 = {
             let executor1 = test_srv
-                .create_executor(mock_executor("executor_1".into()))
+                .create_executor(test_executor_metadata("executor_1".into()))
                 .await?;
 
             test_srv.process_all_state_changes().await?;
@@ -604,7 +604,7 @@ mod tests {
         // register executor2, no tasks assigned to it
         let executor2 = {
             let executor2 = test_srv
-                .create_executor(mock_executor("executor_2".into()))
+                .create_executor(test_executor_metadata("executor_2".into()))
                 .await?;
 
             test_srv.process_all_state_changes().await?;

--- a/server/src/integration_test.rs
+++ b/server/src/integration_test.rs
@@ -4,7 +4,7 @@ mod tests {
 
     use anyhow::Result;
     use data_model::{
-        test_objects::tests::{mock_executor, mock_executor_id, TEST_NAMESPACE},
+        test_objects::tests::{mock_executor, TEST_EXECUTOR_ID, TEST_NAMESPACE},
         Task,
         TaskFailureReason,
         TaskOutcome,
@@ -99,7 +99,7 @@ mod tests {
         // register executor
         let executor = {
             let executor = test_srv
-                .create_executor(mock_executor(mock_executor_id()))
+                .create_executor(mock_executor(TEST_EXECUTOR_ID.into()))
                 .await?;
 
             test_srv.process_all_state_changes().await?;
@@ -239,7 +239,7 @@ mod tests {
         // register executor
         {
             let executor = test_srv
-                .create_executor(mock_executor(mock_executor_id()))
+                .create_executor(mock_executor(TEST_EXECUTOR_ID.into()))
                 .await?;
 
             test_srv.process_all_state_changes().await?;
@@ -338,7 +338,7 @@ mod tests {
         // register executor
         let executor = {
             let executor = test_srv
-                .create_executor(mock_executor(mock_executor_id()))
+                .create_executor(mock_executor(TEST_EXECUTOR_ID.into()))
                 .await?;
 
             test_srv.process_all_state_changes().await?;
@@ -491,7 +491,7 @@ mod tests {
         // register executor
         let executor = {
             let executor = test_srv
-                .create_executor(mock_executor(mock_executor_id()))
+                .create_executor(mock_executor(TEST_EXECUTOR_ID.into()))
                 .await?;
 
             test_srv.process_all_state_changes().await?;

--- a/server/src/integration_test.rs
+++ b/server/src/integration_test.rs
@@ -5,7 +5,6 @@ mod tests {
     use anyhow::Result;
     use data_model::{
         test_objects::tests::{mock_executor, mock_executor_id, TEST_NAMESPACE},
-        ExecutorId,
         Task,
         TaskFailureReason,
         TaskOutcome,
@@ -577,7 +576,7 @@ mod tests {
         // register executor1, task assigned to it
         let executor1 = {
             let executor1 = test_srv
-                .create_executor(mock_executor(ExecutorId::new("executor_1".to_string())))
+                .create_executor(mock_executor("executor_1".into()))
                 .await?;
 
             test_srv.process_all_state_changes().await?;
@@ -605,7 +604,7 @@ mod tests {
         // register executor2, no tasks assigned to it
         let executor2 = {
             let executor2 = test_srv
-                .create_executor(mock_executor(ExecutorId::new("executor_2".to_string())))
+                .create_executor(mock_executor("executor_2".into()))
                 .await?;
 
             test_srv.process_all_state_changes().await?;

--- a/server/src/reconciliation_test.rs
+++ b/server/src/reconciliation_test.rs
@@ -2,8 +2,7 @@
 mod tests {
     use anyhow::Result;
     use data_model::{
-        test_objects::tests::{mock_executor, mock_executor_id, TEST_NAMESPACE},
-        ExecutorId,
+        test_objects::tests::{mock_executor, TEST_EXECUTOR_ID, TEST_NAMESPACE},
         FunctionAllowlist,
         FunctionExecutorState,
         GraphVersion,
@@ -42,7 +41,7 @@ mod tests {
 
         // Register executor in dev mode - task should be allocated
         let executor = test_srv
-            .create_executor(mock_executor(mock_executor_id()))
+            .create_executor(mock_executor(TEST_EXECUTOR_ID.into()))
             .await?;
         test_srv.process_all_state_changes().await?;
 
@@ -105,7 +104,7 @@ mod tests {
             .await?;
 
         // Register executor with non-dev mode and specific allowlist
-        let mut executor_meta = mock_executor(mock_executor_id());
+        let mut executor_meta = mock_executor(TEST_EXECUTOR_ID.into());
         executor_meta.function_allowlist = Some(vec![FunctionAllowlist {
             namespace: Some(TEST_NAMESPACE.to_string()),
             compute_graph_name: Some("graph_A".to_string()),
@@ -175,7 +174,7 @@ mod tests {
         test_srv.process_all_state_changes().await?;
 
         // Register first executor with no allowlist
-        let mut executor1_meta = mock_executor(ExecutorId::new("executor_1".to_string()));
+        let mut executor1_meta = mock_executor("executor_1".into());
         executor1_meta.function_allowlist = None;
 
         let executor1 = test_srv.create_executor(executor1_meta).await?;
@@ -193,7 +192,7 @@ mod tests {
 
         // Register second executor
         let executor2 = test_srv
-            .create_executor(mock_executor(ExecutorId::new("executor_2".to_string())))
+            .create_executor(mock_executor("executor_2".into()))
             .await?;
         test_srv.process_all_state_changes().await?;
 
@@ -260,7 +259,7 @@ mod tests {
 
         // Register executor in dev mode
         let executor = test_srv
-            .create_executor(mock_executor(mock_executor_id()))
+            .create_executor(mock_executor(TEST_EXECUTOR_ID.into()))
             .await?;
         test_srv.process_all_state_changes().await?;
 

--- a/server/src/reconciliation_test.rs
+++ b/server/src/reconciliation_test.rs
@@ -2,7 +2,7 @@
 mod tests {
     use anyhow::Result;
     use data_model::{
-        test_objects::tests::{mock_executor, TEST_EXECUTOR_ID, TEST_NAMESPACE},
+        test_objects::tests::{test_executor_metadata, TEST_EXECUTOR_ID, TEST_NAMESPACE},
         FunctionAllowlist,
         FunctionExecutorState,
         GraphVersion,
@@ -41,7 +41,7 @@ mod tests {
 
         // Register executor in dev mode - task should be allocated
         let executor = test_srv
-            .create_executor(mock_executor(TEST_EXECUTOR_ID.into()))
+            .create_executor(test_executor_metadata(TEST_EXECUTOR_ID.into()))
             .await?;
         test_srv.process_all_state_changes().await?;
 
@@ -104,7 +104,7 @@ mod tests {
             .await?;
 
         // Register executor with non-dev mode and specific allowlist
-        let mut executor_meta = mock_executor(TEST_EXECUTOR_ID.into());
+        let mut executor_meta = test_executor_metadata(TEST_EXECUTOR_ID.into());
         executor_meta.function_allowlist = Some(vec![FunctionAllowlist {
             namespace: Some(TEST_NAMESPACE.to_string()),
             compute_graph_name: Some("graph_A".to_string()),
@@ -174,7 +174,7 @@ mod tests {
         test_srv.process_all_state_changes().await?;
 
         // Register first executor with no allowlist
-        let mut executor1_meta = mock_executor("executor_1".into());
+        let mut executor1_meta = test_executor_metadata("executor_1".into());
         executor1_meta.function_allowlist = None;
 
         let executor1 = test_srv.create_executor(executor1_meta).await?;
@@ -192,7 +192,7 @@ mod tests {
 
         // Register second executor
         let executor2 = test_srv
-            .create_executor(mock_executor("executor_2".into()))
+            .create_executor(test_executor_metadata("executor_2".into()))
             .await?;
         test_srv.process_all_state_changes().await?;
 
@@ -259,7 +259,7 @@ mod tests {
 
         // Register executor in dev mode
         let executor = test_srv
-            .create_executor(mock_executor(TEST_EXECUTOR_ID.into()))
+            .create_executor(test_executor_metadata(TEST_EXECUTOR_ID.into()))
             .await?;
         test_srv.process_all_state_changes().await?;
 

--- a/server/src/testing.rs
+++ b/server/src/testing.rs
@@ -150,6 +150,19 @@ impl TestService {
         Ok(e)
     }
 
+    pub fn tasks(&self) -> Result<Vec<Task>> {
+        let tasks = self
+            .service
+            .indexify_state
+            .reader()
+            .get_all_rows_from_cf::<Task>(IndexifyObjectsColumns::Tasks)?
+            .iter()
+            .map(|r| r.1.clone())
+            .collect::<Vec<_>>();
+
+        Ok(tasks)
+    }
+
     pub async fn assert_task_states(&self, assertions: TaskStateAssertions) -> Result<()> {
         let tasks = self
             .service

--- a/server/src/testing.rs
+++ b/server/src/testing.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use anyhow::Result;
 use blob_store::BlobStorageConfig;
 use data_model::{
-    test_objects::tests::mock_node_fn_output,
+    test_objects::tests::test_node_fn_output,
     Allocation,
     DataPayload,
     ExecutorId,
@@ -460,7 +460,7 @@ impl TestExecutor<'_> {
                 ),
             )?
             .unwrap();
-        let node_output = mock_node_fn_output(
+        let node_output = test_node_fn_output(
             task_allocation.task.as_ref().unwrap().graph_invocation_id(),
             task_allocation.task.as_ref().unwrap().graph_name(),
             task_allocation.task.as_ref().unwrap().function_name(),

--- a/server/state_store/src/lib.rs
+++ b/server/state_store/src/lib.rs
@@ -400,10 +400,10 @@ impl IndexifyState {
 mod tests {
     use data_model::{
         test_objects::tests::{
-            mock_executor,
-            mock_executor_id,
-            mock_graph_a,
-            mock_invocation_payload,
+            test_executor_metadata,
+            test_graph_a,
+            test_invocation_payload_graph_a,
+            TEST_EXECUTOR_ID,
             TEST_NAMESPACE,
         },
         ComputeGraph,
@@ -467,7 +467,7 @@ mod tests {
         let indexify_state = TestStateStore::new().await?.indexify_state;
 
         // Create a compute graph and write it
-        let compute_graph = mock_graph_a("Old Hash".to_string());
+        let compute_graph = test_graph_a("Old Hash".to_string());
         _write_to_test_state_store(&indexify_state, compute_graph).await?;
 
         // Read the compute graph
@@ -484,7 +484,7 @@ mod tests {
         for i in 2..4 {
             // Update the graph
             let new_hash = format!("this is a new hash {}", i);
-            let mut compute_graph = mock_graph_a(new_hash.clone());
+            let mut compute_graph = test_graph_a(new_hash.clone());
             compute_graph.version = GraphVersion(i.to_string());
 
             _write_to_test_state_store(&indexify_state, compute_graph).await?;
@@ -514,13 +514,13 @@ mod tests {
             .compute_graph_name("cg1".to_string())
             .invocation_id("foo1".to_string())
             .graph_version(GraphVersion("1".to_string()))
-            .build(tests::mock_graph_a("image_hash".to_string()))?;
+            .build(tests::test_graph_a("image_hash".to_string()))?;
         let state_change_1 = state_changes::invoke_compute_graph(
             &indexify_state.last_state_change_id,
             &InvokeComputeGraphRequest {
                 namespace: "namespace".to_string(),
                 compute_graph_name: "graph_A".to_string(),
-                invocation_payload: mock_invocation_payload(),
+                invocation_payload: test_invocation_payload_graph_a(),
                 ctx: ctx.clone(),
             },
         )
@@ -531,7 +531,7 @@ mod tests {
         let state_change_2 = state_changes::register_executor(
             &indexify_state.last_state_change_id,
             &UpsertExecutorRequest {
-                executor: mock_executor(mock_executor_id()),
+                executor: test_executor_metadata(TEST_EXECUTOR_ID.into()),
                 function_executor_diagnostics: vec![],
             },
         )
@@ -544,7 +544,7 @@ mod tests {
             &InvokeComputeGraphRequest {
                 namespace: "namespace".to_string(),
                 compute_graph_name: "graph_A".to_string(),
-                invocation_payload: mock_invocation_payload(),
+                invocation_payload: test_invocation_payload_graph_a(),
                 ctx: ctx.clone(),
             },
         )

--- a/server/state_store/src/test_state_store.rs
+++ b/server/state_store/src/test_state_store.rs
@@ -3,9 +3,9 @@ use std::sync::Arc;
 use anyhow::Result;
 use data_model::test_objects::tests::{
     self,
-    mock_invocation_ctx,
-    mock_invocation_payload,
-    mock_invocation_payload_graph_b,
+    test_invocation_ctx,
+    test_invocation_payload_graph_a,
+    test_invocation_payload_graph_b,
     TEST_NAMESPACE,
 };
 
@@ -46,7 +46,7 @@ impl TestStateStore {
 pub async fn with_simple_graph(indexify_state: &IndexifyState) -> String {
     let cg_request = CreateOrUpdateComputeGraphRequest {
         namespace: TEST_NAMESPACE.to_string(),
-        compute_graph: tests::mock_graph_a("image_hash".to_string()),
+        compute_graph: tests::test_graph_a("image_hash".to_string()),
         upgrade_tasks_to_current_version: true,
     };
     indexify_state
@@ -56,10 +56,10 @@ pub async fn with_simple_graph(indexify_state: &IndexifyState) -> String {
         })
         .await
         .unwrap();
-    let invocation_payload = mock_invocation_payload();
-    let ctx = mock_invocation_ctx(
+    let invocation_payload = test_invocation_payload_graph_a();
+    let ctx = test_invocation_ctx(
         TEST_NAMESPACE,
-        &tests::mock_graph_a("image_hash".to_string()),
+        &tests::test_graph_a("image_hash".to_string()),
         &invocation_payload,
     );
     let request = InvokeComputeGraphRequest {
@@ -81,7 +81,7 @@ pub async fn with_simple_graph(indexify_state: &IndexifyState) -> String {
 pub async fn with_router_graph(indexify_state: &IndexifyState) -> String {
     let cg_request = CreateOrUpdateComputeGraphRequest {
         namespace: TEST_NAMESPACE.to_string(),
-        compute_graph: tests::mock_graph_b(),
+        compute_graph: tests::test_graph_b(),
         upgrade_tasks_to_current_version: false,
     };
     indexify_state
@@ -92,8 +92,8 @@ pub async fn with_router_graph(indexify_state: &IndexifyState) -> String {
         .await
         .unwrap();
 
-    let invocation_payload = mock_invocation_payload_graph_b();
-    let ctx = mock_invocation_ctx(TEST_NAMESPACE, &tests::mock_graph_b(), &invocation_payload);
+    let invocation_payload = test_invocation_payload_graph_b();
+    let ctx = test_invocation_ctx(TEST_NAMESPACE, &tests::test_graph_b(), &invocation_payload);
     let request = InvokeComputeGraphRequest {
         namespace: TEST_NAMESPACE.to_string(),
         compute_graph_name: "graph_B".to_string(),
@@ -113,7 +113,7 @@ pub async fn with_router_graph(indexify_state: &IndexifyState) -> String {
 pub async fn with_reducer_graph(indexify_state: &IndexifyState) -> String {
     let cg_request = CreateOrUpdateComputeGraphRequest {
         namespace: TEST_NAMESPACE.to_string(),
-        compute_graph: tests::mock_graph_with_reducer(),
+        compute_graph: tests::test_graph_with_reducer(),
         upgrade_tasks_to_current_version: false,
     };
     indexify_state
@@ -124,10 +124,10 @@ pub async fn with_reducer_graph(indexify_state: &IndexifyState) -> String {
         .await
         .unwrap();
 
-    let invocation_payload = mock_invocation_payload_graph_b();
-    let ctx = mock_invocation_ctx(
+    let invocation_payload = test_invocation_payload_graph_b();
+    let ctx = test_invocation_ctx(
         TEST_NAMESPACE,
-        &tests::mock_graph_with_reducer(),
+        &tests::test_graph_with_reducer(),
         &invocation_payload,
     );
     let request = InvokeComputeGraphRequest {


### PR DESCRIPTION
## Context

We we'd like tests for task outcomes, making sure that explicitly failed invocations fail immediately and that retryable invocations are retried (incrementing the task's attempt count as appropriate).

## What

This change adds those task outcome tests, and also does some refactoring.

## Testing

`cargo test --workspace -- --test-threads 1`

## Contribution Checklist

- [ ] If a Python package was changed, please run `make fmt` in the package directory.
- [X] If the server was changed, please run `make fmt` in `server/`.
- [ ] Make sure all PR Checks are passing.