### PR TITLE
Track internal state in Function Executor controller and dedup termination events

### DIFF
--- a/indexify/poetry.lock
+++ b/indexify/poetry.lock
@@ -1806,14 +1806,14 @@ typing-extensions = {version = "*", markers = "python_version < \"3.11\""}
 
 [[package]]
 name = "tensorlake"
-version = "0.2.7"
+version = "0.2.8"
 description = "Tensorlake SDK for Document Ingestion API and Serverless Workflows"
 optional = false
 python-versions = "<4.0,>=3.10"
 groups = ["main"]
 files = [
-    {file = "tensorlake-0.2.7-py3-none-any.whl", hash = "sha256:101e28da47e428af9ae30318f20218b44ae72634333b3eca0d3bda84a7fee687"},
-    {file = "tensorlake-0.2.7.tar.gz", hash = "sha256:a73e92547e5601fbd64dd85f1e247ff97c398e575a124497d5d6ef6943c80746"},
+    {file = "tensorlake-0.2.8-py3-none-any.whl", hash = "sha256:c62e40eab58fefa28889cca7fb7525f3e0d1c7d8b881a0d5c064bee967921cf0"},
+    {file = "tensorlake-0.2.8.tar.gz", hash = "sha256:118e8cab090ecd9533786531235a54332dfe80cc46f3bdfef0fb3f865b17e287"},
 ]
 
 [package.dependencies]
@@ -2079,4 +2079,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "b39d494b6a7a811fead90481dfdd5dbebddb05785a97d57f3cf13d849174bea5"
+content-hash = "5a942b345e519e208e5c2b4f1b7133d26d45617ad15fde39042b5499878f75a3"

--- a/indexify/pyproject.toml
+++ b/indexify/pyproject.toml
@@ -25,7 +25,7 @@ prometheus-client = "^0.21.1"
 psutil = "^7.0.0"
 # Adds function-executor binary, utils lib, sdk used in indexify-cli commands.
 # We need to specify the tensorlake version exactly because pip install doesn't respect poetry.lock files.
-tensorlake = "0.2.7"
+tensorlake = "0.2.8"
 # Uncomment the next line to use local tensorlake package (only for development!)
 # tensorlake = { path = "../tensorlake", develop = true }
 # pydantic is provided by tensorlake

--- a/indexify/src/indexify/executor/function_executor_controller/destroy_function_executor.py
+++ b/indexify/src/indexify/executor/function_executor_controller/destroy_function_executor.py
@@ -1,28 +1,31 @@
+import asyncio
 from typing import Any, Optional
 
 from indexify.executor.function_executor.function_executor import FunctionExecutor
-from indexify.proto.executor_api_pb2 import FunctionExecutorTerminationReason
 
 from .events import FunctionExecutorDestroyed
 
 
 async def destroy_function_executor(
     function_executor: Optional[FunctionExecutor],
-    termination_reason: FunctionExecutorTerminationReason,
+    lock: asyncio.Lock,
     logger: Any,
 ) -> FunctionExecutorDestroyed:
-    """Destroys a function executor if it's not None.
+    """Destroys the function executor if it's not None.
+
+    The supplied lock is used to ensure that if a destroy operation is in progress,
+    then another caller won't return immediately assuming that the destroy is complete
+    due to its idempotency.
 
     Doesn't raise any exceptions.
     """
     logger = logger.bind(module=__name__)
 
     if function_executor is not None:
-        logger.info(
-            "destroying function executor",
-        )
-        await function_executor.destroy()
+        async with lock:
+            logger.info(
+                "destroying function executor",
+            )
+            await function_executor.destroy()
 
-    return FunctionExecutorDestroyed(
-        is_success=True, termination_reason=termination_reason
-    )
+    return FunctionExecutorDestroyed(is_success=True)

--- a/indexify/src/indexify/executor/function_executor_controller/events.py
+++ b/indexify/src/indexify/executor/function_executor_controller/events.py
@@ -55,19 +55,12 @@ class FunctionExecutorDestroyed(BaseEvent):
     Event indicating that Function Executor has been destroyed.
     """
 
-    def __init__(
-        self, is_success: bool, termination_reason: FunctionExecutorTerminationReason
-    ):
+    def __init__(self, is_success: bool):
         super().__init__(EventType.FUNCTION_EXECUTOR_DESTROYED)
         self.is_success: bool = is_success
-        self.termination_reason: FunctionExecutorTerminationReason = termination_reason
 
     def __str__(self) -> str:
-        return (
-            f"Event(type={self.event_type.name}, "
-            f"is_success={self.is_success}, "
-            f"termination_reason={FunctionExecutorTerminationReason.Name(self.termination_reason)})"
-        )
+        return f"Event(type={self.event_type.name}, " f"is_success={self.is_success})"
 
 
 class ShutdownInitiated(BaseEvent):

--- a/indexify/src/indexify/executor/function_executor_controller/metrics/function_executor_controller.py
+++ b/indexify/src/indexify/executor/function_executor_controller/metrics/function_executor_controller.py
@@ -34,27 +34,34 @@ metric_runnable_tasks_per_function_name: prometheus_client.Gauge = (
     )
 )
 
-metric_function_executors_with_status: prometheus_client.Gauge = (
-    prometheus_client.Gauge(
-        "function_executors_with_status",
-        "Number of Function Executors with a particular status",
-        ["status"],
-    )
+metric_function_executors_with_state: prometheus_client.Gauge = prometheus_client.Gauge(
+    "function_executors_with_state",
+    "Number of Function Executors with a particular internal state",
+    ["state"],
 )
-METRIC_FUNCTION_EXECUTORS_WITH_STATUS_LABEL_UNKNOWN = "unknown"
-METRIC_FUNCTION_EXECUTORS_WITH_STATUS_LABEL_PENDING = "pending"
-METRIC_FUNCTION_EXECUTORS_WITH_STATUS_LABEL_RUNNING = "running"
-METRIC_FUNCTION_EXECUTORS_WITH_STATUS_LABEL_TERMINATED = "terminated"
+METRIC_FUNCTION_EXECUTORS_WITH_STATE_LABEL_UNKNOWN = "unknown"
+METRIC_FUNCTION_EXECUTORS_WITH_STATE_LABEL_NOT_STARTED = "not_started"
+METRIC_FUNCTION_EXECUTORS_WITH_STATE_LABEL_STARTING_UP = "starting_up"
+METRIC_FUNCTION_EXECUTORS_WITH_STATE_LABEL_RUNNING = "running"
+METRIC_FUNCTION_EXECUTORS_WITH_STATE_LABEL_TERMINATING = "terminating"
+METRIC_FUNCTION_EXECUTORS_WITH_STATE_LABEL_TERMINATED = "terminated"
 
-metric_function_executors_with_status.labels(
-    status=METRIC_FUNCTION_EXECUTORS_WITH_STATUS_LABEL_UNKNOWN
+
+metric_function_executors_with_state.labels(
+    state=METRIC_FUNCTION_EXECUTORS_WITH_STATE_LABEL_UNKNOWN
 )
-metric_function_executors_with_status.labels(
-    status=METRIC_FUNCTION_EXECUTORS_WITH_STATUS_LABEL_PENDING
+metric_function_executors_with_state.labels(
+    state=METRIC_FUNCTION_EXECUTORS_WITH_STATE_LABEL_NOT_STARTED
 )
-metric_function_executors_with_status.labels(
-    status=METRIC_FUNCTION_EXECUTORS_WITH_STATUS_LABEL_RUNNING
+metric_function_executors_with_state.labels(
+    state=METRIC_FUNCTION_EXECUTORS_WITH_STATE_LABEL_STARTING_UP
 )
-metric_function_executors_with_status.labels(
-    status=METRIC_FUNCTION_EXECUTORS_WITH_STATUS_LABEL_TERMINATED
+metric_function_executors_with_state.labels(
+    state=METRIC_FUNCTION_EXECUTORS_WITH_STATE_LABEL_RUNNING
+)
+metric_function_executors_with_state.labels(
+    state=METRIC_FUNCTION_EXECUTORS_WITH_STATE_LABEL_TERMINATING
+)
+metric_function_executors_with_state.labels(
+    state=METRIC_FUNCTION_EXECUTORS_WITH_STATE_LABEL_TERMINATED
 )

--- a/indexify/tests/executor/test_metrics.py
+++ b/indexify/tests/executor/test_metrics.py
@@ -171,8 +171,8 @@ class TestMetrics(unittest.TestCase):
             "function_executor_destroy_health_checker_latency_seconds_count",
             "function_executor_destroy_health_checker_latency_seconds_sum",
             "function_executor_destroy_health_checker_errors_total",
-            # FE statuses
-            "function_executors_with_status",
+            # FE states
+            "function_executors_with_state",
             # Executor
             "executor_info",
             "executor_state",


### PR DESCRIPTION
Previously FE Status proto was used for tracking of internal
controller state but FE status proto is it's not sufficient
because we need to also track Terminating state to dedup
FE termination events. So we're splitting reported proto
Status and internal FE controller state in this change.
Then we use the internal state to dedup events.

Also add a lock to FE destroy code to make sure that when
we shutdown FE we don't immediately exit from fe.destroy()
call if another destroy is in progress because fe.destroy()
is also idempotent. When we shutdown FE we need to make sure
that all FE resources were freed on return from FE shutdown.

Also update tensorlake.