### PR TITLE
Fold FE termination reason into FE state

### DIFF
--- a/server/data_model/src/lib.rs
+++ b/server/data_model/src/lib.rs
@@ -1689,7 +1689,7 @@ pub enum FunctionExecutorState {
     // Function Executor is running and ready to accept tasks.
     Running,
     // Function Executor is terminated, all resources are freed.
-    Terminated,
+    Terminated(FunctionExecutorTerminationReason),
 }
 
 #[derive(
@@ -1814,7 +1814,6 @@ pub struct FunctionExecutor {
     pub compute_fn_name: String,
     pub version: GraphVersion,
     pub state: FunctionExecutorState,
-    pub termination_reason: FunctionExecutorTerminationReason,
     pub resources: FunctionExecutorResources,
 }
 
@@ -1881,7 +1880,6 @@ impl FunctionExecutor {
         // Only update fields that change after self FE was created.
         // Other FE mush represent the same FE.
         self.state = other.state;
-        self.termination_reason = other.termination_reason;
     }
 }
 
@@ -1906,10 +1904,6 @@ impl FunctionExecutorBuilder {
             .resources
             .clone()
             .ok_or(anyhow!("resources is required"))?;
-        let termination_reason = self
-            .termination_reason
-            .clone()
-            .ok_or(anyhow!("termination_reason is required"))?;
         Ok(FunctionExecutor {
             id,
             namespace,
@@ -1917,7 +1911,6 @@ impl FunctionExecutorBuilder {
             compute_fn_name,
             version,
             state,
-            termination_reason,
             resources,
         })
     }

--- a/server/src/reconciliation_test.rs
+++ b/server/src/reconciliation_test.rs
@@ -5,6 +5,7 @@ mod tests {
         test_objects::tests::{test_executor_metadata, TEST_EXECUTOR_ID, TEST_NAMESPACE},
         FunctionAllowlist,
         FunctionExecutorState,
+        FunctionExecutorTerminationReason,
         GraphVersion,
         TaskOutcome,
     };
@@ -201,7 +202,9 @@ mod tests {
                 .collect();
             for fe in fes.iter_mut() {
                 if fe.compute_fn_name == "fn_a" {
-                    fe.state = FunctionExecutorState::Terminated;
+                    fe.state = FunctionExecutorState::Terminated(
+                        FunctionExecutorTerminationReason::DesiredStateRemoved,
+                    );
                 }
             }
             executor.update_function_executors(fes).await?;

--- a/server/state_store/src/in_memory_state.rs
+++ b/server/state_store/src/in_memory_state.rs
@@ -1050,10 +1050,13 @@ impl InMemoryState {
                 {
                     num_pending_function_executors += 1;
                 }
-                if function_executor.desired_state == FunctionExecutorState::Terminated ||
-                    function_executor.function_executor.state ==
-                        FunctionExecutorState::Terminated
-                {
+                if matches!(
+                    function_executor.desired_state,
+                    FunctionExecutorState::Terminated(_)
+                ) || matches!(
+                    function_executor.function_executor.state,
+                    FunctionExecutorState::Terminated(_)
+                ) {
                     continue;
                 }
                 // FIXME - Create a reverse index of fe_id -> # active allocations
@@ -1220,7 +1223,10 @@ impl InMemoryState {
             let mut function_executors_to_remove = Vec::new();
             for fe_metadata in function_executors.iter() {
                 // Skip if the FE is already marked for termination
-                if fe_metadata.desired_state == FunctionExecutorState::Terminated {
+                if matches!(
+                    fe_metadata.desired_state,
+                    FunctionExecutorState::Terminated(_)
+                ) {
                     continue;
                 }
 
@@ -1320,7 +1326,9 @@ impl InMemoryState {
             .map(|executor_state| executor_state.function_executors.clone())
             .unwrap_or_default()
             .values()
-            .filter(|fe_meta| fe_meta.desired_state != FunctionExecutorState::Terminated)
+            .filter(|fe_meta| {
+                !matches!(fe_meta.desired_state, FunctionExecutorState::Terminated(_))
+            })
             .map(|fe_meta| fe_meta.clone())
             .collect::<Vec<_>>();
 
@@ -1478,7 +1486,6 @@ mod tests {
         FunctionExecutorResources,
         FunctionExecutorServerMetadata,
         FunctionExecutorState,
-        FunctionExecutorTerminationReason,
         GraphVersion,
         Task,
         TaskFailureReason,
@@ -1613,7 +1620,6 @@ mod tests {
             compute_fn_name: "test-function".to_string(),
             version: GraphVersion("1.0".to_string()),
             state: FunctionExecutorState::Running,
-            termination_reason: FunctionExecutorTerminationReason::Unknown,
             resources: FunctionExecutorResources {
                 cpu_ms_per_sec: 1000,
                 memory_mb: 512,
@@ -1748,7 +1754,6 @@ mod tests {
                 compute_fn_name: "different-function".to_string(),
                 version: GraphVersion("1.0".to_string()),
                 state: FunctionExecutorState::Running,
-                termination_reason: FunctionExecutorTerminationReason::Unknown,
                 resources: FunctionExecutorResources {
                     cpu_ms_per_sec: 1000,
                     memory_mb: 512,


### PR DESCRIPTION
## Context

FE state contains a termination reason that's only needed in the terminated state.

## What

Similar to what we did recently for tasks and allocs, this PR folds the termination reason into the FE state.

## Testing

`cargo test --workspace -- --test-threads 1`

## Contribution Checklist

- [ ] If a Python package was changed, please run `make fmt` in the package directory.
- [X] If the server was changed, please run `make fmt` in `server/`.
- [ ] Make sure all PR Checks are passing.