### PR TITLE
Handle FE termination reasons

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -1510,6 +1510,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "if_chain"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb56e1aa765b4b4f3aadfab769793b7087bb03a4ea4920644a6d238e2df5b9ed"
+
+[[package]]
 name = "im"
 version = "15.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1542,6 +1548,7 @@ dependencies = [
  "futures",
  "hex",
  "hyper",
+ "if_chain",
  "indexify_ui",
  "indexify_utils",
  "metrics",
@@ -2391,6 +2398,7 @@ dependencies = [
  "blob_store",
  "dashmap",
  "data_model",
+ "if_chain",
  "im",
  "indexify_utils",
  "itertools 0.14.0",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -95,6 +95,7 @@ tonic-build = "0.13.1"
 tokio-util = { version = "0.7.15", features = ["full"] }
 priority-queue = "2.5.0"
 hex = "0.4.3"
+if_chain = "1.0.2"
 
 [dependencies]
 async-stream = { workspace = true }
@@ -147,6 +148,7 @@ tonic-reflection = { workspace = true }
 tokio-stream = { workspace = true }
 priority-queue = { workspace = true }
 tokio-util = { workspace = true }
+if_chain = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/server/data_model/src/lib.rs
+++ b/server/data_model/src/lib.rs
@@ -1715,6 +1715,7 @@ pub enum FunctionExecutorTerminationReason {
     FunctionError,
     FunctionTimeout,
     FunctionCancelled,
+    DesiredStateRemoved,
 }
 
 impl FunctionExecutorTerminationReason {

--- a/server/data_model/src/lib.rs
+++ b/server/data_model/src/lib.rs
@@ -1721,8 +1721,7 @@ impl FunctionExecutorTerminationReason {
     pub fn should_count_against_task_retry_attempts(self) -> bool {
         matches!(
             self,
-            Self::Unknown |
-                Self::StartupFailedInternalError |
+            Self::StartupFailedInternalError |
                 Self::StartupFailedFunctionError |
                 Self::StartupFailedFunctionTimeout |
                 Self::Unhealthy |

--- a/server/processor/Cargo.toml
+++ b/server/processor/Cargo.toml
@@ -21,3 +21,4 @@ itertools.workspace = true
 indexify_utils.workspace = true
 im.workspace = true
 nanoid.workspace = true
+if_chain.workspace = true

--- a/server/processor/src/function_executor_manager.rs
+++ b/server/processor/src/function_executor_manager.rs
@@ -308,7 +308,8 @@ impl FunctionExecutorManager {
                 if_chain! {
                         if let Ok(compute_graph_version) = in_memory_state.get_existing_compute_graph_version(&task);
                         if let Some(max_retries) = compute_graph_version.task_max_retries(&task);
-                        if matches!(fe.state, FunctionExecutorState::Terminated(termination_reason) if termination_reason.should_count_against_task_retry_attempts());
+                        if let FunctionExecutorState::Terminated(termination_reason) = fe.state;
+                        if termination_reason.should_count_against_task_retry_attempts();
                         then {
                                 // The alloc's task should be retried iff it has remaining retry
                                 // attempts.

--- a/server/processor/src/function_executor_manager.rs
+++ b/server/processor/src/function_executor_manager.rs
@@ -59,7 +59,7 @@ impl FunctionExecutorManager {
         for fe in &function_executors_to_mark {
             let mut update_fe = fe.clone();
             update_fe.desired_state = FunctionExecutorState::Terminated(
-                FunctionExecutorTerminationReason::FunctionCancelled,
+                FunctionExecutorTerminationReason::DesiredStateRemoved,
             );
             update.new_function_executors.push(*update_fe);
 

--- a/server/src/executor_api.rs
+++ b/server/src/executor_api.rs
@@ -316,25 +316,25 @@ impl TryFrom<FunctionExecutorTerminationReason> for data_model::FunctionExecutor
                 Ok(data_model::FunctionExecutorTerminationReason::Unknown)
             }
             FunctionExecutorTerminationReason::StartupFailedInternalError => {
-                Ok(data_model::FunctionExecutorTerminationReason::PlatformError)
+                Ok(data_model::FunctionExecutorTerminationReason::StartupFailedInternalError)
             }
             FunctionExecutorTerminationReason::StartupFailedFunctionError => {
-                Ok(data_model::FunctionExecutorTerminationReason::CustomerCodeError)
+                Ok(data_model::FunctionExecutorTerminationReason::StartupFailedFunctionError)
             }
             FunctionExecutorTerminationReason::StartupFailedFunctionTimeout => {
-                Ok(data_model::FunctionExecutorTerminationReason::CustomerCodeError)
+                Ok(data_model::FunctionExecutorTerminationReason::StartupFailedFunctionTimeout)
             }
             FunctionExecutorTerminationReason::Unhealthy => {
-                Ok(data_model::FunctionExecutorTerminationReason::PlatformError)
+                Ok(data_model::FunctionExecutorTerminationReason::Unhealthy)
             }
             FunctionExecutorTerminationReason::InternalError => {
-                Ok(data_model::FunctionExecutorTerminationReason::PlatformError)
+                Ok(data_model::FunctionExecutorTerminationReason::InternalError)
             }
             FunctionExecutorTerminationReason::FunctionTimeout => {
-                Ok(data_model::FunctionExecutorTerminationReason::CustomerCodeError)
+                Ok(data_model::FunctionExecutorTerminationReason::FunctionError)
             }
             FunctionExecutorTerminationReason::FunctionCancelled => {
-                Ok(data_model::FunctionExecutorTerminationReason::CustomerCodeError)
+                Ok(data_model::FunctionExecutorTerminationReason::FunctionCancelled)
             }
         }
     }

--- a/server/src/integration_test.rs
+++ b/server/src/integration_test.rs
@@ -594,8 +594,12 @@ mod tests {
             assert_eq!(attempt_number, tasks.get(0).unwrap().attempt_number);
         }
 
-        // make sure the task is still allocated
-        assert_task_counts!(test_srv, total: 1, allocated: 1, pending: 0, completed_success: 0);
+        // make sure the task is still allocated iff the reason is retriable.
+        if reason.is_retriable() {
+            assert_task_counts!(test_srv, total: 1, allocated: 1, pending: 0, completed_success: 0);
+        } else {
+            assert_task_counts!(test_srv, total: 1, allocated: 0, pending: 0, completed_success: 0);
+        }
 
         Ok(())
     }

--- a/server/src/reconciliation_test.rs
+++ b/server/src/reconciliation_test.rs
@@ -303,21 +303,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_fe_retry_attempt_used_on_unknown() -> Result<()> {
-        test_function_executor_retry_attempt_used(
-            FunctionExecutorTerminationReason::Unknown,
-            TEST_FN_MAX_RETRIES,
-        )
-        .await
-    }
-
-    #[tokio::test]
-    async fn test_fe_retry_attempt_used_on_unknown_no_retries() -> Result<()> {
-        test_function_executor_retry_attempt_used(FunctionExecutorTerminationReason::Unknown, 0)
-            .await
-    }
-
-    #[tokio::test]
     async fn test_fe_retry_attempt_used_on_startup_failed_internal_error() -> Result<()> {
         test_function_executor_retry_attempt_used(
             FunctionExecutorTerminationReason::StartupFailedInternalError,
@@ -492,6 +477,21 @@ mod tests {
         assert_task_counts!(test_srv, total: 1, allocated: 1, pending: 0, completed_success: 0);
 
         Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_fe_retry_attempt_not_used_on_unknown() -> Result<()> {
+        test_function_executor_retry_attempt_not_used(
+            FunctionExecutorTerminationReason::Unknown,
+            TEST_FN_MAX_RETRIES,
+        )
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_fe_retry_attempt_not_used_on_unknown_no_retries() -> Result<()> {
+        test_function_executor_retry_attempt_not_used(FunctionExecutorTerminationReason::Unknown, 0)
+            .await
     }
 
     #[tokio::test]

--- a/server/src/reconciliation_test.rs
+++ b/server/src/reconciliation_test.rs
@@ -495,6 +495,24 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_fe_retry_attempt_not_used_on_desired_state_removed() -> Result<()> {
+        test_function_executor_retry_attempt_not_used(
+            FunctionExecutorTerminationReason::DesiredStateRemoved,
+            TEST_FN_MAX_RETRIES,
+        )
+        .await
+    }
+
+    #[tokio::test]
+    async fn test_fe_retry_attempt_not_used_on_desired_state_removed_no_retries() -> Result<()> {
+        test_function_executor_retry_attempt_not_used(
+            FunctionExecutorTerminationReason::DesiredStateRemoved,
+            0,
+        )
+        .await
+    }
+
+    #[tokio::test]
     async fn test_fe_retry_attempt_not_used_on_function_cancelled() -> Result<()> {
         test_function_executor_retry_attempt_not_used(
             FunctionExecutorTerminationReason::FunctionCancelled,

--- a/server/src/testing.rs
+++ b/server/src/testing.rs
@@ -345,14 +345,14 @@ impl TestExecutor<'_> {
         Ok(())
     }
 
-    pub async fn mark_function_executors_as_running(&self) -> Result<()> {
+    pub async fn set_function_executor_states(&self, state: FunctionExecutorState) -> Result<()> {
         let fes = self
             .get_executor_server_state()
             .await?
             .function_executors
             .into_values()
             .map(|mut fe| {
-                fe.state = FunctionExecutorState::Running;
+                fe.state = state;
                 fe
             })
             .collect();
@@ -363,6 +363,11 @@ impl TestExecutor<'_> {
         self.test_service.process_all_state_changes().await?;
 
         Ok(())
+    }
+
+    pub async fn mark_function_executors_as_running(&self) -> Result<()> {
+        self.set_function_executor_states(FunctionExecutorState::Running)
+            .await
     }
 
     pub async fn get_executor_server_state(&self) -> Result<ExecutorMetadata> {

--- a/server/state_store/src/in_memory_state.rs
+++ b/server/state_store/src/in_memory_state.rs
@@ -1429,6 +1429,26 @@ impl InMemoryState {
             allocation_completion_latency: self.allocation_completion_latency.clone(),
         }))
     }
+
+    pub fn get_existing_compute_graph_version<'a>(
+        &'a self,
+        task: &Task,
+    ) -> Result<&'a Box<ComputeGraphVersion>> {
+        self.compute_graph_versions
+            .get(&task.key_compute_graph_version())
+            .ok_or_else(|| {
+                error!(
+                    task_id = task.id.to_string(),
+                    invocation_id = task.invocation_id.to_string(),
+                    namespace = task.namespace,
+                    graph = task.compute_graph_name,
+                    "fn" = task.compute_fn_name,
+                    graph_version = task.graph_version.0,
+                    "compute graph version not found",
+                );
+                anyhow!("compute graph version not found")
+            })
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Context

We're not handling FE termination reasons correctly (retrying the task, and docking it a retry attempt when we're not sure it's our fault).

## What

We've talked through which FE termination reasons should dock retry attempts; this PR implements what we've discussed, mostly fixing #1520 (although we also have to get the retry timeouts correct, which this PR does not do yet).

## Testing

Added tests for all the various FE termination reasons
`cargo test --workspace -- --test-threads 1`

## Contribution Checklist

- [ ] If a Python package was changed, please run `make fmt` in the package directory.
- [X] If the server was changed, please run `make fmt` in `server/`.
- [ ] Make sure all PR Checks are passing.