### PR TITLE
Only charge retries to allocs indicated by executor

### DIFF
--- a/server/data_model/src/lib.rs
+++ b/server/data_model/src/lib.rs
@@ -1668,17 +1668,7 @@ impl Default for FunctionExecutorId {
 }
 
 #[derive(
-    Debug,
-    Clone,
-    Copy,
-    Serialize,
-    Deserialize,
-    PartialEq,
-    Default,
-    strum::AsRefStr,
-    Display,
-    Eq,
-    Hash,
+    Debug, Clone, Serialize, Deserialize, PartialEq, Default, strum::AsRefStr, Display, Eq, Hash,
 )]
 pub enum FunctionExecutorState {
     #[default]
@@ -1688,7 +1678,10 @@ pub enum FunctionExecutorState {
     // Function Executor is running and ready to accept tasks.
     Running,
     // Function Executor is terminated, all resources are freed.
-    Terminated(FunctionExecutorTerminationReason),
+    Terminated {
+        reason: FunctionExecutorTerminationReason,
+        allocs: Vec<String>,
+    },
 }
 
 #[derive(
@@ -1895,7 +1888,7 @@ impl FunctionExecutor {
     pub fn update(&mut self, other: &FunctionExecutor) {
         // Only update fields that change after self FE was created.
         // Other FE mush represent the same FE.
-        self.state = other.state;
+        self.state = other.state.clone();
     }
 }
 

--- a/server/src/executor_api.rs
+++ b/server/src/executor_api.rs
@@ -395,7 +395,10 @@ impl TryFrom<FunctionExecutorState> for data_model::FunctionExecutor {
                 FunctionExecutorStatus::Pending => data_model::FunctionExecutorState::Pending,
                 FunctionExecutorStatus::Running => data_model::FunctionExecutorState::Running,
                 FunctionExecutorStatus::Terminated => {
-                    data_model::FunctionExecutorState::Terminated(termination_reason)
+                    data_model::FunctionExecutorState::Terminated {
+                        reason: termination_reason,
+                        allocs: function_executor_state.allocation_ids_caused_termination,
+                    }
                 }
             },
             resources,

--- a/server/src/testing.rs
+++ b/server/src/testing.rs
@@ -352,7 +352,7 @@ impl TestExecutor<'_> {
             .function_executors
             .into_values()
             .map(|mut fe| {
-                fe.state = state;
+                fe.state = state.clone();
                 fe
             })
             .collect();

--- a/server/state_store/src/in_memory_state.rs
+++ b/server/state_store/src/in_memory_state.rs
@@ -1052,10 +1052,10 @@ impl InMemoryState {
                 }
                 if matches!(
                     function_executor.desired_state,
-                    FunctionExecutorState::Terminated(_)
+                    FunctionExecutorState::Terminated { .. }
                 ) || matches!(
                     function_executor.function_executor.state,
-                    FunctionExecutorState::Terminated(_)
+                    FunctionExecutorState::Terminated { .. }
                 ) {
                     continue;
                 }
@@ -1225,7 +1225,7 @@ impl InMemoryState {
                 // Skip if the FE is already marked for termination
                 if matches!(
                     fe_metadata.desired_state,
-                    FunctionExecutorState::Terminated(_)
+                    FunctionExecutorState::Terminated { .. }
                 ) {
                     continue;
                 }
@@ -1327,7 +1327,10 @@ impl InMemoryState {
             .unwrap_or_default()
             .values()
             .filter(|fe_meta| {
-                !matches!(fe_meta.desired_state, FunctionExecutorState::Terminated(_))
+                !matches!(
+                    fe_meta.desired_state,
+                    FunctionExecutorState::Terminated { .. }
+                )
             })
             .map(|fe_meta| fe_meta.clone())
             .collect::<Vec<_>>();


### PR DESCRIPTION
## Context

When an FE terminates, we only want to charge retry attempts against allocs indicated by the executor.

Fixes #1539 

## What

This change plumbs through the alloc list from the executor, using it as a filter for retries.

## Testing

`cargo test --workspace -- -- test-threads 1`

## Contribution Checklist

- [ ] If a Python package was changed, please run `make fmt` in the package directory.
- [X] If the server was changed, please run `make fmt` in `server/`.
- [ ] Make sure all PR Checks are passing.
