### PR TITLE
Log FE state in termination

### DIFF
--- a/server/data_model/src/lib.rs
+++ b/server/data_model/src/lib.rs
@@ -1716,6 +1716,7 @@ pub enum FunctionExecutorTerminationReason {
     FunctionTimeout,
     FunctionCancelled,
     DesiredStateRemoved,
+    ExecutorRemoved,
 }
 
 impl FunctionExecutorTerminationReason {


### PR DESCRIPTION
## Context

It came up in debugging that we didn't have info logs for the FE termination reason.

## What

Add the FE termination reason to the logs, adding a separate termination reason when the entire executor goes away.

## Testing

`cargo test --workspace -- --test-threads 1`
Also, ran a test that threw an exception from a constructor, and verified that we see the correct info logs.

## Contribution Checklist

- [ ] If a Python package was changed, please run `make fmt` in the package directory.
- [X] If the server was changed, please run `make fmt` in `server/`.
- [ ] Make sure all PR Checks are passing.