### PR TITLE
fix: task ingest

### DIFF
--- a/server/src/executor_api.rs
+++ b/server/src/executor_api.rs
@@ -691,7 +691,6 @@ impl ExecutorAPIService {
                 compute_graph: compute_graph.compute_graph_name.clone(),
                 compute_fn: compute_fn.to_string(),
                 invocation_id: invocation_id.to_string(),
-                task: task.clone(),
                 node_output,
                 executor_id: executor_id.clone(),
                 allocation,

--- a/server/state_store/src/in_memory_state.rs
+++ b/server/state_store/src/in_memory_state.rs
@@ -627,19 +627,6 @@ impl InMemoryState {
                     .insert(req.ctx.key(), Box::new(req.ctx.clone()));
             }
             RequestPayload::IngestTaskOutputs(req) => {
-                // Update task
-                let invocation_ctx_key = GraphInvocationCtx::key_from(
-                    &req.task.namespace,
-                    &req.task.compute_graph_name,
-                    &req.task.invocation_id,
-                );
-                // Only update tasks for running invocations, this can happen if
-                // the invocation failed with pending allocations on executors.
-                if self.invocation_ctx.get(&invocation_ctx_key).is_some() {
-                    self.tasks
-                        .insert(req.task.key(), Box::new(req.task.clone()));
-                }
-
                 // Remove the allocation
                 {
                     self.allocations_by_executor
@@ -659,7 +646,7 @@ impl InMemoryState {
                                             allocation.created_at,
                                             TimeUnit::Milliseconds,
                                         ),
-                                        &[KeyValue::new("outcome", req.task.outcome.to_string())],
+                                        &[KeyValue::new("outcome", req.allocation.outcome.to_string())],
                                     );
 
                                     // Remove the allocation

--- a/server/state_store/src/invocation_events.rs
+++ b/server/state_store/src/invocation_events.rs
@@ -19,7 +19,7 @@ impl InvocationStateChangeEvent {
         Self::TaskCompleted(TaskCompleted {
             invocation_id: event.invocation_id,
             fn_name: event.compute_fn,
-            task_id: event.task.id.to_string(),
+            task_id: event.allocation.task_id.get().to_string(),
             outcome: (&event.allocation.outcome).into(),
             allocation_id: event.allocation.id.to_string(),
         })

--- a/server/state_store/src/requests.rs
+++ b/server/state_store/src/requests.rs
@@ -86,7 +86,6 @@ pub struct IngestTaskOutputsRequest {
     pub compute_graph: String,
     pub compute_fn: String,
     pub invocation_id: String,
-    pub task: Task,
     pub allocation: Allocation,
     pub node_output: NodeOutput,
     pub executor_id: ExecutorId,

--- a/server/state_store/src/state_changes.rs
+++ b/server/state_store/src/state_changes.rs
@@ -110,13 +110,13 @@ pub fn task_outputs_ingested(
                 compute_graph: request.compute_graph.clone(),
                 compute_fn: request.compute_fn.clone(),
                 invocation_id: request.invocation_id.clone(),
-                task_id: request.task.id.clone(),
+                task_id: request.allocation.task_id.clone(),
                 node_output_key: request.node_output.key(),
                 allocation_key: Some(request.allocation_key.clone()),
             },
         ))
         .created_at(get_epoch_time_in_ms())
-        .object_id(request.task.id.clone().to_string())
+        .object_id(request.allocation.task_id.get().to_string())
         .id(StateChangeId::new(last_change_id))
         .processed_at(None)
         .build()?;

--- a/server/state_store/src/state_machine.rs
+++ b/server/state_store/src/state_machine.rs
@@ -786,7 +786,7 @@ pub fn ingest_task_outputs(
         graph = &req.compute_graph,
         invocation_id = &req.invocation_id,
         "fn" = &req.compute_fn,
-        task_id = req.task.id.get(),
+        task_id = req.allocation.task_id.get(),
     );
     let _guard = span.enter();
 
@@ -869,15 +869,6 @@ pub fn ingest_task_outputs(
         &IndexifyObjectsColumns::FnOutputs.cf_db(&db),
         &output_key,
         serialized_output,
-    )?;
-
-    let existing_task = req.task;
-
-    let task_bytes = JsonEncoder::encode(&existing_task)?;
-    txn.put_cf(
-        &IndexifyObjectsColumns::Tasks.cf_db(&db),
-        existing_task.key(),
-        task_bytes,
     )?;
 
     Ok(true)


### PR DESCRIPTION
We shouldn't be updating tasks when we ingest allocation output. By the time the tasks are getting updated, they might be getting updated by the scheduler as well. 

Scenario - 
1. FE fails, and we get FE failure update from the executor. The scheduler updates the task outcome and state
2. If we get a task result simultaenously, if it updates the task also it can collide with (1)