### PR TITLE
Use std logging tags for FE term logging

### DIFF
--- a/server/processor/src/function_executor_manager.rs
+++ b/server/processor/src/function_executor_manager.rs
@@ -284,11 +284,11 @@ impl FunctionExecutorManager {
         // Handle allocations for FEs to be removed and update tasks
         for fe in function_executors_to_remove {
             info!(
-                fe.namespace,
-                fe.compute_graph = fe.compute_graph_name,
-                fe.compute_fn = fe.compute_fn_name,
-                fe.executor_id = fe.id.get(),
-                ?fe.state,
+                namespace = fe.namespace,
+                graph = fe.compute_graph_name,
+                fn = fe.compute_fn_name,
+                executor_id = fe.id.get(),
+                fe_state = ?fe.state,
                 "Removing function executor from executor",
             );
 


### PR DESCRIPTION
## Context

We have [standard logging tags](https://github.com/tensorlakeai/internal-docs/blob/main/architecture/tags.md); we should use them.  :-)

## What

Change to use the standard logging tags where available.

## Testing

Ran a local test; verified that the info message uses the standard fields.

## Contribution Checklist

- [ ] If a Python package was changed, please run `make fmt` in the package directory.
- [X] If the server was changed, please run `make fmt` in `server/`.
- [ ] Make sure all PR Checks are passing.