### PR TITLE
Logging tag standardization

### DIFF
--- a/docs/tags.md
+++ b/docs/tags.md
@@ -1,0 +1,18 @@
+Unified tags for indexify / PE / FE stack. All events/metrics/spans should use these attribute names when relevant.
+
+- graph - Name of graph.
+- graph_version - Version of the graph
+- invocation_id = ID of the invocation.
+- fn - Name of the compute function
+- allocation_id - ID of the allocation
+- task_id - ID of the task.
+- namespace - Name of the namespace.
+- executor_sku - Type of executor (a100, h100, etc)
+- executor_id - ID of the Platform executor
+- fn_executor_id - ID of the function executor.
+- duration_sec - Duration of an operation in secs (use proper suffix if different unit of time is used)
+
+Guiding principles:
+- Consistent - Tag spelling and abreviations should be consistent (e.g. if we are shortening function to fn it should be done everywhere)
+- Concise - Tags should be as short as possible while relaying what they are.
+

--- a/docs/tags.md
+++ b/docs/tags.md
@@ -8,7 +8,7 @@ Unified tags for indexify / PE / FE stack. All events/metrics/spans should use t
 - task_id - ID of the task.
 - namespace - Name of the namespace.
 - executor_sku - Type of executor (a100, h100, etc)
-- executor_id - ID of the Platform executor
+- executor_id - ID of the executor
 - fn_executor_id - ID of the function executor.
 - duration_sec - Duration of an operation in secs (use proper suffix if different unit of time is used)
 

--- a/server/processor/src/function_executor_manager.rs
+++ b/server/processor/src/function_executor_manager.rs
@@ -518,9 +518,8 @@ impl FunctionExecutorManager {
 
         tracing::debug!(
             executor_id = executor_id.get(),
-            "reconciling executor state for executor {} - {:#?}",
-            executor_id.get(),
-            executor
+            ?executor,
+            "reconciling executor state for executor",
         );
 
         // Reconcile function executors

--- a/server/processor/src/function_executor_manager.rs
+++ b/server/processor/src/function_executor_manager.rs
@@ -517,6 +517,7 @@ impl FunctionExecutorManager {
             .clone();
 
         tracing::debug!(
+            executor_id = executor_id.get(),
             "reconciling executor state for executor {} - {:#?}",
             executor_id.get(),
             executor

--- a/server/processor/src/task_creator.rs
+++ b/server/processor/src/task_creator.rs
@@ -272,7 +272,7 @@ impl TaskCreator {
             error!(
                 invocation_id = event.invocation_id.to_string(),
                 namespace = event.namespace,
-                compute_graph = event.compute_graph,
+                graph = event.compute_graph,
                 graph_version = invocation_ctx.graph_version.0,
                 "compute graph version not found",
             );
@@ -381,7 +381,7 @@ impl TaskCreator {
                 task_id = task.id.to_string(),
                 invocation_id = task.invocation_id.to_string(),
                 namespace = task.namespace,
-                compute_graph = task.compute_graph_name,
+                graph = task.compute_graph_name,
                 "fn" = task.compute_fn_name,
                 "compute node not found",
             );
@@ -435,7 +435,7 @@ impl TaskCreator {
             let Some(edge_compute_node) = edge_compute_node else {
                 // This can happen e.g. if the compute graph was updated in non backward
                 // compatible way while the invocation was running.
-                info!(edge = edge, "Edge function not found, failing invocation",);
+                info!(fn = edge, "Edge function not found, failing invocation",);
                 invocation_ctx.complete_invocation(
                     true,
                     GraphInvocationOutcome::Failure(

--- a/server/state_store/src/in_memory_state.rs
+++ b/server/state_store/src/in_memory_state.rs
@@ -597,7 +597,7 @@ impl InMemoryState {
                             executor_id = executor_id.get(),
                             task_key = allocation.task_key(),
                             namespace = allocation.namespace,
-                            compute_graph = allocation.compute_graph,
+                            graph = allocation.compute_graph,
                             "fn" = allocation.compute_fn,
                             invocation_id = allocation.invocation_id,
                             "task not found for allocation"
@@ -812,7 +812,7 @@ impl InMemoryState {
                     } else {
                         error!(
                             namespace = &allocation.namespace,
-                            compute_graph = &allocation.compute_graph,
+                            graph = &allocation.compute_graph,
                             "fn" = &allocation.compute_fn,
                             executor_id = allocation.target.executor_id.get(),
                             invocation_id = &allocation.invocation_id,

--- a/server/state_store/src/in_memory_state.rs
+++ b/server/state_store/src/in_memory_state.rs
@@ -596,6 +596,8 @@ impl InMemoryState {
                         error!(
                             executor_id = executor_id.get(),
                             task_key = allocation.task_key(),
+                            task_id = allocation.task_id.get(),
+                            allocation_id = allocation.id,
                             namespace = allocation.namespace,
                             graph = allocation.compute_graph,
                             "fn" = allocation.compute_fn,
@@ -815,6 +817,7 @@ impl InMemoryState {
                             graph = &allocation.compute_graph,
                             "fn" = &allocation.compute_fn,
                             executor_id = allocation.target.executor_id.get(),
+                            allocation_id = allocation.id,
                             invocation_id = &allocation.invocation_id,
                             task_id = allocation.task_id.get(),
                             "task not found for new allocation"

--- a/server/state_store/src/lib.rs
+++ b/server/state_store/src/lib.rs
@@ -174,7 +174,7 @@ impl IndexifyState {
                     "invoke_compute_graph",
                     namespace = invoke_compute_graph_request.namespace.clone(),
                     invocation_id = invoke_compute_graph_request.invocation_payload.id.clone(),
-                    compute_graph = invoke_compute_graph_request.compute_graph_name.clone(),
+                    graph = invoke_compute_graph_request.compute_graph_name.clone(),
                 );
                 let state_changes = state_changes::invoke_compute_graph(
                     &self.last_state_change_id,


### PR DESCRIPTION
## Context

We've landed a few PRs that don't use the standard tag names; we should fix them.  This PR fixes #1547.

## What

Update logging tags to standard names

## Testing

`cargo test --workspace -- --test-threads 1`

## Contribution Checklist

- [ ] If a Python package was changed, please run `make fmt` in the package directory.
- [X] If the server was changed, please run `make fmt` in `server/`.
- [ ] Make sure all PR Checks are passing.
