### PR TITLE
Change frequent Server info logs to debug

### DIFF
--- a/server/processor/src/function_executor_manager.rs
+++ b/server/processor/src/function_executor_manager.rs
@@ -20,7 +20,7 @@ use state_store::{
     in_memory_state::InMemoryState,
     requests::{RequestPayload, SchedulerUpdateRequest},
 };
-use tracing::{error, info, info_span};
+use tracing::{debug, error, info, info_span};
 
 pub struct FunctionExecutorManager {
     clock: u64,
@@ -47,7 +47,7 @@ impl FunctionExecutorManager {
         let function_executors_to_mark =
             in_memory_state.vacuum_function_executors_candidates(fe_resource)?;
 
-        info!(
+        debug!(
             "vacuum phase identified {} function executors to mark for termination",
             function_executors_to_mark.len(),
         );
@@ -93,7 +93,7 @@ impl FunctionExecutorManager {
         let mut update = SchedulerUpdateRequest::default();
         let mut candidates = in_memory_state.candidate_executors(task)?;
         if candidates.is_empty() {
-            info!("no candidates found for task, running vacuum");
+            debug!("no candidates found for task, running vacuum");
             let fe_resource = in_memory_state.fe_resource_for_task(&task)?;
             let vacuum_update = self.vacuum(in_memory_state, &fe_resource)?;
             update.extend(vacuum_update);
@@ -104,7 +104,7 @@ impl FunctionExecutorManager {
             )?;
             candidates = in_memory_state.candidate_executors(task)?;
         }
-        info!(
+        debug!(
             "found {} candidates for creating function executor",
             candidates.len()
         );
@@ -442,7 +442,7 @@ impl FunctionExecutorManager {
         if function_executors.function_executors.is_empty() &&
             function_executors.num_pending_function_executors == 0
         {
-            info!("no function executors found for task, creating one");
+            debug!("no function executors found for task, creating one");
             let fe_update = self.create_function_executor(in_memory_state, task)?;
             update.extend(fe_update);
             in_memory_state.update_state(
@@ -454,7 +454,7 @@ impl FunctionExecutorManager {
                 in_memory_state.candidate_function_executors(task, self.queue_size)?;
         }
 
-        info!(
+        debug!(
             num_function_executors = function_executors.function_executors.len(),
             num_pending_function_executors = function_executors.num_pending_function_executors,
             "found function executors for task",

--- a/server/src/executors.rs
+++ b/server/src/executors.rs
@@ -20,7 +20,7 @@ use tokio::{
     sync::{watch, Mutex, RwLock},
     time::Instant,
 };
-use tracing::{error, info, trace};
+use tracing::{debug, error, trace};
 
 use crate::{
     executor_api::{
@@ -232,7 +232,7 @@ impl ExecutorManager {
         };
 
         if should_update {
-            info!(
+            debug!(
                 executor_id = executor.id.get(),
                 state_hash = executor.state_hash,
                 clock = executor.clock,


### PR DESCRIPTION
These are logs running on each Server scheduling iteration for not allocated tasks. This results in large log volumes. We still log all important events that are not tied to Server scheduling iterations at info logs. These events are FE creation, FE termination decisions.

Also don't log Executor state updates as these result in large log volumes and don't seem to have much value. We can figure out Executor state changes from Executor logs.