### PR TITLE
Consolidate task retry policy logic

### DIFF
--- a/server/data_model/src/lib.rs
+++ b/server/data_model/src/lib.rs
@@ -1712,18 +1712,37 @@ pub enum FunctionExecutorTerminationReason {
     ExecutorRemoved,
 }
 
-impl FunctionExecutorTerminationReason {
-    pub fn should_count_against_task_retry_attempts(self) -> bool {
-        matches!(
-            self,
-            Self::StartupFailedInternalError |
-                Self::StartupFailedFunctionError |
-                Self::StartupFailedFunctionTimeout |
-                Self::Unhealthy |
-                Self::InternalError |
-                Self::FunctionError |
-                Self::FunctionTimeout
-        )
+impl From<FunctionExecutorTerminationReason> for TaskFailureReason {
+    fn from(reason: FunctionExecutorTerminationReason) -> Self {
+        match reason {
+            FunctionExecutorTerminationReason::Unknown => {
+                TaskFailureReason::FunctionExecutorTerminated
+            }
+            FunctionExecutorTerminationReason::StartupFailedInternalError => {
+                TaskFailureReason::InternalError
+            }
+            FunctionExecutorTerminationReason::StartupFailedFunctionError => {
+                TaskFailureReason::FunctionError
+            }
+            FunctionExecutorTerminationReason::StartupFailedFunctionTimeout => {
+                TaskFailureReason::FunctionTimeout
+            }
+            FunctionExecutorTerminationReason::Unhealthy => TaskFailureReason::FunctionTimeout,
+            FunctionExecutorTerminationReason::InternalError => TaskFailureReason::InternalError,
+            FunctionExecutorTerminationReason::FunctionError => TaskFailureReason::FunctionError,
+            FunctionExecutorTerminationReason::FunctionTimeout => {
+                TaskFailureReason::FunctionTimeout
+            }
+            FunctionExecutorTerminationReason::FunctionCancelled => {
+                TaskFailureReason::TaskCancelled
+            }
+            FunctionExecutorTerminationReason::DesiredStateRemoved => {
+                TaskFailureReason::FunctionExecutorTerminated
+            }
+            FunctionExecutorTerminationReason::ExecutorRemoved => {
+                TaskFailureReason::FunctionExecutorTerminated
+            }
+        }
     }
 }
 

--- a/server/processor/src/lib.rs
+++ b/server/processor/src/lib.rs
@@ -4,4 +4,5 @@ pub mod graph_processor;
 pub mod task_allocator;
 pub mod task_cache;
 pub mod task_creator;
+pub mod task_policy;
 pub mod task_scheduler;

--- a/server/processor/src/task_policy.rs
+++ b/server/processor/src/task_policy.rs
@@ -1,0 +1,78 @@
+use data_model::{ComputeGraphVersion, Task, TaskFailureReason, TaskOutcome, TaskStatus};
+use if_chain::if_chain;
+
+/// Determines task retry policy based on failure reasons and retry
+/// configuration
+pub struct TaskRetryPolicy;
+
+impl TaskRetryPolicy {
+    /// Determines if a task should be retried based on a function executor
+    /// termination, updating the task accordingly
+    pub fn handle_function_executor_termination(
+        task: &mut Task,
+        task_failure_reason: TaskFailureReason,
+        failed_alloc_ids: &[String],
+        alloc_id: &str,
+        compute_graph_version: &ComputeGraphVersion,
+    ) {
+        // Check if this allocation was blamed for the failure
+        if failed_alloc_ids.contains(&alloc_id.to_string()) {
+            // Use the standard allocation failure handling
+            Self::handle_allocation_failure(task, task_failure_reason, compute_graph_version);
+        } else {
+            // This allocation wasn't blamed for the failure, allow retry
+            task.status = TaskStatus::Pending;
+        }
+    }
+
+    /// Determines if a task should be retried based on an allocation failure
+    /// reason, updating the task accordingly
+    pub fn handle_allocation_failure(
+        task: &mut Task,
+        failure_reason: TaskFailureReason,
+        compute_graph_version: &ComputeGraphVersion,
+    ) {
+        let uses_attempt = failure_reason.should_count_against_task_retry_attempts();
+
+        if_chain! {
+            if let Some(max_retries) = compute_graph_version.task_max_retries(task);
+            if failure_reason.is_retriable();
+        if task.attempt_number < max_retries || !uses_attempt;
+            then {
+                // Task can be retried
+                task.status = TaskStatus::Pending;
+                if uses_attempt {
+                    task.attempt_number += 1;
+                }
+            }
+            else {
+                // Task cannot be retried - either no max retries, not retriable, or exhausted attempts.
+                task.status = TaskStatus::Completed;
+                task.outcome = TaskOutcome::Failure(failure_reason);
+            }
+        }
+    }
+
+    /// Determines if a task should be retried based on allocation
+    /// outcome, leaving the task with the appropriate status
+    pub fn handle_allocation_outcome(
+        task: &mut Task,
+        outcome: &TaskOutcome,
+        compute_graph_version: &ComputeGraphVersion,
+    ) {
+        match outcome {
+            TaskOutcome::Success => {
+                task.status = TaskStatus::Completed;
+                task.outcome = *outcome;
+            }
+            TaskOutcome::Failure(failure_reason) => {
+                // Handle allocation failure
+                Self::handle_allocation_failure(task, *failure_reason, compute_graph_version);
+            }
+            TaskOutcome::Unknown => {
+                // For unknown outcomes, set to pending to allow retry
+                task.status = TaskStatus::Pending;
+            }
+        }
+    }
+}

--- a/server/src/reconciliation_test.rs
+++ b/server/src/reconciliation_test.rs
@@ -237,7 +237,8 @@ mod tests {
         reason: FunctionExecutorTerminationReason,
         max_retries: u32,
     ) -> Result<()> {
-        assert!(reason.should_count_against_task_retry_attempts());
+        let task_failure_reason: data_model::TaskFailureReason = reason.into();
+        assert!(task_failure_reason.should_count_against_task_retry_attempts());
 
         let test_srv = testing::TestService::new().await?;
         let Service { indexify_state, .. } = test_srv.service.clone();
@@ -444,7 +445,8 @@ mod tests {
         reason: FunctionExecutorTerminationReason,
         max_retries: u32,
     ) -> Result<()> {
-        assert!(!reason.should_count_against_task_retry_attempts());
+        let task_failure_reason: data_model::TaskFailureReason = reason.into();
+        assert!(!task_failure_reason.should_count_against_task_retry_attempts());
 
         let test_srv = testing::TestService::new().await?;
         let Service { indexify_state, .. } = test_srv.service.clone();


### PR DESCRIPTION
## Context

Prior to this change, we had two copies of the task retry logic; that's at least one copy too many.

## What

This change consolidates the two copies of the task retry logic into a task_policy module.
Fixes #1536 

## Testing

`cargo test --workspace -- --test-threads 1`

## Contribution Checklist

- [ ] If a Python package was changed, please run `make fmt` in the package directory.
- [X] If the server was changed, please run `make fmt` in `server/`.
- [ ] Make sure all PR Checks are passing.
