### PR TITLE
Use total allocations for active_allocations_gauge

### DIFF
--- a/server/state_store/src/in_memory_state.rs
+++ b/server/state_store/src/in_memory_state.rs
@@ -31,7 +31,10 @@ use indexify_utils::{get_elapsed_time, TimeUnit};
 use metrics::low_latency_boundaries;
 use opentelemetry::{
     metrics::{Histogram, ObservableGauge},
+    Array,
     KeyValue,
+    StringValue,
+    Value,
 };
 use tokio::sync::RwLock;
 use tracing::{debug, error, warn};
@@ -249,35 +252,44 @@ impl InMemoryMetrics {
 
                     match allocations_by_executor {
                         Some(allocations_by_executor) => {
+                            let mut total_allocations = 0u64;
+                            let mut fn_uris = HashSet::new();
+
                             // Process the cloned data outside the lock scope
-                            for (executor_id, fn_map) in allocations_by_executor.iter() {
+                            for (_, fn_map) in allocations_by_executor.iter() {
                                 for (_, allocations) in fn_map.iter() {
                                     if allocations.is_empty() {
                                         continue;
                                     }
-                                    observer.observe(
-                                        allocations.len() as u64,
-                                        &[
-                                            KeyValue::new(
-                                                "executor_id",
-                                                executor_id.get().to_string(),
-                                            ),
-                                            KeyValue::new(
-                                                "fn_uri",
-                                                // Use the first allocation's function URI if
-                                                // available
-                                                // or fallback to the function executor's URI if
-                                                // available
-                                                allocations
-                                                    .iter()
-                                                    .next()
-                                                    .map(|a| a.fn_uri())
-                                                    .unwrap_or("unknown".to_string()),
-                                            ),
-                                        ],
-                                    );
+                                    total_allocations += allocations.len() as u64;
+
+                                    // Get the function URI from the first allocation
+                                    if let Some(allocation) = allocations.iter().next() {
+                                        fn_uris.insert(allocation.fn_uri());
+                                    }
                                 }
                             }
+
+                            let executor_ids: Vec<StringValue> = allocations_by_executor
+                                .keys()
+                                .map(|executor_id| StringValue::from(executor_id.get().to_string()))
+                                .collect();
+
+                            let fn_uris: Vec<StringValue> = fn_uris
+                                .into_iter()
+                                .map(|uri| StringValue::from(uri))
+                                .collect();
+
+                            observer.observe(
+                                total_allocations,
+                                &[
+                                    KeyValue::new(
+                                        "executor_ids",
+                                        Value::Array(Array::String(executor_ids)),
+                                    ),
+                                    KeyValue::new("fn_uris", Value::Array(Array::String(fn_uris))),
+                                ],
+                            );
                         }
                         None => {}
                     }


### PR DESCRIPTION
## Context

In the active_allocations_gauge computation, we're calling observe() for each executor; AFAICT, this causes us to effectively discard all but the last executor's information.

Fixes #1559 

## What

This change summarizes the information from the in-memory state, gathering the total number of allocations, and attaching attributes for the executors with allocations and the unique fn URIs being run.

## Testing

`cargo test --workspace -- --test-threads 1` -- this doesn't actually measure that the updated gauge is doing the right thing, though; AFAICT we'll need to run the server in dev (or at least against some opentelemetry server) to verify the fix.

## Contribution Checklist

- [ ] If a Python package was changed, please run `make fmt` in the package directory.
- [X] If the server was changed, please run `make fmt` in `server/`.
- [ ] Make sure all PR Checks are passing.
