### PR TITLE
ci: use Namespace GHA runners

### DIFF
--- a/.github/workflows/build_ecr_image.yaml
+++ b/.github/workflows/build_ecr_image.yaml
@@ -4,17 +4,17 @@ on:
   workflow_dispatch:
     inputs:
       environment:
-        description: "Environment to post the image to"
+        description: 'Environment to post the image to'
         required: true
         type: string
 
   workflow_call:
     inputs:
       environment:
-        description: "Environment to post the image to"
+        description: 'Environment to post the image to'
         required: true
         type: string
-        
+
 permissions:
   id-token: write
   contents: read
@@ -27,7 +27,7 @@ jobs:
   build-and-push:
     name: Build indexify server and push to ${{ inputs.environment }}
     environment: ${{ inputs.environment }}
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-rust-builder-amd64
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -38,16 +38,10 @@ jobs:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           role-session-name: github-actions-platform-api
           aws-region: ${{ secrets.AWS_REGION }}
-        
+
       - name: Login to Amazon ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
 
       - run: |
           docker buildx build --platform=linux/amd64 --push . -t ${{ steps.login-ecr.outputs.registry }}/indexify-server:${{ github.sha }} -t ${{ steps.login-ecr.outputs.registry }}/indexify-server:latest -f dockerfiles/Dockerfile.local

--- a/.github/workflows/publish_indexify_server.yaml
+++ b/.github/workflows/publish_indexify_server.yaml
@@ -51,7 +51,7 @@ jobs:
 
   create-release:
     name: Create GitHub Release
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-rust-builder-amd64
     needs:
       - build-release-packages
       - extract-version
@@ -171,7 +171,7 @@ jobs:
 
   build-and-push-docker-images:
     name: Build and Push Docker Images
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-rust-builder-amd64
     needs:
       - extract-version
       - create-release
@@ -179,8 +179,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -29,7 +29,7 @@ jobs:
 
   build_server:
     name: Build Indexify Server
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-rust-builder-amd64
     steps:
       - name: Install protobuf package
         run: sudo apt install -y protobuf-compiler


### PR DESCRIPTION
## Context

Now that we have a contract with Namespace Labs, we can utilize our concurrency capacity to build our images using Namespace's provided runners.

## What

Change every build job building any kind of Rust binary with our Rust builder profile. It is important we keep the Rust things separate from other builders due to how the cache volume in the Namespace works.

We can have a separate profile for Python things.