### PR TITLE
Add version tag to ECR builds.

### DIFF
--- a/.github/workflows/build_ecr_image.yaml
+++ b/.github/workflows/build_ecr_image.yaml
@@ -7,6 +7,10 @@ on:
         description: 'Environment to post the image to'
         required: true
         type: string
+      version:
+        description: 'Version tag to apply to image'
+        required: true
+        type: string
 
   workflow_call:
     inputs:
@@ -15,6 +19,11 @@ on:
         required: true
         type: string
 
+      version:
+        description: 'Version tag to apply to image'
+        required: true
+        type: string
+        
 permissions:
   id-token: write
   contents: read
@@ -44,4 +53,6 @@ jobs:
         uses: aws-actions/amazon-ecr-login@v2
 
       - run: |
-          docker buildx build --platform=linux/amd64 --push . -t ${{ steps.login-ecr.outputs.registry }}/indexify-server:${{ github.sha }} -t ${{ steps.login-ecr.outputs.registry }}/indexify-server:latest -f dockerfiles/Dockerfile.local
+          docker buildx build --platform=linux/amd64 --push . -t ${{ steps.login-ecr.outputs.registry }}/indexify-server:${{ github.sha }} -t ${{ steps.login-ecr.outputs.registry }}/indexify-server:latest -t ${{ steps.login-ecr.outputs.registry }}/indexify-server:$VERSION_TAG -t -f dockerfiles/Dockerfile.local
+        env:
+          VERSION_TAG: ${{inputs.version}}

--- a/.github/workflows/build_ecr_image.yaml
+++ b/.github/workflows/build_ecr_image.yaml
@@ -23,7 +23,7 @@ on:
         description: 'Version tag to apply to image'
         required: true
         type: string
-        
+
 permissions:
   id-token: write
   contents: read
@@ -53,6 +53,6 @@ jobs:
         uses: aws-actions/amazon-ecr-login@v2
 
       - run: |
-          docker buildx build --platform=linux/amd64 --push . -t ${{ steps.login-ecr.outputs.registry }}/indexify-server:${{ github.sha }} -t ${{ steps.login-ecr.outputs.registry }}/indexify-server:latest -t ${{ steps.login-ecr.outputs.registry }}/indexify-server:$VERSION_TAG -t -f dockerfiles/Dockerfile.local
+          docker buildx build --platform=linux/amd64 --push . -t ${{ steps.login-ecr.outputs.registry }}/indexify-server:${{ github.sha }} -t ${{ steps.login-ecr.outputs.registry }}/indexify-server:latest -t ${{ steps.login-ecr.outputs.registry }}/indexify-server:$VERSION_TAG -f dockerfiles/Dockerfile.local
         env:
           VERSION_TAG: ${{inputs.version}}

--- a/.github/workflows/build_ecr_image.yaml
+++ b/.github/workflows/build_ecr_image.yaml
@@ -55,4 +55,4 @@ jobs:
       - run: |
           docker buildx build --platform=linux/amd64 --push . -t ${{ steps.login-ecr.outputs.registry }}/indexify-server:${{ github.sha }} -t ${{ steps.login-ecr.outputs.registry }}/indexify-server:latest -t ${{ steps.login-ecr.outputs.registry }}/indexify-server:$VERSION_TAG -f dockerfiles/Dockerfile.local
         env:
-          VERSION_TAG: ${{inputs.version}}
+          VERSION_TAG: ${{ inputs.version }}

--- a/.github/workflows/build_on_merge.yaml
+++ b/.github/workflows/build_on_merge.yaml
@@ -11,6 +11,10 @@ permissions:
   contents: read
   pull-requests: write
 
+defaults:
+  run:
+    working-directory: ./server
+    
 jobs:
   extract-version:
     name: Extract Version Number

--- a/.github/workflows/build_on_merge.yaml
+++ b/.github/workflows/build_on_merge.yaml
@@ -12,14 +12,33 @@ permissions:
   pull-requests: write
 
 jobs:
+  extract-version:
+    name: Extract Version Number
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version_extraction.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: version_extraction
+        run:
+          echo "version=$(cargo metadata --format-version 1 | jq '.packages[] |
+          select(.name == "indexify-server") | .version' | xargs)" >>
+          "$GITHUB_OUTPUT"
+
   build_dev_ecr:
     uses: ./.github/workflows/build_ecr_image.yaml
     with: 
       environment: dev
+      version: ${{ needs.extract-version.outputs.version }}
     secrets: inherit
+    needs:
+      - extract-version
 
   build_prod_ecr:
     uses: ./.github/workflows/build_ecr_image.yaml
     with: 
       environment: prod
+      version: ${{ needs.extract-version.outputs.version }}
     secrets: inherit
+    needs:
+      - extract-version

--- a/.github/workflows/build_on_merge.yaml
+++ b/.github/workflows/build_on_merge.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - 'main'
-      - 'server-sse-stream-stable'
+      - 'tag-ecr-builds-with-version'
 
 permissions:
   id-token: write

--- a/statefulset-indexify-server-qauat.yaml
+++ b/statefulset-indexify-server-qauat.yaml
@@ -1,0 +1,133 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  creationTimestamp: "2025-05-28T17:21:39Z"
+  generation: 2
+  labels:
+    app.kubernetes.io/name: indexify-server-qauat
+  name: indexify-server-qauat
+  namespace: dev
+  resourceVersion: "25624701"
+  uid: 96ad2b44-792a-475f-9dc7-b8714bf6131f
+spec:
+  persistentVolumeClaimRetentionPolicy:
+    whenDeleted: Delete
+    whenScaled: Retain
+  podManagementPolicy: OrderedReady
+  replicas: 1
+  revisionHistoryLimit: 0
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: indexify-server-qauat
+  serviceName: indexify-server-qauat
+  template:
+    metadata:
+      annotations:
+        ad.datadoghq.com/indexify-server-qauat.checks: '{"openmetrics":{"instances":[{"collect_counters_with_distributions":true,"histogram_buckets_as_distributions":true,"metrics":[".*"],"namespace":"indexify","openmetrics_endpoint":"http://%%host%%:8900/metrics/service"}]}}'
+      labels:
+        app.kubernetes.io/name: indexify-server-qauat
+    spec:
+      automountServiceAccountToken: true
+      containers:
+        - args:
+            - infinity
+          command:
+            - sleep
+          env:
+            - name: RUST_LOG
+              value: info
+            - name: AWS_REGION
+              value: us-east-1
+            - name: RUST_BACKTRACE
+              value: full
+          image: 347620126581.dkr.ecr.us-east-1.amazonaws.com/indexify-server:9603d5566eb9c82518faa236dd37446e0a86bb84t
+          imagePullPolicy: Always
+          livenessProbe:
+            exec:
+              command:
+                - echo
+                - Please make a real liveness probe
+            failureThreshold: 3
+            initialDelaySeconds: 3
+            periodSeconds: 3
+            successThreshold: 1
+            timeoutSeconds: 1
+          name: indexify-server-qauat
+          ports:
+            - containerPort: 8900
+              name: http
+              protocol: TCP
+            - containerPort: 8901
+              name: grpc
+              protocol: TCP
+          readinessProbe:
+            exec:
+              command:
+                - echo
+                - Please make a real liveness probe
+            failureThreshold: 3
+            initialDelaySeconds: 3
+            periodSeconds: 3
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              memory: 8Gi
+            requests:
+              cpu: 250m
+              memory: 50Mi
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          volumeMounts:
+            - mountPath: /etc/indexify
+              mountPropagation: None
+              name: config
+            - mountPath: /data/indexify/state
+              mountPropagation: None
+              name: data
+      dnsPolicy: ClusterFirst
+      enableServiceLinks: true
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      serviceAccount: indexify-server-qauat
+      serviceAccountName: indexify-server-qauat
+      shareProcessNamespace: false
+      terminationGracePeriodSeconds: 30
+      volumes:
+        - configMap:
+            defaultMode: 420
+            items:
+              - key: config.yaml
+                path: config.yaml
+            name: indexify-server-qauat
+            optional: false
+          name: config
+  updateStrategy:
+    rollingUpdate:
+      partition: 0
+    type: RollingUpdate
+  volumeClaimTemplates:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
+        name: data
+        namespace: dev
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 10Gi
+        storageClassName: ebs-indexify
+        volumeMode: Filesystem
+      status:
+        phase: Pending
+status:
+  availableReplicas: 0
+  collisionCount: 0
+  currentRevision: indexify-server-qauat-59d448f789
+  observedGeneration: 2
+  replicas: 1
+  updateRevision: indexify-server-qauat-557d87779c
+  updatedReplicas: 1


### PR DESCRIPTION
## Context

This tags ECR builds with the version found in the Cargo.toml file. Makes operations easier by using meaningful version tags instead of commit hashes. 

## What

Tag indexify-server ECR builds with the server version.

## Testing

See GHA test run here: https://github.com/tensorlakeai/indexify/actions/runs/16177421662

## Contribution Checklist

- [ ] If a Python package was changed, please run `make fmt` in the package directory.
- [ ] If the server was changed, please run `make fmt` in `server/`.
- [ ] Make sure all PR Checks are passing.
<!--
Notes:

Tests of a Python package can be run manually. Start a Server and an Executor then
run `make test` in the Python package directory.

To test if changes to the server are backward compatible with the latest
release, label the PR with `ci_compat_test`. This might report failures
unrelated to your change if previous incompatible changes were pushed without
being released yet
-->
