### PR TITLE
Add processor debug log support

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -1578,6 +1578,7 @@ dependencies = [
  "tower-http",
  "tower-otel-http-metrics",
  "tracing",
+ "tracing-appender",
  "tracing-opentelemetry",
  "tracing-subscriber",
  "url",
@@ -3692,6 +3693,18 @@ dependencies = [
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-appender"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3566e8ce28cc0a3fe42519fc80e6b4c943cc4c8cef275620eb8dac2d3d4e06cf"
+dependencies = [
+ "crossbeam-channel",
+ "thiserror 1.0.69",
+ "time",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -81,6 +81,7 @@ opentelemetry-otlp = { version = "0.29.0", features = [
     "grpc-tonic",
 ] }
 tracing-opentelemetry = "0.30.0"
+tracing-appender = "0.2.3"
 dashmap = "6.1.0"
 tower-otel-http-metrics = { version = "0.15.0", features = ["axum"] }
 im = { version = "15.1.0" }
@@ -132,6 +133,7 @@ opentelemetry = { workspace = true }
 opentelemetry_sdk.workspace = true
 metrics = { workspace = true }
 tracing-opentelemetry = { workspace = true }
+tracing-appender = { workspace = true }
 opentelemetry-otlp = { workspace = true }
 axum-tracing-opentelemetry = { version = "0.28.0", features = [
     "tracing_level_info",

--- a/server/sample_config.yaml
+++ b/server/sample_config.yaml
@@ -1,8 +1,5 @@
 state_store_path: indexify_server_state 
 listen_addr: 0.0.0.0:8900
-blob_storage:
-  path: "s3://indexifyblobs"
-  dynamodb_table: kvs_cas_table 
 
 telemetry:
   enable_tracing: false
@@ -12,3 +9,5 @@ telemetry:
   endpoint: "http://localhost:4317"
   # Metrics export interval in seconds (defaults to 10 if not specified)
   metrics_interval: 5
+  # Optional path to write processor debug logs to a rotating file
+  processor_debug_log_file: "/tmp/indexify/processor.log"

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -77,6 +77,9 @@ pub struct TelemetryConfig {
     // Metrics export interval. Defaults to 10 seconds.
     #[serde(with = "duration_serde")]
     pub metrics_interval: Duration,
+    // Optional path to write processor debug logs to a rotating
+    // file.
+    pub processor_debug_log_file: Option<String>,
 }
 
 impl Default for TelemetryConfig {
@@ -86,6 +89,7 @@ impl Default for TelemetryConfig {
             enable_metrics: false,
             endpoint: None,
             metrics_interval: Duration::from_secs(10),
+            processor_debug_log_file: None,
         }
     }
 }


### PR DESCRIPTION
## Context

We recently turned down the verbosity of the logs we're sending to the collector, but we still want to save detailed scheduler logs locally for debugging purposes.

Fixes #1576 

## What

This change adds a processor module debug log option, with daily rotation.

## Testing

Ran the server; verified that it does not log below INFO to its stdout, but that it does log events DEBUG and lower in the processor module to the requested log file.

## Contribution Checklist

- [ ] If a Python package was changed, please run `make fmt` in the package directory.
- [X] If the server was changed, please run `make fmt` in `server/`.
- [ ] Make sure all PR Checks are passing.