### PR TITLE
Allow TOML config files

### DIFF
--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -39,7 +39,7 @@ tokio = { version = "1.45.1", features = ["full"] }
 once_cell = "1.21.3"
 itertools = "0.14.0"
 serde_yaml = "0.9.34"
-figment = { version = "0.10.19", features = ["yaml"] }
+figment = { version = "0.10.19", features = ["yaml", "toml"] }
 axum = { version = "0.8.4", features = ["multipart", "macros", "tokio"] }
 axum-server = "0.7.2"
 tempfile = "3.20.0"

--- a/server/sample_config.toml
+++ b/server/sample_config.toml
@@ -1,0 +1,17 @@
+state_store_path = "indexify_server_state"
+listen_addr = "0.0.0.0:8900"
+
+[telemetry]
+enable_tracing = false
+enable_metrics = false
+# Shared OTLP endpoint for both traces and metrics
+# If specified, both traces and metrics will be sent to this endpoint
+endpoint = "http://localhost:4317"
+# Metrics export interval in seconds (defaults to 10 if not specified)
+metrics_interval = 5
+# Optional path to write local logs to a rotating file
+local_log_file = "/tmp/indexify/local.log"
+
+# List of targets and their log levels for local logging
+[telemetry.local_log_targets]
+scheduler = "debug"


### PR DESCRIPTION
## Context

Our current configs are in YAML; given that serde-yaml is deprecated, it'd be useful to reduce our dependencies on YAML as a file format.

## What

This change lets us use .toml configs.

## Testing

Ran a local server with a TOML config, and verified that it was picking up settings from it.

## Contribution Checklist

- [ ] If a Python package was changed, please run `make fmt` in the package directory.
- [X] If the server was changed, please run `make fmt` in `server/`.
- [x] Make sure all PR Checks are passing.
