### PR TITLE
Tweak metrics exporter keys

### DIFF
--- a/server/sample_config.toml
+++ b/server/sample_config.toml
@@ -11,6 +11,9 @@ endpoint = "http://localhost:4317"
 metrics_interval = 5
 # Optional path to write local logs to a rotating file
 local_log_file = "/tmp/indexify/local.log"
+# Instance ID for this Indexify server instance
+# Used as a metric attribute "indexify.instance.id"
+instance_id = "indexify-server-1"
 
 # List of targets and their log levels for local logging
 [telemetry.local_log_targets]

--- a/server/sample_config.yaml
+++ b/server/sample_config.yaml
@@ -14,3 +14,6 @@ telemetry:
   # List of targets and their log levels for local logging
   local_log_targets:
     scheduler: "debug"
+  # Instance ID for this Indexify server instance
+  # Used as a metric attribute "indexify.instance.id"
+  instance_id: "indexify-server-1"

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -90,6 +90,9 @@ pub struct TelemetryConfig {
     // Format: {"target_name": "log_level"}, e.g., {"scheduler": "debug"}
     #[serde(default)]
     pub local_log_targets: std::collections::HashMap<String, String>,
+    // Instance ID for this Indexify server instance.
+    // Used as a metric attribute "indexify.instance.id".
+    pub instance_id: Option<String>,
 }
 
 impl Default for TelemetryConfig {
@@ -101,6 +104,7 @@ impl Default for TelemetryConfig {
             metrics_interval: Duration::from_secs(10),
             local_log_file: None,
             local_log_targets: std::collections::HashMap::new(),
+            instance_id: None,
         }
     }
 }

--- a/server/src/service.rs
+++ b/server/src/service.rs
@@ -47,8 +47,10 @@ impl Service {
         let config = Arc::new(config);
         init_provider(
             config.telemetry.enable_metrics,
-            config.telemetry.endpoint.clone(),
+            config.telemetry.endpoint.as_ref(),
             config.telemetry.metrics_interval,
+            config.telemetry.instance_id.as_ref(),
+            env!("CARGO_PKG_VERSION"),
         )?;
         let (shutdown_tx, shutdown_rx) = watch::channel(());
         let blob_storage = Arc::new(


### PR DESCRIPTION
## Context

Just a couple of tweaks @j3m7 asked for as we move to OTLP.

## What

This change gets the version right (pulling it from the main crate), adds `service.namespace`, and adds `indexify.instance.id`.

## Testing

None; we'll see how these new values work with the dev telemetry.

## Contribution Checklist

- [ ] If a Python package was changed, please run `make fmt` in the package directory.
- [X] If the server was changed, please run `make fmt` in `server/`.
- [ ] Make sure all PR Checks are passing.