### PR TITLE
Add MVP synthetic integration test

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,10 @@
+# Environment Integration Testing
+
+The tests here are a start at a comprehensive system integration test,
+to be run against a deployed Indexify environment via a GitHub action.
+
+Since these tests are not intended for normal system testing, they are
+omitted by default from pytest test discovery.
+
+To run these tests locally, use `pytest -m integration`.  It may be
+useful to override the options in `conftest.py`.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,121 @@
+import pytest
+import os
+import uuid
+import time
+import random
+import tensorlake
+from tensorlake import RemoteGraph, Graph
+from tensorlake.functions_sdk.graph_serialization import graph_code_dir_path
+from typing import Union
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--server-url",
+        action="store",
+        default="http://localhost:8900",
+        help="Server URL for remote graphs",
+    )
+    parser.addoption(
+        "--function-counts",
+        action="store",
+        default="3,5",
+        help="Comma-separated list of function counts for test graphs (e.g., '3,5,10')",
+    )
+    parser.addoption(
+        "--num-invocations",
+        action="store",
+        default="2",
+        help="Number of invocations to run per graph",
+    )
+    parser.addoption(
+        "--timeout",
+        action="store",
+        default="300",
+        help="Timeout in seconds for test completion (default: 300 = 5 minutes)",
+    )
+
+
+@pytest.fixture
+def server_url(request):
+    return request.config.getoption("--server-url")
+
+
+@pytest.fixture
+def tensorlake_client(server_url):
+    return tensorlake.TensorlakeClient(service_url=server_url)
+
+
+@pytest.fixture
+def function_counts(request):
+    """Parse function counts from command line argument"""
+    function_counts_str = request.config.getoption("--function-counts")
+    return [int(count.strip()) for count in function_counts_str.split(",")]
+
+
+@pytest.fixture
+def num_invocations(request):
+    """Get number of invocations from command line argument"""
+    return int(request.config.getoption("--num-invocations"))
+
+
+@pytest.fixture
+def timeout(request):
+    """Get timeout in seconds from command line argument"""
+    return int(request.config.getoption("--timeout"))
+
+
+@pytest.fixture
+def test_graphs(tensorlake_client, function_counts):
+    """Returns a list of graphs to run for testing"""
+    created_graph_names = []
+
+    def _create_graph(num_functions: int = 3, namespace: str = None):
+        print(f"Deploying synthetic test graph with {num_functions} functions")
+
+        # Generate UUID for version
+        version = str(uuid.uuid4())
+
+        tags = (
+            dict(tag.split(":") for tag in os.environ.get("DEPLOYMENT_TAGS").split(","))
+            if os.environ.get("DEPLOYMENT_TAGS")
+            else {
+                "hostname": os.uname().nodename,
+            }
+        )
+
+        # Import and create graph from separate file
+        from synthetic_test_graph import create_synthetic_test_graph
+
+        graph = create_synthetic_test_graph(
+            num_functions=num_functions, namespace=namespace
+        )
+
+        print(f"Deploying graph: {graph.name}")
+        remote_graph = RemoteGraph.deploy(
+            graph=graph,
+            code_dir_path=graph_code_dir_path(__file__),
+            client=tensorlake_client,
+        )
+
+        # Track created graph for cleanup
+        created_graph_names.append(graph.name)
+
+        return remote_graph
+
+    # Create graphs based on command line function counts
+    graphs = []
+    for i, num_functions in enumerate(function_counts):
+        namespace = f"ns{i+1}"
+        graph = _create_graph(num_functions=num_functions, namespace=namespace)
+        graphs.append(graph)
+
+    yield graphs
+
+    # Cleanup all created graphs
+    for remote_graph_name in created_graph_names:
+        try:
+            print(f"Deleting graph: {remote_graph_name}")
+            tensorlake_client.delete_compute_graph(remote_graph_name)
+        except Exception as e:
+            print(f"Warning: Failed to delete graph {remote_graph_name}: {e}")

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+junit_family=xunit2
+markers = integration: integration tests.
+addopts = -m 'not integration'

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,0 +1,2 @@
+pytest
+tensorlake

--- a/tests/synthetic_test_graph.py
+++ b/tests/synthetic_test_graph.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python
+
+import time
+import random
+import uuid
+from tensorlake import tensorlake_function, Graph
+from typing import List
+from pydantic import BaseModel
+
+
+class TestResult(BaseModel):
+    results: List[dict] = []
+    total_count: int = 0
+
+
+# Module-scoped compute functions
+@tensorlake_function()
+def generate_work_items(num_functions: int) -> List[dict]:
+    """Generate a list of work items - this will automatically fan out"""
+    print(f"generate_work_items{num_functions}")
+    return [{"id": i, "data": f"work_item_{i}"} for i in range(num_functions)]
+
+
+@tensorlake_function()
+def process_work_item(id: int, data: str) -> dict:
+    """Process each work item (this runs in parallel for each item in the list)"""
+    print(f"process_work_items")
+    # Random delay between 0.1 and 2.0 seconds
+    delay = random.uniform(0.1, 2.0)
+    time.sleep(delay)
+    return {"id": id, "data": data, "delay": delay, "completed_at": time.time()}
+
+
+@tensorlake_function(accumulate=TestResult)
+def collect_results(
+    accumulator: TestResult, id: int, data: str, delay: float, completed_at: float
+) -> TestResult:
+    """Accumulate all results"""
+    print(f"collect_results")
+    result = {"id": id, "data": data, "delay": delay, "completed_at": completed_at}
+    accumulator.results.append(result)
+    accumulator.total_count += 1
+    return accumulator
+
+
+def create_synthetic_test_graph(num_functions: int = 3, namespace: str = None):
+    """Create a synthetic test graph with fan-out behavior for testing"""
+
+    # Build the graph
+    version = str(uuid.uuid4())
+    graph_name = f"synthetic_test_graph_{num_functions}_{version}"
+    graph = Graph(
+        start_node=generate_work_items,
+        name=graph_name,
+        description=f"Synthetic test graph with {num_functions} functions",
+    )
+
+    # Set namespace if provided
+    if namespace:
+        graph.namespace = namespace
+
+    # Add edges
+    graph.add_edge(generate_work_items, process_work_item)
+    graph.add_edge(process_work_item, collect_results)
+
+    return graph

--- a/tests/test_synthetic_graphs.py
+++ b/tests/test_synthetic_graphs.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python
+
+import pytest
+import tensorlake
+import time
+from tensorlake.http_client import InvocationFinishedEvent
+import threading
+from collections import defaultdict
+from rich import print
+
+
+@pytest.mark.integration
+def test_synthetic_graph_workflow(
+    test_graphs, function_counts, num_invocations, timeout, record_testsuite_property
+):
+    # Get the list of graphs to test
+    graphs = test_graphs
+    expected_total_invocations = len(graphs) * num_invocations
+
+    # Start invocations using streaming API
+    print(
+        f"Starting {expected_total_invocations} parallel invocations ({num_invocations} per graph)..."
+    )
+    start_time = time.time()
+
+    # Track invocations and their completion
+    invocation_streams = []
+    completed_invocations = set()
+    results = {}
+    invocation_times = {}  # Track start and end times for each invocation
+
+    def stream_invocation(graph, num_functions, graph_index, invocation_index):
+        """Stream a single invocation and collect its events"""
+        try:
+            stream = graph.stream(block_until_done=True, num_functions=num_functions)
+            invocation_id = None
+
+            for event in stream:
+                if invocation_id is None:
+                    invocation_id = event.payload.invocation_id
+                    invocation_start_time = time.time()
+                    invocation_times[invocation_id] = {"start": invocation_start_time}
+                    print(
+                        f"Started invocation {len(invocation_streams)+1}/{expected_total_invocations} on graph{graph_index+1} (num_functions={num_functions}): {invocation_id}"
+                    )
+
+                # Print the event for tracing
+                print(f"[{invocation_id}] {event}")
+
+                # Check if this is an invocation finished event
+                if isinstance(event.payload, InvocationFinishedEvent):
+                    invocation_end_time = time.time()
+                    invocation_times[invocation_id]["end"] = invocation_end_time
+                    invocation_duration = (
+                        invocation_end_time - invocation_times[invocation_id]["start"]
+                    )
+                    print(
+                        f"Invocation {invocation_id} completed after {time.time() - start_time:.2f} seconds (duration: {invocation_duration:.2f}s)"
+                    )
+
+                    # Get the final result (returns list with TestResult object)
+                    result_list = graph.output(invocation_id, "collect_results")
+
+                    # Validate result structure
+                    assert result_list is not None
+                    assert len(result_list) == 1
+                    result = result_list[0]  # Extract the TestResult object
+                    assert hasattr(result, "results")
+                    assert hasattr(result, "total_count")
+
+                    results[invocation_id] = result
+                    completed_invocations.add(invocation_id)
+                    break
+
+        except Exception as e:
+            print(f"Error in invocation stream: {e}")
+            raise
+
+    # Start all invocations in parallel using threads
+    threads = []
+    for i, graph in enumerate(graphs):
+        num_functions = function_counts[i]
+        for j in range(num_invocations):
+            thread = threading.Thread(
+                target=stream_invocation, args=(graph, num_functions, i, j)
+            )
+            thread.start()
+            threads.append(thread)
+            invocation_streams.append(thread)
+
+    print(
+        f"All {expected_total_invocations} invocations started in {time.time() - start_time:.2f} seconds"
+    )
+
+    # Wait for all threads to complete or timeout
+    for thread in threads:
+        remaining_time = timeout - (time.time() - start_time)
+        if remaining_time > 0:
+            thread.join(timeout=remaining_time)
+        else:
+            break
+
+    total_time = time.time() - start_time
+    completed = len(completed_invocations)
+    print(f"All {completed} invocations completed in {total_time:.2f} seconds")
+
+    # Calculate invocation timing statistics
+    invocation_durations = []
+    for inv_id, times in invocation_times.items():
+        if "end" in times:
+            duration = times["end"] - times["start"]
+            invocation_durations.append(duration)
+
+    if invocation_durations:
+        min_time = min(invocation_durations)
+        max_time = max(invocation_durations)
+        avg_time = sum(invocation_durations) / len(invocation_durations)
+        parallelization_efficiency = sum(invocation_durations) / total_time
+
+        # Record properties for test suite reporting
+        record_testsuite_property("total_test_time", f"{total_time:.2f}")
+        record_testsuite_property("min_invocation_time", f"{min_time:.2f}")
+        record_testsuite_property("max_invocation_time", f"{max_time:.2f}")
+        record_testsuite_property("avg_invocation_time", f"{avg_time:.2f}")
+        record_testsuite_property(
+            "parallelization_efficiency", f"{parallelization_efficiency:.1f}"
+        )
+        record_testsuite_property("total_invocations", str(expected_total_invocations))
+        record_testsuite_property(
+            "function_counts", ",".join(map(str, function_counts))
+        )
+        record_testsuite_property("num_invocations_per_graph", str(num_invocations))
+
+        print(f"\n📊 Invocation Statistics:")
+        print(f"  Total test time: {total_time:.2f}s")
+        print(f"  Individual invocation times:")
+        print(f"    Min: {min_time:.2f}s")
+        print(f"    Max: {max_time:.2f}s")
+        print(f"    Avg: {avg_time:.2f}s")
+        print(f"  Parallelization efficiency: {parallelization_efficiency:.1f}x")
+
+    # Verify all completed
+    assert (
+        completed == expected_total_invocations
+    ), f"Only {completed} out of {expected_total_invocations} invocations completed"
+
+    # Verify results
+    assert len(results) == expected_total_invocations
+
+    # Dynamically check results for each function count
+    for expected_count in function_counts:
+        matching_results = [
+            r for r in results.values() if r.total_count == expected_count
+        ]
+        assert (
+            len(matching_results) == num_invocations
+        ), f"Expected {num_invocations} results with {expected_count} functions, got {len(matching_results)}"
+
+    print(
+        f"\n✅ All tests passed! Successfully ran {expected_total_invocations} parallel invocations across {len(graphs)} graphs with function counts: {function_counts}."
+    )


### PR DESCRIPTION
## Context

We want to have a comprehensive integration test we can run as an action against various deployment environments.

Fixes #1586 

## What

This change just adds the initial form of the integration test - it's relatively simplistic, but it drives the server through its state changes, it allows the caller to vary the load on the server, and it reports some useful test metrics; it should be sufficient for building the GHA.

## Testing

Ran it against a local server, and observed the generated xunit2 report.

## Contribution Checklist

- [ ] If a Python package was changed, please run `make fmt` in the package directory.
- [ ] If the server was changed, please run `make fmt` in `server/`.
- [ ] Make sure all PR Checks are passing.