### PR TITLE
Use correct IDs when removing FE

### DIFF
--- a/server/src/processor/function_executor_manager.rs
+++ b/server/src/processor/function_executor_manager.rs
@@ -297,7 +297,8 @@ impl FunctionExecutorManager {
                 namespace = fe.namespace,
                 graph = fe.compute_graph_name,
                 fn = fe.compute_fn_name,
-                executor_id = fe.id.get(),
+                executor_id = executor_server_metadata.executor_id.get(),
+                fn_executor_id = fe.id.get(),
                 fe_state = ?fe.state,
                 "Removing function executor from executor",
             );


### PR DESCRIPTION
## Context

Fixes #1596 

## What

Just tweaks the FE and executor IDs when removing an FE so that they show up correctly in logs

## Testing

`cargo b`

## Contribution Checklist

- [ ] If a Python package was changed, please run `make fmt` in the package directory.
- [X] If the server was changed, please run `make fmt` in `server/`.
- [ ] Make sure all PR Checks are passing.
