### PR TITLE
fix: postcss and brace-expansion versioning

### DIFF
--- a/server/ui/package-lock.json
+++ b/server/ui/package-lock.json
@@ -6444,9 +6444,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -8494,9 +8494,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.184",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.184.tgz",
-      "integrity": "sha512-zlaUk/wwnR/27FHNarzOtMgfxD1Q0/2Aby7PnURumQTal7yauqQ3c2HHcG/pjLFTvF3AWv44kMWyArVlfHeDlw==",
+      "version": "1.5.185",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.185.tgz",
+      "integrity": "sha512-dYOZfUk57hSMPePoIQ1fZWl1Fkj+OshhEVuPacNKWzC1efe56OsHY3l/jCfiAgIICOU3VgOIdoq7ahg7r7n6MQ==",
       "dev": true,
       "license": "ISC"
     },
@@ -14959,9 +14959,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.30",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.30.tgz",
-      "integrity": "sha512-7ZEao1g4kd68l97aWG/etQKPKq07us0ieSZ2TnFDk11i0ZfDW2AwKHYU8qv4MZKqN2fdBfg+7q0ES06UA73C1g==",
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
       "dev": true,
       "funding": [
         {
@@ -14979,9 +14979,9 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"

--- a/server/ui/package.json
+++ b/server/ui/package.json
@@ -40,12 +40,12 @@
     "web-vitals": "^2.1.4"
   },
   "overrides": {
-    "postcss": "<8.4.31",
-    "brace-expansion": "<=1.1.11",
+    "postcss": "^8.4.31",
+    "brace-expansion": "^1.1.11",
     "webpack-dev-server": "4.15.2"
   },
   "scripts": {
-    "start": "serve build --single",
+    "start": "serve build",
     "dev": "react-scripts start",
     "build": "cross-env NODE_ENV=production react-scripts build",
     "test": "react-scripts test",


### PR DESCRIPTION
- Update of "postcss" package, this is okay as we're not using its features (postcss). See vulnerability here https://github.com/tensorlakeai/indexify/security/dependabot/136
- Update of "brace-expansion" package. See vulnerability here https://github.com/tensorlakeai/indexify/security/dependabot/212
