### PR TITLE
Use report_executor_state for grpc channel health monitoring and recreate desired states stream if it's idle for 5 minutes

### DIFF
--- a/indexify/src/indexify/executor/executor.py
+++ b/indexify/src/indexify/executor/executor.py
@@ -69,7 +69,6 @@ class Executor:
         self._channel_manager = ChannelManager(
             server_address=grpc_server_addr,
             config_path=config_path,
-            health_checker=health_checker,
             logger=self._logger,
         )
         function_allowlist: List[FunctionURI] = parse_function_uris(function_uris)
@@ -80,6 +79,7 @@ class Executor:
             function_allowlist=function_allowlist,
             channel_manager=self._channel_manager,
             host_resources_provider=host_resources_provider,
+            health_checker=health_checker,
             logger=self._logger,
         )
         self._state_reporter.update_executor_status(

--- a/indexify/src/indexify/executor/metrics/state_reporter.py
+++ b/indexify/src/indexify/executor/metrics/state_reporter.py
@@ -6,11 +6,11 @@ metric_state_report_rpcs = prometheus_client.Counter(
     "state_report_rpcs",
     "Number of Executor state report RPCs to Server",
 )
-metric_state_report_errors = prometheus_client.Counter(
+metric_state_report_rpc_errors = prometheus_client.Counter(
     "state_report_rpc_errors",
     "Number of Executor state report RPC errors",
 )
-metric_state_report_latency: prometheus_client.Histogram = (
+metric_state_report_rpc_latency: prometheus_client.Histogram = (
     latency_metric_for_fast_operation(
         "state_report_rpc", "Executor state report rpc to Server"
     )

--- a/indexify/src/indexify/proto/executor_api.proto
+++ b/indexify/src/indexify/proto/executor_api.proto
@@ -288,7 +288,5 @@ service ExecutorAPI {
 
     // Called by Executor to open a stream of its desired states. When Server wants Executor to change something
     // it puts a message on the stream with the new desired state of the Executor.
-    //
-    // Deprecated HTTP API is used to download the serialized graph and task inputs.
     rpc get_desired_executor_states(GetDesiredExecutorStatesRequest) returns (stream DesiredExecutorState) {}
 }

--- a/indexify/src/indexify/proto/executor_api_pb2_grpc.py
+++ b/indexify/src/indexify/proto/executor_api_pb2_grpc.py
@@ -79,8 +79,6 @@ class ExecutorAPIServicer(object):
     def get_desired_executor_states(self, request, context):
         """Called by Executor to open a stream of its desired states. When Server wants Executor to change something
         it puts a message on the stream with the new desired state of the Executor.
-
-        Deprecated HTTP API is used to download the serialized graph and task inputs.
         """
         context.set_code(grpc.StatusCode.UNIMPLEMENTED)
         context.set_details("Method not implemented!")

--- a/server/proto/executor_api.proto
+++ b/server/proto/executor_api.proto
@@ -288,7 +288,5 @@ service ExecutorAPI {
 
     // Called by Executor to open a stream of its desired states. When Server wants Executor to change something
     // it puts a message on the stream with the new desired state of the Executor.
-    //
-    // Deprecated HTTP API is used to download the serialized graph and task inputs.
     rpc get_desired_executor_states(GetDesiredExecutorStatesRequest) returns (stream DesiredExecutorState) {}
 }


### PR DESCRIPTION
We can't rely on channel state reported by grpc client library
because it's incorrect if client doesn't get any data from network
e.g. on Server crashes or proxy/load balancers restarts/misbehaving.

Using report_executor_state as application level pings ensures that
we run the rpc on the channel end to end and all the network paths
on the way are examined for working correctly at the moment.

See example discussion:
https://github.com/grpc/grpc/issues/20861

Also recreate desired states stream if Executor didn't get any
desired state from Server for 5 minutes. This is because no
new desired state might be recieved by Executor due to network
disruption (e.g. a proxy didn't send RST TPC packet due to a
proxy outage). Recreating the stream if it's idle for 5 minutes
ensures that it's not idle due to a network disruption but
Server actually doesn't want to send anything.

I tested this with 5 sec timeout locally and it worked smoothly.