### PR TITLE
Update tensorlake and pin httpx version

### DIFF
--- a/indexify/poetry.lock
+++ b/indexify/poetry.lock
@@ -1738,14 +1738,14 @@ typing-extensions = {version = "*", markers = "python_version < \"3.11\""}
 
 [[package]]
 name = "tensorlake"
-version = "0.2.27"
+version = "0.2.28"
 description = "Tensorlake SDK for Document Ingestion API and Serverless Workflows"
 optional = false
 python-versions = "<4.0,>=3.10"
 groups = ["main"]
 files = [
-    {file = "tensorlake-0.2.27-py3-none-any.whl", hash = "sha256:23abe21706dc40a6cc8c7d6bb43adc0da6cfef7ad9fe6960409c5caddc9b101d"},
-    {file = "tensorlake-0.2.27.tar.gz", hash = "sha256:b65aed084360d8a3e50b464b0d8eec989e06881344b8a092e6627f3f33f38fa1"},
+    {file = "tensorlake-0.2.28-py3-none-any.whl", hash = "sha256:b34a5e42ec917c6c0fb9cea7006616143bde4a0c9334bfd0c6483ed042d61fed"},
+    {file = "tensorlake-0.2.28.tar.gz", hash = "sha256:80135d6c2ae84f7da18a19f83639fe2f5949cf69a1a99223a8f13e8b40d86448"},
 ]
 
 [package.dependencies]
@@ -1755,7 +1755,7 @@ cloudpickle = ">=3.1.0,<4.0.0"
 docker = ">=7.1.0,<8.0.0"
 grpcio = "1.73.1"
 grpcio-tools = "1.73.1"
-httpx = {version = "0.27.2", extras = ["http2"]}
+httpx = {version = ">=0.27.2,<1.0", extras = ["http2"]}
 httpx-sse = ">=0.4.1,<0.5.0"
 nanoid = ">=2.0.0,<3.0.0"
 pydantic = ">=2.0,<3.0"
@@ -2001,4 +2001,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "c02f06865689cc5018650b4a54481998ad35772d8cf0733d210f1afe141a79d6"
+content-hash = "09201f77b0a569118a8ef7d247d398bfe18844ae3535f5bd3b563197f6c8a422"

--- a/indexify/pyproject.toml
+++ b/indexify/pyproject.toml
@@ -17,19 +17,20 @@ indexify-cli = "indexify.cli:cli"
 python = "^3.10"
 # structlog is provided by tensorlake
 # pyyaml is provided by tensorlake
-# httpx is provided by tensorlake
 
 # Executor only
 aiohttp = "^3.12.14"
+# mTLS support for httpx 0.28.1 is broken, wait for 0.28.2 to see if the bug is fixed
+httpx = { version = "0.27.2", extras = ["http2"] }
+pydantic = "^2.11"
 prometheus-client = "^0.22.1"
 psutil = "^7.0.0"
 boto3 = "^1.39.8"
 # Adds function-executor binary, utils lib, sdk used in indexify-cli commands.
 # We need to specify the tensorlake version exactly because pip install doesn't respect poetry.lock files.
-tensorlake = "0.2.27"
+tensorlake = "0.2.28"
 # Uncomment the next line to use local tensorlake package (only for development!)
 # tensorlake = { path = "../tensorlake", develop = true }
-# pydantic is provided by tensorlake
 # grpcio is provided by tensorlake
 # grpcio-tools is provided by tensorlake
 

--- a/indexify/src/indexify/executor/host_resources/host_resources.py
+++ b/indexify/src/indexify/executor/host_resources/host_resources.py
@@ -1,13 +1,14 @@
+from dataclasses import dataclass
 from typing import Any, List, Optional
 
 import psutil
-from pydantic import BaseModel
 
 from .nvidia_gpu import NvidiaGPUInfo
 from .nvidia_gpu_allocator import NvidiaGPUAllocator
 
 
-class HostResources(BaseModel):
+@dataclass
+class HostResources:
     cpu_count: int
     memory_mb: int
     disk_mb: int

--- a/indexify/src/indexify/executor/host_resources/nvidia_gpu.py
+++ b/indexify/src/indexify/executor/host_resources/nvidia_gpu.py
@@ -1,8 +1,7 @@
 import subprocess
+from dataclasses import dataclass
 from enum import Enum
 from typing import Any, List
-
-from pydantic import BaseModel
 
 
 # Only NVIDIA GPUs currently supported in Tensorlake SDK are listed here.
@@ -17,7 +16,8 @@ class NVIDIA_GPU_MODEL(str, Enum):
     A10 = "A10"
 
 
-class NvidiaGPUInfo(BaseModel):
+@dataclass
+class NvidiaGPUInfo:
     index: str
     uuid: str
     product_name: str  # The official product name.


### PR DESCRIPTION
Tensorlake relaxes versioning requirements for httpx and
pydantic packages. We need to pin httpx and pydantic in indexify
to not get them updated without us knowing about that.

Also remove code that uses pydantic in Executor where we don't
serilize anything.

This is complementary to https://github.com/tensorlakeai/tensorlake/pull/262