### PR TITLE
V1 routes

### DIFF
--- a/indexify/src/indexify/cli/deploy.py
+++ b/indexify/src/indexify/cli/deploy.py
@@ -5,7 +5,7 @@ from tensorlake.functions_sdk.workflow_module import (
     WorkflowModuleInfo,
     load_workflow_module_info,
 )
-from tensorlake.functions_sdk.remote_graph import RemoteGraph
+from tensorlake.remote_graph import RemoteGraph
 
 
 @click.command(

--- a/indexify/src/indexify/cli/deploy.py
+++ b/indexify/src/indexify/cli/deploy.py
@@ -5,7 +5,7 @@ from tensorlake.functions_sdk.workflow_module import (
     WorkflowModuleInfo,
     load_workflow_module_info,
 )
-from tensorlake.remote_graph import RemoteGraph
+from tensorlake.functions_sdk.remote_graph import RemoteGraph
 
 
 @click.command(

--- a/server/src/data_model/mod.rs
+++ b/server/src/data_model/mod.rs
@@ -420,8 +420,6 @@ pub struct ComputeGraph {
     pub description: String,
     #[serde(default)]
     pub tags: HashMap<String, String>,
-    #[serde(default)]
-    pub replaying: bool,
     pub created_at: u64,
     // Fields below are versioned. The version field is currently managed manually by users
     pub version: GraphVersion,
@@ -2214,7 +2212,6 @@ mod tests {
                 minor_version: 10,
                 sdk_version: "1.2.3".to_string(),
             },
-            replaying: false,
         };
 
         struct TestCase {
@@ -2253,7 +2250,6 @@ mod tests {
                     name: "graph2".to_string(),                  // different
                     version: crate::data_model::GraphVersion::from("100"),   // different
                     created_at: 10,                              // different
-                    replaying: true,                             // different
                     ..original_graph.clone()
                 },
                 expected_graph: ComputeGraph {

--- a/server/src/data_model/test_objects.rs
+++ b/server/src/data_model/test_objects.rs
@@ -146,7 +146,6 @@ pub mod tests {
                 minor_version: 10,
                 sdk_version: "1.2.3".to_string(),
             },
-            replaying: false,
         }
     }
 

--- a/server/src/http_objects.rs
+++ b/server/src/http_objects.rs
@@ -840,7 +840,7 @@ pub struct FnOutputs {
 }
 
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
-pub struct InvocationId {
+pub struct RequestId {
     pub id: String,
 }
 

--- a/server/src/http_objects.rs
+++ b/server/src/http_objects.rs
@@ -159,37 +159,37 @@ impl From<data_model::ImageInformation> for ImageInformation {
 }
 
 #[derive(Debug, Serialize, Deserialize, ToSchema, Clone)]
-pub struct NodeTimeoutSeconds(pub u32);
+pub struct TimeoutSeconds(pub u32);
 
-impl NodeTimeoutSeconds {
+impl TimeoutSeconds {
     fn validate(&self) -> Result<(), IndexifyAPIError> {
         if self.0 == 0 {
             return Err(IndexifyAPIError::bad_request(
-                "Node timeout must be greater than 0",
+                "timeout must be greater than 0",
             ));
         }
         if self.0 > 24 * 60 * 60 {
             return Err(IndexifyAPIError::bad_request(
-                "Node timeout must be less than or equal 24 hours",
+                "timeout must be less than or equal 24 hours",
             ));
         }
         Ok(())
     }
 }
 
-impl From<NodeTimeoutSeconds> for data_model::NodeTimeoutMS {
-    fn from(value: NodeTimeoutSeconds) -> Self {
+impl From<TimeoutSeconds> for data_model::NodeTimeoutMS {
+    fn from(value: TimeoutSeconds) -> Self {
         data_model::NodeTimeoutMS(value.0 * 1000)
     }
 }
 
-impl From<data_model::NodeTimeoutMS> for NodeTimeoutSeconds {
-    fn from(value: data_model::NodeTimeoutMS) -> NodeTimeoutSeconds {
-        NodeTimeoutSeconds(value.0 / 1000)
+impl From<data_model::NodeTimeoutMS> for TimeoutSeconds {
+    fn from(value: data_model::NodeTimeoutMS) -> TimeoutSeconds {
+        TimeoutSeconds(value.0 / 1000)
     }
 }
 
-impl Default for NodeTimeoutSeconds {
+impl Default for TimeoutSeconds {
     fn default() -> Self {
         data_model::NodeTimeoutMS::default().into()
     }
@@ -417,7 +417,7 @@ pub struct ComputeFn {
     #[serde(default)]
     pub secret_names: Vec<String>,
     #[serde(default, rename = "timeout_sec")]
-    pub timeout: NodeTimeoutSeconds,
+    pub timeout: TimeoutSeconds,
     #[serde(default)]
     pub resources: NodeResources,
     #[serde(default)]
@@ -528,8 +528,6 @@ pub struct ComputeGraph {
     #[serde(default = "get_epoch_time_in_ms")]
     pub created_at: u64,
     pub runtime_information: RuntimeInformation,
-    #[serde(skip_deserializing)]
-    pub replaying: bool,
 }
 
 impl ComputeGraph {
@@ -563,7 +561,6 @@ impl ComputeGraph {
             edges: self.edges.clone(),
             created_at: 0,
             runtime_information: self.runtime_information.into(),
-            replaying: false,
             tombstoned: self.tombstoned,
         };
         Ok(compute_graph)
@@ -588,7 +585,6 @@ impl From<data_model::ComputeGraph> for ComputeGraph {
             edges: compute_graph.edges,
             created_at: compute_graph.created_at,
             runtime_information: compute_graph.runtime_information.into(),
-            replaying: compute_graph.replaying,
             tombstoned: compute_graph.tombstoned,
         }
     }
@@ -729,7 +725,7 @@ pub struct Task {
     pub input_payload: Option<DataPayload>,
     pub reducer_input_payload: Option<DataPayload>,
     pub output_payload_uri_prefix: Option<String>,
-    pub timeout: NodeTimeoutSeconds,
+    pub timeout: TimeoutSeconds,
     pub resources: NodeResources,
     pub retry_policy: NodeRetryPolicy,
     pub allocations: Vec<Allocation>,
@@ -827,7 +823,7 @@ impl From<GraphInvocationFailureReason> for InvocationFailureReason {
 }
 
 #[derive(Debug, Serialize, Deserialize, ToSchema, Clone)]
-pub struct InvocationError {
+pub struct RequestError {
     pub function_name: String,
     pub message: String,
 }
@@ -859,7 +855,7 @@ pub struct Invocation {
     pub task_analytics: HashMap<String, TaskAnalytics>,
     pub graph_version: String,
     pub created_at: u64,
-    pub invocation_error: Option<InvocationError>,
+    pub invocation_error: Option<RequestError>,
 }
 
 impl From<GraphInvocationCtx> for Invocation {
@@ -1139,7 +1135,7 @@ pub struct ExecutorsAllocationsResponse {
 }
 
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
-pub struct InvocationQueryParams {
+pub struct RequestQueryParams {
     pub block_until_finish: Option<bool>,
 }
 

--- a/server/src/http_objects_v1.rs
+++ b/server/src/http_objects_v1.rs
@@ -1,0 +1,330 @@
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
+use crate::{
+    config::ExecutorConfig,
+    data_model::{
+        self,
+        ComputeGraphCode,
+        GraphInvocationCtx,
+        GraphInvocationFailureReason,
+        GraphInvocationOutcome,
+    },
+    http_objects::{
+        self,
+        ComputeFn,
+        GraphVersion,
+        IndexifyAPIError,
+        RequestError,
+        TaskOutcome,
+        TaskStatus,
+    },
+    utils::get_epoch_time_in_ms,
+};
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct ComputeGraph {
+    pub name: String,
+    pub namespace: String,
+    pub description: String,
+    #[serde(default)]
+    pub tombstoned: bool,
+    pub entrypoint: ComputeFn,
+    pub version: GraphVersion,
+    #[serde(default)]
+    pub tags: Option<HashMap<String, String>>,
+    pub functions: HashMap<String, ComputeFn>,
+    pub edges: HashMap<String, Vec<String>>,
+    #[serde(default = "get_epoch_time_in_ms")]
+    pub created_at: u64,
+    pub runtime_information: http_objects::RuntimeInformation,
+}
+
+impl ComputeGraph {
+    pub fn into_data_model(
+        self,
+        code_path: &str,
+        sha256_hash: &str,
+        size: u64,
+        executor_config: &ExecutorConfig,
+    ) -> Result<data_model::ComputeGraph, IndexifyAPIError> {
+        let mut nodes = HashMap::new();
+        for (name, node) in self.functions {
+            node.validate(executor_config)?;
+            nodes.insert(name, node.into());
+        }
+        let start_fn: data_model::ComputeFn = self.entrypoint.into();
+
+        let compute_graph = data_model::ComputeGraph {
+            name: self.name,
+            namespace: self.namespace,
+            description: self.description,
+            start_fn,
+            tags: self.tags.unwrap_or_default(),
+            version: self.version.into(),
+            code: ComputeGraphCode {
+                sha256_hash: sha256_hash.to_string(),
+                size,
+                path: code_path.to_string(),
+            },
+            nodes,
+            edges: self.edges.clone(),
+            created_at: 0,
+            runtime_information: self.runtime_information.into(),
+            tombstoned: self.tombstoned,
+        };
+        Ok(compute_graph)
+    }
+}
+
+impl From<data_model::ComputeGraph> for ComputeGraph {
+    fn from(compute_graph: data_model::ComputeGraph) -> Self {
+        let start_fn = compute_graph.start_fn.into();
+        let mut nodes = HashMap::new();
+        for (k, v) in compute_graph.nodes.into_iter() {
+            nodes.insert(k, v.into());
+        }
+        Self {
+            name: compute_graph.name,
+            namespace: compute_graph.namespace,
+            description: compute_graph.description,
+            entrypoint: start_fn,
+            tags: Some(compute_graph.tags),
+            version: compute_graph.version.into(),
+            functions: nodes,
+            edges: compute_graph.edges,
+            created_at: compute_graph.created_at,
+            runtime_information: compute_graph.runtime_information.into(),
+            tombstoned: compute_graph.tombstoned,
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct ComputeGraphsList {
+    pub compute_graphs: Vec<ComputeGraph>,
+    pub cursor: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct ShallowGraphRequest {
+    pub id: String,
+    pub created_at: u64,
+    pub completed: bool,
+    pub outcome: RequestOutcome,
+}
+
+impl From<GraphInvocationCtx> for ShallowGraphRequest {
+    fn from(ctx: GraphInvocationCtx) -> Self {
+        Self {
+            id: ctx.invocation_id.to_string(),
+            created_at: ctx.created_at,
+            completed: ctx.completed,
+            outcome: ctx.outcome.into(),
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct GraphRequests {
+    pub requests: Vec<ShallowGraphRequest>,
+    pub prev_cursor: Option<String>,
+    pub next_cursor: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct Task {
+    pub id: String,
+    pub status: TaskStatus,
+    pub outcome: TaskOutcome,
+    pub graph_version: GraphVersion,
+    pub allocations: Vec<Allocation>,
+    pub creation_time_ns: u128,
+}
+
+impl Task {
+    pub fn from_data_model_task(task: data_model::Task, allocations: Vec<Allocation>) -> Self {
+        Self {
+            id: task.id.to_string(),
+            outcome: task.outcome.into(),
+            status: task.status.into(),
+            graph_version: task.graph_version.into(),
+            allocations,
+            creation_time_ns: task.creation_time_ns,
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct Tasks {
+    pub tasks: Vec<Task>,
+    pub cursor: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema, Clone)]
+pub enum RequestStatus {
+    Pending,
+    Running,
+    Finalized,
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema, Clone)]
+pub enum RequestOutcome {
+    Undefined,
+    Success,
+    Failure,
+}
+
+impl From<GraphInvocationOutcome> for RequestOutcome {
+    fn from(outcome: GraphInvocationOutcome) -> Self {
+        match outcome {
+            GraphInvocationOutcome::Unknown => RequestOutcome::Undefined,
+            GraphInvocationOutcome::Success => RequestOutcome::Success,
+            GraphInvocationOutcome::Failure(_) => RequestOutcome::Failure,
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema, Clone)]
+pub enum RequestFailureReason {
+    Unknown,
+    InternalError,
+    FunctionError,
+    InvocationError,
+    NextFunctionNotFound,
+}
+
+impl From<GraphInvocationFailureReason> for RequestFailureReason {
+    fn from(failure_reason: GraphInvocationFailureReason) -> Self {
+        match failure_reason {
+            GraphInvocationFailureReason::Unknown => RequestFailureReason::Unknown,
+            GraphInvocationFailureReason::InternalError => RequestFailureReason::InternalError,
+            GraphInvocationFailureReason::FunctionError => RequestFailureReason::FunctionError,
+            GraphInvocationFailureReason::InvocationError => RequestFailureReason::InvocationError,
+            GraphInvocationFailureReason::NextFunctionNotFound => {
+                RequestFailureReason::NextFunctionNotFound
+            }
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema, Clone)]
+pub struct FnOutput {
+    pub id: String,
+    pub num_outputs: u64,
+    pub compute_fn: String,
+    pub created_at: u64,
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema, Clone)]
+pub struct Request {
+    pub id: String,
+    pub completed: bool,
+    pub status: RequestStatus,
+    pub outcome: RequestOutcome,
+    pub failure_reason: RequestFailureReason,
+    pub outstanding_tasks: u64,
+    pub task_analytics: HashMap<String, TaskAnalytics>,
+    pub graph_version: String,
+    pub created_at: u64,
+    pub invocation_error: Option<RequestError>,
+    pub outputs: Vec<FnOutput>,
+}
+
+impl Request {
+    pub fn build(
+        ctx: GraphInvocationCtx,
+        outputs: Vec<FnOutput>,
+        invocation_error: Option<RequestError>,
+    ) -> Self {
+        let mut task_analytics = HashMap::new();
+        for (k, v) in ctx.fn_task_analytics {
+            task_analytics.insert(
+                k,
+                TaskAnalytics {
+                    pending_tasks: v.pending_tasks,
+                    successful_tasks: v.successful_tasks,
+                    failed_tasks: v.failed_tasks,
+                },
+            );
+        }
+        let status = if ctx.completed {
+            RequestStatus::Finalized
+        } else if ctx.outstanding_tasks > 0 {
+            RequestStatus::Running
+        } else {
+            RequestStatus::Pending
+        };
+        Self {
+            id: ctx.invocation_id.to_string(),
+            completed: ctx.completed,
+            outcome: ctx.outcome.clone().into(),
+            failure_reason: match &ctx.outcome {
+                GraphInvocationOutcome::Failure(reason) => reason.clone().into(),
+                _ => GraphInvocationFailureReason::Unknown.into(),
+            },
+            status,
+            outstanding_tasks: ctx.outstanding_tasks,
+            task_analytics,
+            graph_version: ctx.graph_version.0,
+            created_at: ctx.created_at,
+            invocation_error,
+            outputs,
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema, Clone)]
+pub struct TaskAnalytics {
+    pub pending_tasks: u64,
+    pub successful_tasks: u64,
+    pub failed_tasks: u64,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, ToSchema)]
+pub struct Allocation {
+    pub id: String,
+    pub executor_id: String,
+    pub function_executor_id: String,
+    pub created_at: u128,
+    pub outcome: TaskOutcome,
+    pub attempt_number: u32,
+}
+
+impl From<data_model::Allocation> for Allocation {
+    fn from(allocation: data_model::Allocation) -> Self {
+        Self {
+            id: allocation.id.to_string(),
+            executor_id: allocation.target.executor_id.to_string(),
+            function_executor_id: allocation.target.function_executor_id.get().to_string(),
+            created_at: allocation.created_at,
+            outcome: allocation.outcome.into(),
+            attempt_number: allocation.attempt_number,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::http_objects::ComputeFn;
+
+    #[test]
+    fn test_compute_graph_deserialization() {
+        // Don't delete this. It makes it easier
+        // to test the deserialization of the ComputeGraph struct
+        // from the python side
+        let json = r#"{"name":"test","description":"test","entrypoint":{"name":"extractor_a","fn_name":"extractor_a","description":"Random description of extractor_a", "reducer": false,  "image_information": {"image_name": "name1", "tag": "tag1", "base_image": "base1", "run_strs": ["tuff", "life", "running", "docker"], "sdk_version":"1.2.3"}, "input_encoder":"cloudpickle", "output_encoder":"cloudpickle", "image_name": "default_image"},"functions":{"extractor_a":{"name":"extractor_a","fn_name":"extractor_a","description":"Random description of extractor_a", "reducer": false,  "image_information": {"image_name": "name1", "tag": "tag1", "base_image": "base1", "run_strs": ["tuff", "life", "running", "docker"], "sdk_version":"1.2.3"}, "input_encoder":"cloudpickle", "output_encoder":"cloudpickle","image_name": "default_image"},"extractor_b":{"name":"extractor_b","fn_name":"extractor_b","description":"", "reducer": false,  "image_information": {"image_name": "name1", "tag": "tag1", "base_image": "base1", "run_strs": ["tuff", "life", "running", "docker"], "sdk_version":"1.2.3"}, "input_encoder":"cloudpickle", "output_encoder":"cloudpickle", "image_name": "default_image"},"extractor_c":{"name":"extractor_c","fn_name":"extractor_c","description":"", "reducer": false,  "image_information": {"image_name": "name1", "tag": "tag1", "base_image": "base1", "run_strs": ["tuff", "life", "running", "docker"], "sdk_version":"1.2.3"}, "input_encoder":"cloudpickle", "output_encoder":"cloudpickle", "image_name": "default_image"}},"edges":{"extractor_a":["extractor_b"],"extractor_b":["extractor_c"]},"runtime_information": {"major_version": 3, "minor_version": 10, "sdk_version": "1.2.3"}, "version": "1.2.3"}"#;
+        let mut json_value: serde_json::Value = serde_json::from_str(json).unwrap();
+        json_value["namespace"] = serde_json::Value::String("test".to_string());
+        let _: super::ComputeGraph = serde_json::from_value(json_value).unwrap();
+    }
+
+    #[test]
+    fn test_compute_fn_deserialization() {
+        let json = r#"{"name": "one", "fn_name": "two", "description": "desc", "reducer": true, "image_name": "im1", "image_information": {"image_name": "name1", "tag": "tag1", "base_image": "base1", "run_strs": ["tuff", "life", "running", "docker"], "sdk_version":"1.2.3"}, "input_encoder": "cloudpickle", "output_encoder":"cloudpickle"}"#;
+        let compute_fn: ComputeFn = serde_json::from_str(json).unwrap();
+        println!("{:?}", compute_fn);
+    }
+}

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -30,6 +30,7 @@ mod executor_api;
 mod executors;
 mod gc_test;
 mod http_objects;
+mod http_objects_v1;
 mod indexify_ui;
 mod integration_test;
 mod metrics;
@@ -37,6 +38,8 @@ mod openapi;
 mod processor;
 mod reconciliation_test;
 mod routes;
+mod routes_internal;
+mod routes_v1;
 mod service;
 mod state_store;
 mod utils;
@@ -176,10 +179,12 @@ async fn main() {
     };
 
     if cli.gen_cloud_openapi {
-        let api_docs_yaml = routes::ApiDoc::openapi().to_yaml().unwrap_or_else(|err| {
-            eprintln!("Failed to generate OpenAPI spec: {}", err);
-            std::process::exit(1);
-        });
+        let api_docs_yaml = routes_internal::ApiDoc::openapi()
+            .to_yaml()
+            .unwrap_or_else(|err| {
+                eprintln!("Failed to generate OpenAPI spec: {}", err);
+                std::process::exit(1);
+            });
 
         openapi::generate_cloud_openapi(api_docs_yaml);
         std::process::exit(0);

--- a/server/src/processor/function_executor_manager.rs
+++ b/server/src/processor/function_executor_manager.rs
@@ -1,7 +1,7 @@
 use anyhow::{anyhow, Result};
 use if_chain::if_chain;
 use rand::seq::IndexedRandom;
-use tracing::{debug, error, info, info_span};
+use tracing::{debug, error, info, info_span, warn};
 
 use crate::{
     data_model::{
@@ -409,7 +409,7 @@ impl FunctionExecutorManager {
         let Some(mut executor_server_metadata) =
             in_memory_state.executor_states.get(executor_id).cloned()
         else {
-            error!(
+            warn!(
                 target: targets::SCHEDULER,
                 executor_id = executor_id.get(),
                 "executor {} not found while removing function executors",

--- a/server/src/routes/compute_graphs.rs
+++ b/server/src/routes/compute_graphs.rs
@@ -1,0 +1,226 @@
+use anyhow::anyhow;
+use axum::{
+    extract::{Multipart, Path, Query, State},
+    Json,
+};
+use base64::{prelude::BASE64_STANDARD, Engine};
+use futures::StreamExt;
+use tracing::info;
+use utoipa::ToSchema;
+
+use crate::{
+    blob_store::PutResult,
+    data_model::ComputeGraphError,
+    http_objects::{self, IndexifyAPIError, ListParams},
+    http_objects_v1,
+    routes::routes_state::RouteState,
+    state_store::requests::{
+        CreateOrUpdateComputeGraphRequest,
+        DeleteComputeGraphRequest,
+        RequestPayload,
+        StateMachineUpdateRequest,
+    },
+};
+
+#[allow(dead_code)]
+#[derive(ToSchema)]
+struct ComputeGraphCreateType {
+    compute_graph: http_objects::ComputeGraph,
+    #[schema(format = "binary")]
+    code: String,
+}
+
+/// Create or update a workflow
+#[utoipa::path(
+    post,
+    path = "v1/namespaces/{namespace}/compute-graphs",
+    tag = "operations",
+    request_body(content_type = "multipart/form-data", content = inline(ComputeGraphCreateType)),
+    responses(
+        (status = 200, description = "create or update a compute graph"),
+        (status = INTERNAL_SERVER_ERROR, description = "unable to create compute graph")
+    ),
+)]
+pub async fn create_or_update_compute_graph_v1(
+    Path(namespace): Path<String>,
+    State(state): State<RouteState>,
+    mut compute_graph_code: Multipart,
+) -> Result<(), IndexifyAPIError> {
+    let mut compute_graph_definition: Option<http_objects_v1::ComputeGraph> = Option::None;
+    let mut put_result: Option<PutResult> = None;
+    let mut upgrade_tasks_to_current_version: Option<bool> = None;
+    while let Some(field) = compute_graph_code
+        .next_field()
+        .await
+        .map_err(|err| IndexifyAPIError::internal_error(anyhow!(err)))?
+    {
+        let name = field.name();
+        if let Some(name) = name {
+            if name == "code" {
+                let stream = field.map(|res| res.map_err(|err| anyhow!(err)));
+                let file_name = format!("{}_{}", namespace, nanoid::nanoid!());
+                let result = state
+                    .blob_storage
+                    .put(&file_name, stream)
+                    .await
+                    .map_err(IndexifyAPIError::internal_error)?;
+                put_result = Some(result);
+            } else if name == "compute_graph" {
+                let text = field
+                    .text()
+                    .await
+                    .map_err(|e| IndexifyAPIError::bad_request(&e.to_string()))?;
+                let mut json_value: serde_json::Value = serde_json::from_str(&text)?;
+                json_value["namespace"] = serde_json::Value::String(namespace.clone());
+                compute_graph_definition = Some(serde_json::from_value(json_value)?);
+            } else if name == "upgrade_tasks_to_latest_version" {
+                let text = field
+                    .text()
+                    .await
+                    .map_err(|e| IndexifyAPIError::bad_request(&e.to_string()))?;
+                upgrade_tasks_to_current_version = Some(serde_json::from_str::<bool>(&text)?);
+            } else if name == "code_content_type" {
+                let code_content_type = field
+                    .text()
+                    .await
+                    .map_err(|e| IndexifyAPIError::bad_request(&e.to_string()))?;
+                if code_content_type != "application/zip" {
+                    return Err(IndexifyAPIError::bad_request(
+                        "Code content type must be application/zip",
+                    ));
+                }
+            }
+        }
+    }
+
+    let compute_graph_definition = compute_graph_definition.ok_or(
+        IndexifyAPIError::bad_request("Compute graph definition is required"),
+    )?;
+
+    let put_result = put_result.ok_or(IndexifyAPIError::bad_request("Code is required"))?;
+
+    let compute_graph = compute_graph_definition.into_data_model(
+        &put_result.url,
+        &put_result.sha256_hash,
+        put_result.size_bytes,
+        &state.config.executor,
+    )?;
+    let name = compute_graph.name.clone();
+    info!(
+        "creating compute graph {}, upgrade existing tasks and invocations: {}",
+        name,
+        upgrade_tasks_to_current_version.unwrap_or(false)
+    );
+    let request = RequestPayload::CreateOrUpdateComputeGraph(CreateOrUpdateComputeGraphRequest {
+        namespace,
+        compute_graph,
+        upgrade_tasks_to_current_version: upgrade_tasks_to_current_version.unwrap_or(false),
+    });
+    let result = state
+        .indexify_state
+        .write(StateMachineUpdateRequest {
+            payload: request,
+            processed_state_changes: vec![],
+        })
+        .await;
+    if let Err(err) = result {
+        return match err.root_cause().downcast_ref::<ComputeGraphError>() {
+            Some(ComputeGraphError::VersionExists) => Err(IndexifyAPIError::bad_request(
+                "This graph version already exists, please update the graph version",
+            )),
+            _ => Err(IndexifyAPIError::internal_error(err)),
+        };
+    }
+
+    info!("compute graph created: {}", name);
+    Ok(())
+}
+
+/// Delete compute graph
+#[utoipa::path(
+    delete,
+    path = "v1/namespaces/{namespace}/compute-graphs/{compute_graph}",
+    tag = "operations",
+    responses(
+        (status = 200, description = "compute graph deleted successfully"),
+        (status = BAD_REQUEST, description = "unable to delete compute graph")
+    ),
+)]
+pub async fn delete_compute_graph(
+    Path((namespace, compute_graph)): Path<(String, String)>,
+    State(state): State<RouteState>,
+) -> Result<(), IndexifyAPIError> {
+    let request = RequestPayload::TombstoneComputeGraph(DeleteComputeGraphRequest {
+        namespace,
+        name: compute_graph.clone(),
+    });
+    state
+        .indexify_state
+        .write(StateMachineUpdateRequest {
+            payload: request,
+            processed_state_changes: vec![],
+        })
+        .await
+        .map_err(IndexifyAPIError::internal_error)?;
+
+    info!("compute graph deleted: {}", compute_graph);
+    Ok(())
+}
+
+/// List compute graphs
+#[utoipa::path(
+    get,
+    path = "v1/namespaces/{namespace}/compute-graphs",
+    tag = "operations",
+    params(
+        ListParams
+    ),
+    responses(
+        (status = 200, description = "lists compute graphs", body = http_objects_v1::ComputeGraphsList),
+        (status = INTERNAL_SERVER_ERROR, description = "internal server error")
+    ),
+)]
+pub async fn list_compute_graphs(
+    Path(namespace): Path<String>,
+    Query(params): Query<ListParams>,
+    State(state): State<RouteState>,
+) -> Result<Json<http_objects_v1::ComputeGraphsList>, IndexifyAPIError> {
+    let cursor = params
+        .cursor
+        .map(|c| BASE64_STANDARD.decode(c).unwrap_or(vec![]));
+    let (compute_graphs, cursor) = state
+        .indexify_state
+        .reader()
+        .list_compute_graphs(&namespace, cursor.as_deref(), params.limit)
+        .map_err(IndexifyAPIError::internal_error)?;
+    let cursor = cursor.map(|c| BASE64_STANDARD.encode(c));
+    Ok(Json(http_objects_v1::ComputeGraphsList {
+        compute_graphs: compute_graphs.into_iter().map(|c| c.into()).collect(),
+        cursor,
+    }))
+}
+
+/// Get a compute graph definition
+#[utoipa::path(
+    get,
+    path = "/namespaces/{namespace}/compute_graphs/{compute_graph}",
+    tag = "operations",
+    responses(
+        (status = 200, description = "compute graph definition", body = http_objects::ComputeGraph),
+        (status = INTERNAL_SERVER_ERROR, description = "internal server error")
+    ),
+)]
+pub async fn get_compute_graph(
+    Path((namespace, name)): Path<(String, String)>,
+    State(state): State<RouteState>,
+) -> Result<Json<http_objects_v1::ComputeGraph>, IndexifyAPIError> {
+    let compute_graph = state
+        .indexify_state
+        .reader()
+        .get_compute_graph(&namespace, &name)
+        .map_err(IndexifyAPIError::internal_error)?;
+    if let Some(compute_graph) = compute_graph {
+        return Ok(Json(compute_graph.into()));
+    }
+    Err(IndexifyAPIError::not_found("Compute Graph not found"))
+}

--- a/server/src/routes/download.rs
+++ b/server/src/routes/download.rs
@@ -6,11 +6,11 @@ use axum::{
 };
 use futures::TryStreamExt;
 
-use super::RouteState;
+use super::routes_state::RouteState;
 use crate::{
     blob_store::BlobStorage,
     data_model::GraphInvocationError,
-    http_objects::{IndexifyAPIError, InvocationError},
+    http_objects::{IndexifyAPIError, RequestError},
 };
 
 pub async fn download_invocation_payload(
@@ -56,7 +56,7 @@ pub async fn download_invocation_payload(
 pub async fn download_invocation_error(
     invocation_error: Option<GraphInvocationError>,
     blob_storage: &BlobStorage,
-) -> Result<Option<InvocationError>, IndexifyAPIError> {
+) -> Result<Option<RequestError>, IndexifyAPIError> {
     let Some(invocation_error) = invocation_error else {
         return Ok(None);
     };
@@ -84,7 +84,7 @@ pub async fn download_invocation_error(
         ))
     })?;
 
-    return Ok(Some(InvocationError {
+    return Ok(Some(RequestError {
         function_name: invocation_error.function_name,
         message,
     }));
@@ -93,11 +93,11 @@ pub async fn download_invocation_error(
 /// Get function output
 #[utoipa::path(
     get,
-    path = "/namespaces/{namespace}/compute_graphs/{compute_graph}/invocations/{invocation_id}/fn/{fn_name}/output/{id}",
+    path = "v1/namespaces/{namespace}/compute-graphs/{compute_graph}/requests/{request_id}/fn/{fn_name}/outputs/{index}",
     tag = "retrieve",
     responses(
-        (status = 200, description = "Function output"),
-        (status = INTERNAL_SERVER_ERROR, description = "Internal Server Error")
+        (status = 200, description = "function output"),
+        (status = INTERNAL_SERVER_ERROR, description = "internal server error")
     ),
 )]
 pub async fn download_fn_output_payload(

--- a/server/src/routes/download.rs
+++ b/server/src/routes/download.rs
@@ -90,7 +90,6 @@ pub async fn download_invocation_error(
     }));
 }
 
-
 pub async fn download_fn_output_payload(
     Path((namespace, compute_graph, invocation_id, fn_name, id)): Path<(
         String,
@@ -163,7 +162,6 @@ pub async fn download_fn_output_payload(
         .map_err(|e| IndexifyAPIError::internal_error_str(&e.to_string()))
 }
 
-
 /// Get function output
 #[utoipa::path(
     get,
@@ -188,13 +186,7 @@ pub async fn v1_download_fn_output_payload(
     let output = state
         .indexify_state
         .reader()
-        .fn_output_payload(
-            &namespace,
-            &compute_graph,
-            &invocation_id,
-            &fn_name,
-            &id,
-        )
+        .fn_output_payload(&namespace, &compute_graph, &invocation_id, &fn_name, &id)
         .map_err(|e| {
             IndexifyAPIError::internal_error(anyhow!(
                 "failed to download invocation payload: {}",

--- a/server/src/routes/internal_ingest.rs
+++ b/server/src/routes/internal_ingest.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 use tracing::{debug, error};
 use utoipa::ToSchema;
 
-use super::RouteState;
+use super::routes_state::RouteState;
 use crate::{
     blob_store::{BlobStorage, PutResult},
     data_model::{self, DataPayload},

--- a/server/src/routes/invoke.rs
+++ b/server/src/routes/invoke.rs
@@ -155,7 +155,7 @@ pub async fn invoke_with_object(
         .get("Content-Type")
         .and_then(|value| value.to_str().ok())
         .map(|s| s.to_string())
-        .unwrap_or("application/cbor".to_string());
+        .unwrap_or("application/octet-stream".to_string());
 
     state.metrics.invocations.add(1, &[]);
     let should_block = params.block_until_finish.unwrap_or(false);

--- a/server/src/routes/invoke.rs
+++ b/server/src/routes/invoke.rs
@@ -12,10 +12,10 @@ use tokio::sync::broadcast::{error::RecvError, Receiver};
 use tracing::{error, info, warn};
 use uuid::Uuid;
 
-use super::RouteState;
+use super::routes_state::RouteState;
 use crate::{
     data_model::{self, GraphInvocationCtxBuilder, InvocationPayloadBuilder},
-    http_objects::{IndexifyAPIError, InvocationId, InvocationQueryParams},
+    http_objects::{IndexifyAPIError, InvocationId, RequestQueryParams},
     state_store::{
         invocation_events::{InvocationFinishedEvent, InvocationStateChangeEvent},
         requests::{InvokeComputeGraphRequest, RequestPayload, StateMachineUpdateRequest},
@@ -132,21 +132,21 @@ async fn create_invocation_event_stream(
     }
 }
 
-/// Invoke Compute Graph
+/// Make a request to a workflow
 #[utoipa::path(
     post,
     path = "/namespaces/{namespace}/compute_graphs/{compute_graph}/invoke_object",
     request_body(content_type = "application/json", content = inline(serde_json::Value)),
     tag = "ingestion",
     responses(
-        (status = 200, description = "invocation successful"),
+        (status = 200, description = "request successful"),
         (status = 400, description = "bad request"),
-        (status = INTERNAL_SERVER_ERROR, description = "Internal Server Error")
+        (status = INTERNAL_SERVER_ERROR, description = "internal server error")
     ),
 )]
 pub async fn invoke_with_object(
     Path((namespace, compute_graph)): Path<(String, String)>,
-    Query(params): Query<InvocationQueryParams>,
+    Query(params): Query<RequestQueryParams>,
     State(state): State<RouteState>,
     headers: HeaderMap,
     body: Body,

--- a/server/src/routes/invoke.rs
+++ b/server/src/routes/invoke.rs
@@ -17,7 +17,7 @@ use crate::{
     data_model::{self, GraphInvocationCtxBuilder, InvocationPayloadBuilder},
     http_objects::{IndexifyAPIError, RequestId, RequestQueryParams},
     state_store::{
-        invocation_events::{RequestFinishedEvent, InvocationStateChangeEvent},
+        invocation_events::{InvocationStateChangeEvent, RequestFinishedEvent},
         requests::{InvokeComputeGraphRequest, RequestPayload, StateMachineUpdateRequest},
     },
 };

--- a/server/src/routes/logs.rs
+++ b/server/src/routes/logs.rs
@@ -5,7 +5,7 @@ use axum::{
     http::Response,
 };
 
-use super::RouteState;
+use super::routes_state::RouteState;
 use crate::{blob_store::BlobStorage, data_model::DataPayload, http_objects::IndexifyAPIError};
 
 #[utoipa::path(

--- a/server/src/routes/mod.rs
+++ b/server/src/routes/mod.rs
@@ -1,0 +1,6 @@
+pub mod compute_graphs;
+pub mod download;
+pub mod internal_ingest;
+pub mod invoke;
+pub mod logs;
+pub mod routes_state;

--- a/server/src/routes/routes_state.rs
+++ b/server/src/routes/routes_state.rs
@@ -1,0 +1,19 @@
+use std::sync::Arc;
+
+use crate::{
+    blob_store,
+    config::ServerConfig,
+    executors::ExecutorManager,
+    metrics::api_io_stats,
+    state_store::{kv::KVS, IndexifyState},
+};
+
+#[derive(Clone)]
+pub struct RouteState {
+    pub config: Arc<ServerConfig>,
+    pub indexify_state: Arc<IndexifyState>,
+    pub blob_storage: Arc<blob_store::BlobStorage>,
+    pub kvs: Arc<KVS>,
+    pub executor_manager: Arc<ExecutorManager>,
+    pub metrics: Arc<api_io_stats::Metrics>,
+}

--- a/server/src/routes_v1.rs
+++ b/server/src/routes_v1.rs
@@ -1,0 +1,409 @@
+use std::collections::HashMap;
+
+use anyhow::Result;
+use axum::{
+    extract::{Path, Query, RawPathParams, Request, State},
+    middleware::{self, Next},
+    response::IntoResponse,
+    routing::{delete, get, post},
+    Json,
+    Router,
+};
+use base64::prelude::*;
+use compute_graphs::{delete_compute_graph, get_compute_graph, list_compute_graphs};
+use download::{download_fn_output_payload, download_invocation_error};
+use invoke::invoke_with_object;
+use tracing::info;
+use utoipa::{OpenApi, ToSchema};
+use utoipa_swagger_ui::SwaggerUi;
+
+use crate::{
+    http_objects::{
+        Allocation,
+        CacheKey,
+        ComputeFn,
+        ComputeGraph,
+        ComputeGraphsList,
+        CreateNamespace,
+        CursorDirection,
+        ExecutorMetadata,
+        ExecutorsAllocationsResponse,
+        GraphInvocations,
+        GraphVersion,
+        ImageInformation,
+        IndexifyAPIError,
+        Invocation,
+        ListParams,
+        Namespace,
+        NamespaceList,
+        RuntimeInformation,
+        StateChangesResponse,
+        Task,
+        TaskOutcome,
+        Tasks,
+        UnallocatedTasks,
+    },
+    http_objects_v1::{self, GraphRequests},
+    routes::{
+        compute_graphs::{self, create_or_update_compute_graph_v1},
+        download,
+        invoke,
+        routes_state::RouteState,
+    },
+    state_store::{
+        self,
+        requests::{
+            DeleteInvocationRequest,
+            NamespaceRequest,
+            RequestPayload,
+            StateMachineUpdateRequest,
+        },
+    },
+};
+
+#[derive(OpenApi)]
+#[openapi(
+        paths(
+            invoke::invoke_with_object,
+            graph_requests,
+            find_invocation,
+            compute_graphs::create_or_update_compute_graph_v1,
+            compute_graphs::list_compute_graphs,
+            compute_graphs::get_compute_graph,
+            compute_graphs::delete_compute_graph,
+            list_tasks,
+            delete_invocation,
+            download::download_fn_output_payload,
+        ),
+        components(
+            schemas(
+                CreateNamespace,
+                NamespaceList,
+                IndexifyAPIError,
+                Namespace,
+                ComputeGraph,
+		        CacheKey,
+                ComputeFn,
+                ListParams,
+                ComputeGraphCreateType,
+                ComputeGraphsList,
+                ImageInformation,
+                ExecutorMetadata,
+                RuntimeInformation,
+                Task,
+                TaskOutcome,
+                Tasks,
+                GraphInvocations,
+                GraphVersion,
+                Allocation,
+                ExecutorsAllocationsResponse,
+                UnallocatedTasks,
+                StateChangesResponse,
+            )
+        ),
+        tags(
+            (name = "indexify", description = "Indexify API")
+        )
+    )]
+
+pub struct ApiDoc;
+
+pub fn configure_v1_routes(route_state: RouteState) -> Router {
+    Router::new()
+        .merge(
+            SwaggerUi::new("/docs/public/swagger")
+                .url("/docs/public/openapi.json", ApiDoc::openapi()),
+        )
+        .nest(
+            "/v1/namespaces/{namespace}",
+            v1_namespace_routes(route_state.clone()),
+        )
+}
+
+/// Namespace router with namespace specific layers.
+fn v1_namespace_routes(route_state: RouteState) -> Router {
+    Router::new()
+        .route(
+            "/compute-graphs",
+            post(create_or_update_compute_graph_v1).with_state(route_state.clone()),
+        )
+        .route(
+            "/compute-graphs",
+            get(list_compute_graphs).with_state(route_state.clone()),
+        )
+        .route(
+            "/compute-graphs/{compute_graph}",
+            delete(delete_compute_graph).with_state(route_state.clone()),
+        )
+        .route(
+            "/compute-graphs/{compute_graph}",
+            get(get_compute_graph).with_state(route_state.clone()),
+        )
+        .route(
+            "/compute-graphs/{compute_graph}",
+            post(invoke_with_object).with_state(route_state.clone()),
+        )
+        .route(
+            "/compute-graphs/{compute_graph}/requests",
+            get(graph_requests).with_state(route_state.clone()),
+        )
+        .route(
+            "/compute-graphs/{compute_graph}/requests/{request_id}",
+            get(find_invocation).with_state(route_state.clone()),
+        )
+        .route(
+            "/compute-graphs/{compute_graph}/requests/{request_id}",
+            delete(delete_invocation).with_state(route_state.clone()),
+        )
+        .route(
+            "/compute-graphs/{compute_graph}/requests/{request_id}/tasks",
+            get(list_tasks).with_state(route_state.clone()),
+        )
+        .route(
+            "/compute-graphs/{compute_graph}/requests/{request_id}/fn/{fn_name}/outputs/{index}",
+            get(download_fn_output_payload).with_state(route_state.clone()),
+        )
+        .layer(middleware::from_fn(move |rpp, r, n| {
+            namespace_middleware(route_state.clone(), rpp, r, n)
+        }))
+}
+
+/// Middleware to check if the namespace exists.
+async fn namespace_middleware(
+    route_state: RouteState,
+    params: RawPathParams,
+    request: Request,
+    next: Next,
+) -> Result<impl IntoResponse, IndexifyAPIError> {
+    // get the namespace path variable from the path
+    let namespace_param = params.iter().find(|(key, _)| *key == "namespace");
+
+    // if the namespace path variable is found, check if the namespace exists
+    if let Some((_, namespace)) = namespace_param {
+        let reader = route_state.indexify_state.reader();
+        let ns = reader
+            .get_namespace(namespace)
+            .map_err(IndexifyAPIError::internal_error)?;
+
+        if ns.is_none() {
+            route_state
+                .indexify_state
+                .write(StateMachineUpdateRequest {
+                    payload: RequestPayload::CreateNameSpace(NamespaceRequest {
+                        name: namespace.to_string(),
+                    }),
+                    processed_state_changes: vec![],
+                })
+                .await
+                .map_err(IndexifyAPIError::internal_error)?;
+
+            info!("namespace created: {:?}", namespace);
+        }
+    }
+
+    Ok(next.run(request).await)
+}
+
+#[allow(dead_code)]
+#[derive(ToSchema)]
+struct ComputeGraphCreateType {
+    compute_graph: ComputeGraph,
+    #[schema(format = "binary")]
+    code: String,
+}
+
+/// List requests for a workflow
+#[utoipa::path(
+    get,
+    path = "/namespaces/{namespace}/compute_graphs/{compute_graph}/requests",
+    tag = "ingestion",
+    params(
+        ListParams
+    ),
+    responses(
+        (status = 200, description = "List Graph Invocations", body = GraphInvocations),
+        (status = INTERNAL_SERVER_ERROR, description = "Internal Server Error")
+    ),
+)]
+async fn graph_requests(
+    Path((namespace, compute_graph)): Path<(String, String)>,
+    Query(params): Query<ListParams>,
+    State(state): State<RouteState>,
+) -> Result<Json<GraphRequests>, IndexifyAPIError> {
+    let cursor = params
+        .cursor
+        .map(|c| BASE64_STANDARD.decode(c).unwrap_or(vec![]));
+    let direction = match params.direction {
+        Some(CursorDirection::Forward) => Some(state_store::scanner::CursorDirection::Forward),
+        Some(CursorDirection::Backward) => Some(state_store::scanner::CursorDirection::Backward),
+        None => None,
+    };
+    let (invocation_ctxs, prev_cursor, next_cursor) = state
+        .indexify_state
+        .reader()
+        .list_invocations(
+            &namespace,
+            &compute_graph,
+            cursor.as_deref(),
+            params.limit.unwrap_or(100),
+            direction,
+        )
+        .map_err(IndexifyAPIError::internal_error)?;
+    let mut requests = vec![];
+    for invocation_ctx in invocation_ctxs {
+        let shallow_request = invocation_ctx.clone().into();
+        requests.push(shallow_request);
+    }
+    let prev_cursor = prev_cursor.map(|c| BASE64_STANDARD.encode(c));
+    let next_cursor = next_cursor.map(|c| BASE64_STANDARD.encode(c));
+
+    Ok(Json(GraphRequests {
+        requests,
+        prev_cursor,
+        next_cursor,
+    }))
+}
+
+/// List tasks for a request
+#[utoipa::path(
+    get,
+    path = "v1/namespaces/{namespace}/compute-graphs/{compute_graph}/requests/{request_id}/tasks",
+    tag = "operations",
+    params(
+        ListParams
+    ),
+    responses(
+        (status = 200, description = "list tasks for a given request id", body = Tasks),
+        (status = INTERNAL_SERVER_ERROR, description = "internal server error")
+    ),
+)]
+#[axum::debug_handler]
+async fn list_tasks(
+    Path((namespace, compute_graph, invocation_id)): Path<(String, String, String)>,
+    Query(params): Query<ListParams>,
+    State(state): State<RouteState>,
+) -> Result<Json<http_objects_v1::Tasks>, IndexifyAPIError> {
+    let cursor = params
+        .cursor
+        .map(|c| BASE64_STANDARD.decode(c).unwrap_or(vec![]));
+    let (tasks, cursor) = state
+        .indexify_state
+        .reader()
+        .list_tasks_by_compute_graph(
+            &namespace,
+            &compute_graph,
+            &invocation_id,
+            cursor.as_deref(),
+            params.limit,
+        )
+        .map_err(IndexifyAPIError::internal_error)?;
+    let allocations = state
+        .indexify_state
+        .reader()
+        .get_allocations_by_invocation(&namespace, &compute_graph, &invocation_id)
+        .map_err(IndexifyAPIError::internal_error)?;
+    let mut allocations_by_task_id: HashMap<String, Vec<http_objects_v1::Allocation>> =
+        HashMap::new();
+    for allocation in allocations {
+        allocations_by_task_id
+            .entry(allocation.task_id.to_string())
+            .or_insert_with(Vec::new)
+            .push(allocation.into());
+    }
+    let mut http_tasks = vec![];
+    for task in tasks {
+        let allocations = allocations_by_task_id
+            .get(task.id.get())
+            .map(|a| a.clone())
+            .clone()
+            .unwrap_or_default();
+        http_tasks.push(http_objects_v1::Task::from_data_model_task(
+            task,
+            allocations,
+        ));
+    }
+    let cursor = cursor.map(|c| BASE64_STANDARD.encode(c));
+    Ok(Json(http_objects_v1::Tasks {
+        tasks: http_tasks,
+        cursor,
+    }))
+}
+
+/// Get request status by id
+#[utoipa::path(
+    get,
+    path = "v1/namespaces/{namespace}/compute-graphs/{compute_graph}/requests/{request_id}",
+    tag = "retrieve",
+    responses(
+        (status = 200, description = "Details about a given invocation", body = Invocation),
+        (status = NOT_FOUND, description = "Invocation not found"),
+        (status = INTERNAL_SERVER_ERROR, description = "Internal Server Error")
+    ),
+)]
+async fn find_invocation(
+    Path((namespace, compute_graph, invocation_id)): Path<(String, String, String)>,
+    State(state): State<RouteState>,
+) -> Result<Json<http_objects_v1::Request>, IndexifyAPIError> {
+    let invocation_ctx = state
+        .indexify_state
+        .reader()
+        .invocation_ctx(&namespace, &compute_graph, &invocation_id)
+        .map_err(IndexifyAPIError::internal_error)?
+        .ok_or(IndexifyAPIError::not_found("invocation not found"))?;
+
+    let (outputs, _cursor) = state
+        .indexify_state
+        .reader()
+        .list_outputs_by_compute_graph(&namespace, &compute_graph, &invocation_id, None, None)
+        .map_err(IndexifyAPIError::internal_error)?;
+    let mut http_outputs = vec![];
+    for output in outputs {
+        http_outputs.push(http_objects_v1::FnOutput {
+            id: output.id.clone(),
+            num_outputs: output.payloads.len() as u64,
+            compute_fn: output.compute_fn_name.clone(),
+            created_at: output.created_at,
+        });
+    }
+
+    let invocation_error =
+        download_invocation_error(invocation_ctx.invocation_error.clone(), &state.blob_storage)
+            .await?;
+
+    let request = http_objects_v1::Request::build(invocation_ctx, http_outputs, invocation_error);
+
+    Ok(Json(request))
+}
+
+/// Delete a specific request
+#[utoipa::path(
+    delete,
+    path = "v1/namespaces/{namespace}/compute-graphs/{compute_graph}/requests/{request_id}",
+    tag = "operations",
+    responses(
+        (status = 200, description = "request has been deleted"),
+        (status = INTERNAL_SERVER_ERROR, description = "internal server error")
+    ),
+)]
+#[axum::debug_handler]
+async fn delete_invocation(
+    Path((namespace, compute_graph, invocation_id)): Path<(String, String, String)>,
+    State(state): State<RouteState>,
+) -> Result<(), IndexifyAPIError> {
+    let request = RequestPayload::TombstoneInvocation(DeleteInvocationRequest {
+        namespace,
+        compute_graph,
+        invocation_id,
+    });
+    let req = StateMachineUpdateRequest {
+        payload: request,
+        processed_state_changes: vec![],
+    };
+
+    state
+        .indexify_state
+        .write(req)
+        .await
+        .map_err(IndexifyAPIError::internal_error)?;
+    Ok(())
+}

--- a/server/src/state_store/invocation_events.rs
+++ b/server/src/state_store/invocation_events.rs
@@ -1,9 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crate::{
-    data_model::TaskOutcome,
-    state_store::requests::AllocationOutput,
-};
+use crate::{data_model::TaskOutcome, state_store::requests::AllocationOutput};
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum InvocationStateChangeEvent {
@@ -27,18 +24,19 @@ impl InvocationStateChangeEvent {
 
     pub fn invocation_id(&self) -> String {
         match self {
-            InvocationStateChangeEvent::RequestFinished(RequestFinishedEvent { id }) => {
-                id.clone()
-            }
-            InvocationStateChangeEvent::TaskCreated(TaskCreated { request_id: invocation_id, .. }) => {
-                invocation_id.clone()
-            }
-            InvocationStateChangeEvent::TaskAssigned(TaskAssigned { request_id: invocation_id, .. }) => {
-                invocation_id.clone()
-            }
-            InvocationStateChangeEvent::TaskCompleted(TaskCompleted { request_id: invocation_id, .. }) => {
-                invocation_id.clone()
-            }
+            InvocationStateChangeEvent::RequestFinished(RequestFinishedEvent { id }) => id.clone(),
+            InvocationStateChangeEvent::TaskCreated(TaskCreated {
+                request_id: invocation_id,
+                ..
+            }) => invocation_id.clone(),
+            InvocationStateChangeEvent::TaskAssigned(TaskAssigned {
+                request_id: invocation_id,
+                ..
+            }) => invocation_id.clone(),
+            InvocationStateChangeEvent::TaskCompleted(TaskCompleted {
+                request_id: invocation_id,
+                ..
+            }) => invocation_id.clone(),
             InvocationStateChangeEvent::TaskMatchedCache(TaskMatchedCache {
                 request_id: invocation_id,
                 ..

--- a/server/src/state_store/invocation_events.rs
+++ b/server/src/state_store/invocation_events.rs
@@ -1,9 +1,7 @@
-use std::collections::HashMap;
-
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    data_model::{TaskAnalytics, TaskOutcome},
+    data_model::TaskOutcome,
     state_store::requests::AllocationOutput,
 };
 
@@ -13,13 +11,13 @@ pub enum InvocationStateChangeEvent {
     TaskAssigned(TaskAssigned),
     TaskCompleted(TaskCompleted),
     TaskMatchedCache(TaskMatchedCache),
-    InvocationFinished(InvocationFinishedEvent),
+    RequestFinished(RequestFinishedEvent),
 }
 
 impl InvocationStateChangeEvent {
     pub fn from_task_finished(event: AllocationOutput) -> Self {
         Self::TaskCompleted(TaskCompleted {
-            invocation_id: event.invocation_id,
+            request_id: event.invocation_id,
             fn_name: event.compute_fn,
             task_id: event.allocation.task_id.get().to_string(),
             outcome: (&event.allocation.outcome).into(),
@@ -29,20 +27,20 @@ impl InvocationStateChangeEvent {
 
     pub fn invocation_id(&self) -> String {
         match self {
-            InvocationStateChangeEvent::InvocationFinished(InvocationFinishedEvent { id }) => {
+            InvocationStateChangeEvent::RequestFinished(RequestFinishedEvent { id }) => {
                 id.clone()
             }
-            InvocationStateChangeEvent::TaskCreated(TaskCreated { invocation_id, .. }) => {
+            InvocationStateChangeEvent::TaskCreated(TaskCreated { request_id: invocation_id, .. }) => {
                 invocation_id.clone()
             }
-            InvocationStateChangeEvent::TaskAssigned(TaskAssigned { invocation_id, .. }) => {
+            InvocationStateChangeEvent::TaskAssigned(TaskAssigned { request_id: invocation_id, .. }) => {
                 invocation_id.clone()
             }
-            InvocationStateChangeEvent::TaskCompleted(TaskCompleted { invocation_id, .. }) => {
+            InvocationStateChangeEvent::TaskCompleted(TaskCompleted { request_id: invocation_id, .. }) => {
                 invocation_id.clone()
             }
             InvocationStateChangeEvent::TaskMatchedCache(TaskMatchedCache {
-                invocation_id,
+                request_id: invocation_id,
                 ..
             }) => invocation_id.clone(),
         }
@@ -50,26 +48,20 @@ impl InvocationStateChangeEvent {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct InvocationFinishedEvent {
+pub struct RequestFinishedEvent {
     pub id: String,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct TaskCreated {
-    pub invocation_id: String,
+    pub request_id: String,
     pub fn_name: String,
     pub task_id: String,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct DiagnosticMessage {
-    pub invocation_id: String,
-    pub message: String,
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct TaskAssigned {
-    pub invocation_id: String,
+    pub request_id: String,
     pub fn_name: String,
     pub task_id: String,
     pub allocation_id: String,
@@ -95,7 +87,7 @@ impl From<&TaskOutcome> for TaskOutcomeSummary {
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct TaskCompleted {
-    pub invocation_id: String,
+    pub request_id: String,
     pub fn_name: String,
     pub task_id: String,
     pub allocation_id: String,
@@ -104,15 +96,7 @@ pub struct TaskCompleted {
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct TaskMatchedCache {
-    pub invocation_id: String,
+    pub request_id: String,
     pub fn_name: String,
     pub task_id: String,
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct InvocationFinished {
-    pub namespace: String,
-    pub compute_graph: String,
-    pub invocation_id: String,
-    pub analytics: HashMap<String, TaskAnalytics>,
 }

--- a/server/src/state_store/mod.rs
+++ b/server/src/state_store/mod.rs
@@ -12,7 +12,7 @@ use std::{
 
 use anyhow::{anyhow, Result};
 use in_memory_state::{InMemoryMetrics, InMemoryState};
-use invocation_events::{RequestFinishedEvent, InvocationStateChangeEvent};
+use invocation_events::{InvocationStateChangeEvent, RequestFinishedEvent};
 use opentelemetry::KeyValue;
 use requests::{RequestPayload, StateMachineUpdateRequest};
 use rocksdb::{ColumnFamilyDescriptor, Options, TransactionDB, TransactionDBOptions};
@@ -374,13 +374,13 @@ impl IndexifyState {
 
                 for invocation_ctx in &sched_update.updated_invocations_states {
                     if invocation_ctx.completed {
-                        let _ = self.task_event_tx.send(
-                            InvocationStateChangeEvent::RequestFinished(
-                                RequestFinishedEvent {
-                                    id: invocation_ctx.invocation_id.clone(),
-                                },
-                            ),
-                        );
+                        let _ =
+                            self.task_event_tx
+                                .send(InvocationStateChangeEvent::RequestFinished(
+                                    RequestFinishedEvent {
+                                        id: invocation_ctx.invocation_id.clone(),
+                                    },
+                                ));
                     }
                 }
             }

--- a/server/src/state_store/mod.rs
+++ b/server/src/state_store/mod.rs
@@ -12,7 +12,7 @@ use std::{
 
 use anyhow::{anyhow, Result};
 use in_memory_state::{InMemoryMetrics, InMemoryState};
-use invocation_events::{InvocationFinishedEvent, InvocationStateChangeEvent};
+use invocation_events::{RequestFinishedEvent, InvocationStateChangeEvent};
 use opentelemetry::KeyValue;
 use requests::{RequestPayload, StateMachineUpdateRequest};
 use rocksdb::{ColumnFamilyDescriptor, Options, TransactionDB, TransactionDBOptions};
@@ -339,7 +339,7 @@ impl IndexifyState {
                         .task_event_tx
                         .send(InvocationStateChangeEvent::TaskAssigned(
                             invocation_events::TaskAssigned {
-                                invocation_id: allocation.invocation_id.clone(),
+                                request_id: allocation.invocation_id.clone(),
                                 fn_name: allocation.compute_fn.clone(),
                                 task_id: allocation.task_id.get().to_string(),
                                 executor_id: allocation.target.executor_id.get().to_string(),
@@ -354,7 +354,7 @@ impl IndexifyState {
                             self.task_event_tx
                                 .send(InvocationStateChangeEvent::TaskMatchedCache(
                                     invocation_events::TaskMatchedCache {
-                                        invocation_id: task.invocation_id.clone(),
+                                        request_id: task.invocation_id.clone(),
                                         fn_name: task.compute_fn_name.clone(),
                                         task_id: task.id.to_string(),
                                     },
@@ -364,7 +364,7 @@ impl IndexifyState {
                             .task_event_tx
                             .send(InvocationStateChangeEvent::TaskCreated(
                                 invocation_events::TaskCreated {
-                                    invocation_id: task.invocation_id.clone(),
+                                    request_id: task.invocation_id.clone(),
                                     fn_name: task.compute_fn_name.clone(),
                                     task_id: task.id.to_string(),
                                 },
@@ -375,8 +375,8 @@ impl IndexifyState {
                 for invocation_ctx in &sched_update.updated_invocations_states {
                     if invocation_ctx.completed {
                         let _ = self.task_event_tx.send(
-                            InvocationStateChangeEvent::InvocationFinished(
-                                InvocationFinishedEvent {
+                            InvocationStateChangeEvent::RequestFinished(
+                                RequestFinishedEvent {
                                     id: invocation_ctx.invocation_id.clone(),
                                 },
                             ),


### PR DESCRIPTION
v1 routes for Indexify. Created an /internal routes for admin apis and the public apis are /v1/namespaces routes. 

We have the following APIs - 
1. Create Graph  - `POST /compute-graphs`
2. List Graphs - `GET /compute-graphs` 
3. Delete Graph - `DELETE /compute-graphs/{compute_graph}`
4. Get Graph - `GET /compute-graphs/{compute_graph}` 
5. Create new Request - `POST /compute-graphs/{compute_graph}` 
6. List Requests - `GET /compute-graphs/{compute_graph}/requests` 
7. Get a Request's Metadata - `GET /compute-graphs/{compute_graph}/requests/{request_id}` 
8. Delete or Cancel a Request - `DELETE /compute-graphs/{compute_graph}/requests/{request_id}` 
9. Tasks - `GET /compute-graphs/{compute_graph}/requests/{request_id}/tasks` 
10. Download output of a function - `GET /compute-graphs/{compute_graph}/requests/{request_id}/fn/{fn_name}/outputs/{index}` 

Note there is no separate api for listing outputs, when you get a request's metadata we return the list of outputs, status, etc. 