### PR TITLE
Bump indexify-server version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1453,7 +1453,7 @@ dependencies = [
 
 [[package]]
 name = "indexify-server"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "indexify-server"
-version = "0.3.5"
+version = "0.3.6"
 edition = "2021"
 authors = ["Tensorlake Inc. <support@tensorlake.ai>"]
 license = "Apache-2.0"


### PR DESCRIPTION
## Context

Bumping the server version for release

## What

This sets us to indexify-server 0.3.6

## Testing

None

## Contribution Checklist

- [ ] If a Python package was changed, please run `make fmt` in the package directory.
- [ ] If the server was changed, please run `make fmt` in `server/`.
- [ ] Make sure all PR Checks are passing.
