### PR TITLE
Use async RPCs for FE task management

### DIFF
--- a/indexify/src/indexify/executor/function_executor_controller/metrics/run_task.py
+++ b/indexify/src/indexify/executor/function_executor_controller/metrics/run_task.py
@@ -6,23 +6,24 @@ from indexify.executor.monitoring.metrics import (
 
 metric_function_executor_run_task_rpcs: prometheus_client.Counter = (
     prometheus_client.Counter(
-        "function_executor_run_task_rpcs", "Number of Function Executor run task RPCs"
+        "function_executor_run_task_rpcs",
+        "Number of Function Executor run task lifecycle RPC sequences",
     )
 )
 metric_function_executor_run_task_rpc_errors: prometheus_client.Counter = (
     prometheus_client.Counter(
         "function_executor_run_task_rpc_errors",
-        "Number of Function Executor run task RPC errors",
+        "Number of Function Executor run task lifecycle RPC errors",
     )
 )
 metric_function_executor_run_task_rpc_latency: prometheus_client.Histogram = (
     latency_metric_for_customer_controlled_operation(
-        "function_executor_run_task_rpc", "Function Executor run task RPC"
+        "function_executor_run_task_rpc", "Function Executor run task lifecycle RPC"
     )
 )
 metric_function_executor_run_task_rpcs_in_progress: prometheus_client.Gauge = (
     prometheus_client.Gauge(
         "function_executor_run_task_rpcs_in_progress",
-        "Number of Function Executor run task RPCs in progress",
+        "Number of Function Executor run task lifecycle RPCs in progress",
     )
 )

--- a/indexify/src/indexify/executor/function_executor_controller/run_task.py
+++ b/indexify/src/indexify/executor/function_executor_controller/run_task.py
@@ -6,15 +6,22 @@ from typing import Any, Optional
 
 import grpc
 from tensorlake.function_executor.proto.function_executor_pb2 import (
-    RunTaskRequest,
-    RunTaskResponse,
+    AwaitTaskProgress,
+    AwaitTaskRequest,
+    CreateTaskRequest,
+    DeleteTaskRequest,
+    FunctionInputs,
     SerializedObject,
+    Task,
 )
 from tensorlake.function_executor.proto.function_executor_pb2 import (
     TaskFailureReason as FETaskFailureReason,
 )
 from tensorlake.function_executor.proto.function_executor_pb2 import (
     TaskOutcomeCode as FETaskOutcomeCode,
+)
+from tensorlake.function_executor.proto.function_executor_pb2 import (
+    TaskResult,
 )
 from tensorlake.function_executor.proto.function_executor_pb2_grpc import (
     FunctionExecutorStub,
@@ -44,6 +51,9 @@ _ENABLE_INJECT_TASK_CANCELLATIONS = (
     os.getenv("INDEXIFY_INJECT_TASK_CANCELLATIONS", "0") == "1"
 )
 
+_CREATE_TASK_TIMEOUT_SECS = 5
+_DELETE_TASK_TIMEOUT_SECS = 5
+
 
 async def run_task_on_function_executor(
     task_info: TaskInfo, function_executor: FunctionExecutor, logger: Any
@@ -53,21 +63,21 @@ async def run_task_on_function_executor(
     Doesn't raise any exceptions.
     """
     logger = logger.bind(module=__name__)
-    request: RunTaskRequest = RunTaskRequest(
+    task = Task(
+        task_id=task_info.allocation.task.id,
         namespace=task_info.allocation.task.namespace,
         graph_name=task_info.allocation.task.graph_name,
         graph_version=task_info.allocation.task.graph_version,
         function_name=task_info.allocation.task.function_name,
         graph_invocation_id=task_info.allocation.task.graph_invocation_id,
-        task_id=task_info.allocation.task.id,
         allocation_id=task_info.allocation.allocation_id,
-        function_input=task_info.input,
+        request=FunctionInputs(function_input=task_info.input),
     )
     # Don't keep the input in memory after we started running the task.
     task_info.input = None
 
     if task_info.init_value is not None:
-        request.function_init_value.CopyFrom(task_info.init_value)
+        task.request.function_init_value.CopyFrom(task_info.init_value)
         # Don't keep the init value in memory after we started running the task.
         task_info.init_value = None
 
@@ -83,45 +93,42 @@ async def run_task_on_function_executor(
     function_executor_termination_reason: Optional[
         FunctionExecutorTerminationReason
     ] = None
-    execution_start_time: Optional[float] = None
+
+    execution_start_time: Optional[float] = time.monotonic()
 
     # If this RPC failed due to customer code crashing the server we won't be
     # able to detect this. We'll treat this as our own error for now and thus
     # let the AioRpcError to be raised here.
     timeout_sec = task_info.allocation.task.timeout_ms / 1000.0
     try:
-        channel: grpc.aio.Channel = function_executor.channel()
-        execution_start_time = time.monotonic()
-        response: RunTaskResponse = await FunctionExecutorStub(channel).run_task(
-            request, timeout=timeout_sec
-        )
-        task_info.output = _task_output_from_function_executor_response(
+        task_result = await _run_task(task, function_executor, timeout_sec)
+
+        task_info.output = _task_output_from_function_executor_result(
             allocation=task_info.allocation,
-            response=response,
+            result=task_result,
             execution_start_time=execution_start_time,
             execution_end_time=time.monotonic(),
             logger=logger,
         )
+    except asyncio.TimeoutError:
+        # The task is still running in FE, we only cancelled the client-side RPC.
+        function_executor_termination_reason = (
+            FunctionExecutorTerminationReason.FUNCTION_EXECUTOR_TERMINATION_REASON_FUNCTION_TIMEOUT
+        )
+        task_info.output = TaskOutput.function_timeout(
+            allocation=task_info.allocation,
+            timeout_sec=timeout_sec,
+            execution_start_time=execution_start_time,
+            execution_end_time=time.monotonic(),
+        )
     except grpc.aio.AioRpcError as e:
-        if e.code() == grpc.StatusCode.DEADLINE_EXCEEDED:
-            # The task is still running in FE, we only cancelled the client-side RPC.
-            function_executor_termination_reason = (
-                FunctionExecutorTerminationReason.FUNCTION_EXECUTOR_TERMINATION_REASON_FUNCTION_TIMEOUT
-            )
-            task_info.output = TaskOutput.function_timeout(
-                allocation=task_info.allocation,
-                timeout_sec=timeout_sec,
-                execution_start_time=execution_start_time,
-                execution_end_time=time.monotonic(),
-            )
-        else:
-            metric_function_executor_run_task_rpc_errors.inc()
-            logger.error("task execution failed", exc_info=e)
-            task_info.output = TaskOutput.internal_error(
-                allocation=task_info.allocation,
-                execution_start_time=execution_start_time,
-                execution_end_time=time.monotonic(),
-            )
+        metric_function_executor_run_task_rpc_errors.inc()
+        logger.error("task execution failed", exc_info=e)
+        task_info.output = TaskOutput.internal_error(
+            allocation=task_info.allocation,
+            execution_start_time=execution_start_time,
+            execution_end_time=time.monotonic(),
+        )
     except asyncio.CancelledError:
         # The task is still running in FE, we only cancelled the client-side RPC.
         function_executor_termination_reason = (
@@ -171,26 +178,70 @@ async def run_task_on_function_executor(
     )
 
 
-def _task_output_from_function_executor_response(
+async def _run_task(
+    task: Task, function_executor: FunctionExecutor, timeout_sec: float
+):
+    """Runs the task, returning the result, reporting errors via exceptions."""
+
+    last_response: Optional[AwaitTaskProgress] = None
+    channel: grpc.aio.Channel = function_executor.channel()
+    fe_stub = FunctionExecutorStub(channel)
+
+    # Use a single timeout across all three GRPC calls, restarting when await_task() returns responses
+    current_rpc = None
+
+    try:
+        # Create task with timeout
+        current_rpc = fe_stub.create_task(CreateTaskRequest(task=task))
+        await asyncio.wait_for(current_rpc, timeout=_CREATE_TASK_TIMEOUT_SECS)
+        current_rpc = None
+
+        # Await task with timeout resets on each response
+        current_rpc = fe_stub.await_task(AwaitTaskRequest(task_id=task.task_id))
+
+        while True:
+            # Wait for next response with fresh timeout each time
+            response = await asyncio.wait_for(current_rpc.read(), timeout=timeout_sec)
+            if response == grpc.aio.EOF:
+                current_rpc = None
+                break
+            last_response = response
+
+        # Delete task with timeout
+        current_rpc = fe_stub.delete_task(DeleteTaskRequest(task_id=task.task_id))
+        await asyncio.wait_for(current_rpc, timeout=_DELETE_TASK_TIMEOUT_SECS)
+
+    finally:
+        # Cancel any outstanding RPCs to clean up our client-side resources
+        if current_rpc is not None:
+            current_rpc.cancel()
+
+    if not last_response or last_response.WhichOneof("response") != "task_result":
+        raise Exception("Expected a final task result")
+
+    return last_response.task_result
+
+
+def _task_output_from_function_executor_result(
     allocation: TaskAllocation,
-    response: RunTaskResponse,
+    result: TaskResult,
     execution_start_time: Optional[float],
     execution_end_time: Optional[float],
     logger: Any,
 ) -> TaskOutput:
-    response_validator = MessageValidator(response)
+    response_validator = MessageValidator(result)
     response_validator.required_field("stdout")
     response_validator.required_field("stderr")
     response_validator.required_field("outcome_code")
 
     metrics = TaskMetrics(counters={}, timers={})
-    if response.HasField("metrics"):
+    if result.HasField("metrics"):
         # Can be None if e.g. function failed.
-        metrics.counters = dict(response.metrics.counters)
-        metrics.timers = dict(response.metrics.timers)
+        metrics.counters = dict(result.metrics.counters)
+        metrics.timers = dict(result.metrics.timers)
 
     outcome_code: TaskOutcomeCode = _to_task_outcome_code(
-        response.outcome_code, logger=logger
+        result.outcome_code, logger=logger
     )
     failure_reason: Optional[TaskFailureReason] = None
     invocation_error_output: Optional[SerializedObject] = None
@@ -198,11 +249,11 @@ def _task_output_from_function_executor_response(
     if outcome_code == TaskOutcomeCode.TASK_OUTCOME_CODE_FAILURE:
         response_validator.required_field("failure_reason")
         failure_reason: Optional[TaskFailureReason] = _to_task_failure_reason(
-            response.failure_reason, logger
+            result.failure_reason, logger
         )
         if failure_reason == TaskFailureReason.TASK_FAILURE_REASON_INVOCATION_ERROR:
             response_validator.required_field("invocation_error_output")
-            invocation_error_output = response.invocation_error_output
+            invocation_error_output = result.invocation_error_output
 
     if _ENABLE_INJECT_TASK_CANCELLATIONS:
         logger.warning("injecting cancellation failure for the task allocation")
@@ -217,10 +268,10 @@ def _task_output_from_function_executor_response(
         outcome_code=outcome_code,
         failure_reason=failure_reason,
         invocation_error_output=invocation_error_output,
-        function_outputs=response.function_outputs,
-        next_functions=response.next_functions,
-        stdout=response.stdout,
-        stderr=response.stderr,
+        function_outputs=result.function_outputs,
+        next_functions=result.next_functions,
+        stdout=result.stdout,
+        stderr=result.stderr,
         metrics=metrics,
         execution_start_time=execution_start_time,
         execution_end_time=execution_end_time,

--- a/indexify/src/indexify/executor/function_executor_controller/task_output.py
+++ b/indexify/src/indexify/executor/function_executor_controller/task_output.py
@@ -96,6 +96,24 @@ class TaskOutput:
         )
 
     @classmethod
+    def function_executor_unresponsive(
+        cls,
+        allocation: TaskAllocation,
+        execution_start_time: Optional[float],
+        execution_end_time: Optional[float],
+    ) -> "TaskOutput":
+        """Creates a TaskOutput for an unresponsive FE."""
+        # Task stdout, stderr is not available.
+        return TaskOutput(
+            allocation=allocation,
+            outcome_code=TaskOutcomeCode.TASK_OUTCOME_CODE_FAILURE,
+            failure_reason=TaskFailureReason.TASK_FAILURE_REASON_FUNCTION_ERROR,
+            stderr=f"Function executor is not producing health check progress reports.",
+            execution_start_time=execution_start_time,
+            execution_end_time=execution_end_time,
+        )
+
+    @classmethod
     def task_cancelled(
         cls,
         allocation: TaskAllocation,

--- a/indexify/src/indexify/executor/function_executor_controller/task_output.py
+++ b/indexify/src/indexify/executor/function_executor_controller/task_output.py
@@ -108,7 +108,7 @@ class TaskOutput:
             allocation=allocation,
             outcome_code=TaskOutcomeCode.TASK_OUTCOME_CODE_FAILURE,
             failure_reason=TaskFailureReason.TASK_FAILURE_REASON_FUNCTION_ERROR,
-            stderr=f"Function executor is not producing health check progress reports.",
+            stderr=f"Function executor is not responding to task lifecycle RPCs.",
             execution_start_time=execution_start_time,
             execution_end_time=execution_end_time,
         )

--- a/indexify/src/indexify/executor/function_executor_controller/task_output.py
+++ b/indexify/src/indexify/executor/function_executor_controller/task_output.py
@@ -108,7 +108,6 @@ class TaskOutput:
             allocation=allocation,
             outcome_code=TaskOutcomeCode.TASK_OUTCOME_CODE_FAILURE,
             failure_reason=TaskFailureReason.TASK_FAILURE_REASON_FUNCTION_ERROR,
-            stderr=f"Function executor is not responding to task lifecycle RPCs.",
             execution_start_time=execution_start_time,
             execution_end_time=execution_end_time,
         )


### PR DESCRIPTION
## Context

We want to use asynchronous RPCs for FE task management, so that we can stream results and get progress updates from the FE.

## What

This change implements the executor side of using asynchronous streaming RPCs for FE task management.  NB: It should not go in until https://github.com/tensorlakeai/tensorlake/pull/284 lands.

## Testing

Tensorlake tests, Indexify Python tests

## Contribution Checklist

- [X] If a Python package was changed, please run `make fmt` in the package directory.
- [ ] If the server was changed, please run `make fmt` in `server/`.
- [ ] Make sure all PR Checks are passing.