### PR TITLE
Add support for JSON and SSE responses to invoke endpoint

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,5 +2,19 @@
     "python.analysis.extraPaths": [
         "./indexify/src",
         "./tensorlake/src"
+    ],
+    "cSpell.words": [
+        "cpus",
+        "nanos",
+        "readahead",
+        "retriable",
+        "rocksdb",
+        "sched",
+        "schedulable",
+        "strs",
+        "tensorlake",
+        "tombstoned",
+        "Upserted",
+        "utoipa"
     ]
 }

--- a/indexify/tests/cli/test_server_fe_scaling.py
+++ b/indexify/tests/cli/test_server_fe_scaling.py
@@ -80,7 +80,7 @@ class TestServerFunctionExecutorScaling(unittest.TestCase):
 
         invocation_ids: List[str] = []
         for _ in range(_FE_ALLOCATIONS_QUEUE_SIZE):
-            invocation_id = graph.run(block_until_done=False, sleep_secs=0.01)
+            invocation_id = graph.call(sleep_secs=0.01)
             invocation_ids.append(invocation_id)
 
         fe_ids: Set[str] = set()

--- a/server/src/data_model/mod.rs
+++ b/server/src/data_model/mod.rs
@@ -339,6 +339,10 @@ pub struct ComputeFn {
     #[serde(default)]
     pub retry_policy: FunctionRetryPolicy,
     pub cache_key: Option<CacheKey>,
+    #[serde(default)]
+    pub parameters: Vec<ParameterMetadata>,
+    #[serde(default)]
+    pub return_type: Option<serde_json::Value>,
 }
 
 impl ComputeFn {
@@ -412,6 +416,14 @@ pub struct RuntimeInformation {
     pub minor_version: u8,
     #[serde(default)]
     pub sdk_version: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ParameterMetadata {
+    pub name: String,
+    pub description: Option<String>,
+    pub required: bool,
+    pub data_type: serde_json::Value,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -1048,7 +1060,7 @@ pub enum TaskFailureReason {
     InternalError,
     // Clear function code failure typically by raising an exception from the function code.
     FunctionError,
-    // Function code run time exceeded its cofigured timeout.
+    // Function code run time exceeded its configured timeout.
     FunctionTimeout,
     // Function code raised InvocationError to mark the invocation as permanently failed.
     InvocationError,

--- a/server/src/http_objects.rs
+++ b/server/src/http_objects.rs
@@ -1136,11 +1136,6 @@ pub struct ExecutorsAllocationsResponse {
     pub executors: Vec<ExecutorAllocations>,
 }
 
-#[derive(Debug, Serialize, Deserialize, ToSchema)]
-pub struct RequestQueryParams {
-    pub block_until_finish: Option<bool>,
-}
-
 #[cfg(test)]
 mod tests {
     use crate::http_objects::ComputeFn;

--- a/server/src/http_objects.rs
+++ b/server/src/http_objects.rs
@@ -424,6 +424,10 @@ pub struct ComputeFn {
     pub retry_policy: NodeRetryPolicy,
     #[serde(rename = "cache_key")]
     pub cache_key: Option<CacheKey>,
+    #[serde(default)]
+    pub parameters: Vec<ParameterMetadata>,
+    #[serde(default)]
+    pub return_type: Option<serde_json::Value>,
 }
 
 impl From<ComputeFn> for data_model::ComputeFn {
@@ -442,6 +446,8 @@ impl From<ComputeFn> for data_model::ComputeFn {
             resources: val.resources.into(),
             retry_policy: val.retry_policy.into(),
             cache_key: val.cache_key.and_then(|v| Some(v.into())),
+            parameters: val.parameters.into_iter().map(|p| p.into()).collect(),
+            return_type: val.return_type,
         }
     }
 }
@@ -461,6 +467,8 @@ impl From<data_model::ComputeFn> for ComputeFn {
             resources: c.resources.into(),
             retry_policy: c.retry_policy.into(),
             cache_key: c.cache_key.and_then(|v| Some(v.into())),
+            parameters: c.parameters.into_iter().map(|p| p.into()).collect(),
+            return_type: c.return_type,
         }
     }
 }
@@ -512,6 +520,35 @@ impl From<data_model::RuntimeInformation> for RuntimeInformation {
     }
 }
 
+#[derive(Debug, Serialize, Deserialize, ToSchema, Clone)]
+pub struct ParameterMetadata {
+    pub name: String,
+    pub description: Option<String>,
+    pub required: bool,
+    pub data_type: serde_json::Value,
+}
+
+impl From<data_model::ParameterMetadata> for ParameterMetadata {
+    fn from(parameter: data_model::ParameterMetadata) -> Self {
+        Self {
+            name: parameter.name,
+            description: parameter.description,
+            required: parameter.required,
+            data_type: parameter.data_type,
+        }
+    }
+}
+
+impl From<ParameterMetadata> for data_model::ParameterMetadata {
+    fn from(parameter: ParameterMetadata) -> Self {
+        Self {
+            name: parameter.name,
+            description: parameter.description,
+            required: parameter.required,
+            data_type: parameter.data_type,
+        }
+    }
+}
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
 pub struct ComputeGraph {
     pub name: String,

--- a/server/src/routes/compute_graphs.rs
+++ b/server/src/routes/compute_graphs.rs
@@ -203,10 +203,10 @@ pub async fn list_compute_graphs(
 /// Get a compute graph definition
 #[utoipa::path(
     get,
-    path = "/namespaces/{namespace}/compute_graphs/{compute_graph}",
+    path = "/v1/namespaces/{namespace}/compute-graphs/{compute_graph}",
     tag = "operations",
     responses(
-        (status = 200, description = "compute graph definition", body = http_objects::ComputeGraph),
+        (status = 200, description = "compute graph definition", body = http_objects_v1::ComputeGraph),
         (status = INTERNAL_SERVER_ERROR, description = "internal server error")
     ),
 )]

--- a/server/src/routes/invoke.rs
+++ b/server/src/routes/invoke.rs
@@ -3,9 +3,10 @@ use std::{collections::HashMap, time::Duration};
 use anyhow::anyhow;
 use axum::{
     body::Body,
-    extract::{Path, Query, State},
+    extract::{Path, State},
     http::HeaderMap,
     response::{sse::Event, IntoResponse},
+    Json,
 };
 use futures::{Stream, StreamExt};
 use tokio::sync::broadcast::{error::RecvError, Receiver};
@@ -15,7 +16,7 @@ use uuid::Uuid;
 use super::routes_state::RouteState;
 use crate::{
     data_model::{self, GraphInvocationCtxBuilder, InvocationPayloadBuilder},
-    http_objects::{IndexifyAPIError, RequestId, RequestQueryParams},
+    http_objects::{IndexifyAPIError, RequestId},
     state_store::{
         invocation_events::{InvocationStateChangeEvent, RequestFinishedEvent},
         requests::{InvokeComputeGraphRequest, RequestPayload, StateMachineUpdateRequest},
@@ -146,11 +147,21 @@ async fn create_invocation_event_stream(
 )]
 pub async fn invoke_with_object(
     Path((namespace, compute_graph)): Path<(String, String)>,
-    Query(params): Query<RequestQueryParams>,
     State(state): State<RouteState>,
     headers: HeaderMap,
     body: Body,
 ) -> Result<impl IntoResponse, IndexifyAPIError> {
+    let accept_header = headers
+        .get("accept")
+        .and_then(|value| value.to_str().ok())
+        .unwrap_or("");
+
+    if !accept_header.contains("application/json") && !accept_header.contains("text/event-stream") {
+        return Err(IndexifyAPIError::bad_request(
+            "accept header must be application/json or text/event-stream",
+        ));
+    }
+
     let encoding = headers
         .get("Content-Type")
         .and_then(|value| value.to_str().ok())
@@ -158,7 +169,6 @@ pub async fn invoke_with_object(
         .unwrap_or("application/octet-stream".to_string());
 
     state.metrics.invocations.add(1, &[]);
-    let should_block = params.block_until_finish.unwrap_or(false);
     let payload_key = Uuid::new_v4().to_string();
     let payload_stream = body
         .into_data_stream()
@@ -191,9 +201,10 @@ pub async fn invoke_with_object(
     // subscribing to task event stream before creation to not loose events once
     // invocation is created.
     let mut rx: Option<Receiver<InvocationStateChangeEvent>> = None;
-    if should_block {
+    if accept_header.contains("text/event-stream") {
         rx.replace(state.indexify_state.task_event_stream());
     }
+
     let compute_graph = state
         .indexify_state
         .reader()
@@ -217,7 +228,7 @@ pub async fn invoke_with_object(
         namespace: namespace.clone(),
         compute_graph_name: compute_graph.name.clone(),
         invocation_payload,
-        ctx: graph_invocation_ctx,
+        ctx: graph_invocation_ctx.clone(),
     });
     state
         .indexify_state
@@ -230,15 +241,22 @@ pub async fn invoke_with_object(
             IndexifyAPIError::internal_error(anyhow!("failed to upload content: {}", e))
         })?;
 
+    if accept_header.contains("application/json") {
+        return Ok(Json(RequestId {
+            id: graph_invocation_ctx.invocation_id,
+        })
+        .into_response());
+    }
+
     let invocation_event_stream =
         create_invocation_event_stream(id, rx, state, namespace, compute_graph.name).await;
-    Ok(
-        axum::response::Sse::new(invocation_event_stream).keep_alive(
+    Ok(axum::response::Sse::new(invocation_event_stream)
+        .keep_alive(
             axum::response::sse::KeepAlive::new()
                 .interval(Duration::from_secs(1))
                 .text("keep-alive-text"),
-        ),
-    )
+        )
+        .into_response())
 }
 
 /// Stream progress of a request until it is completed

--- a/server/src/routes/invoke.rs
+++ b/server/src/routes/invoke.rs
@@ -353,13 +353,6 @@ pub async fn invoke_with_object(
             IndexifyAPIError::internal_error(anyhow!("failed to upload content: {}", e))
         })?;
 
-    if !should_block {
-        return Ok(Json(RequestId {
-            id: graph_invocation_ctx.invocation_id,
-        })
-        .into_response());
-    }
-
     let invocation_event_stream =
         create_invocation_progress_stream(id, rx, state, namespace, compute_graph.name).await;
     Ok(axum::response::Sse::new(invocation_event_stream)

--- a/server/src/routes/invoke.rs
+++ b/server/src/routes/invoke.rs
@@ -152,9 +152,9 @@ pub async fn invoke_with_object(
     body: Body,
 ) -> Result<impl IntoResponse, IndexifyAPIError> {
     let accept_header = headers
-        .get("accept")
+        .get("Accept")
         .and_then(|value| value.to_str().ok())
-        .unwrap_or("");
+        .unwrap_or("application/json");
 
     if !accept_header.contains("application/json") && !accept_header.contains("text/event-stream") {
         return Err(IndexifyAPIError::bad_request(

--- a/server/src/routes_internal.rs
+++ b/server/src/routes_internal.rs
@@ -12,15 +12,11 @@ use axum::{
     Router,
 };
 use base64::prelude::*;
-use download::{
-    download_fn_output_payload,
-    download_invocation_error,
-    download_invocation_payload,
-};
+use download::{download_fn_output_payload, download_invocation_error};
 use futures::StreamExt;
 use hyper::StatusCode;
 use internal_ingest::ingest_fn_outputs;
-use invoke::{invoke_with_object, wait_until_invocation_completed};
+use invoke::{invoke_with_object, progress_stream};
 use logs::download_allocation_logs;
 use nanoid::nanoid;
 use tracing::info;
@@ -253,15 +249,11 @@ pub fn namespace_routes(route_state: RouteState) -> Router {
         )
         .route(
             "/compute_graphs/{compute_graph}/invocations/{invocation_id}/wait",
-            get(wait_until_invocation_completed).with_state(route_state.clone()),
+            get(progress_stream).with_state(route_state.clone()),
         )
         .route(
             "/compute_graphs/{compute_graph}/notify",
             get(notify_on_change).with_state(route_state.clone()),
-        )
-        .route(
-            "/compute_graphs/{compute_graph}/invocations/{invocation_id}/payload",
-            get(download_invocation_payload).with_state(route_state.clone()),
         )
         .route(
             "/compute_graphs/{compute_graph}/invocations/{invocation_id}/fn/{fn_name}/output/{id}",

--- a/server/src/routes_v1.rs
+++ b/server/src/routes_v1.rs
@@ -47,7 +47,7 @@ use crate::{
     routes::{
         compute_graphs::{self, create_or_update_compute_graph_v1},
         download::{self, v1_download_fn_output_payload},
-        invoke::{self, wait_until_invocation_completed},
+        invoke::{self, progress_stream},
         routes_state::RouteState,
     },
     state_store::{
@@ -153,7 +153,7 @@ fn v1_namespace_routes(route_state: RouteState) -> Router {
         )
         .route(
             "/compute-graphs/{compute_graph}/requests/{request_id}/progress",
-            get(wait_until_invocation_completed).with_state(route_state.clone()),
+            get(progress_stream).with_state(route_state.clone()),
         )
         .route(
             "/compute-graphs/{compute_graph}/requests/{request_id}",
@@ -219,7 +219,7 @@ struct ComputeGraphCreateType {
 /// List requests for a workflow
 #[utoipa::path(
     get,
-    path = "/namespaces/{namespace}/compute_graphs/{compute_graph}/requests",
+    path = "/v1/namespaces/{namespace}/compute-graphs/{compute_graph}/requests",
     tag = "ingestion",
     params(
         ListParams

--- a/server/src/routes_v1.rs
+++ b/server/src/routes_v1.rs
@@ -12,7 +12,7 @@ use axum::{
 use base64::prelude::*;
 use compute_graphs::{delete_compute_graph, get_compute_graph, list_compute_graphs};
 use download::download_invocation_error;
-use invoke::invoke_with_object;
+use invoke::invoke_with_object_v1;
 use tracing::info;
 use utoipa::{OpenApi, ToSchema};
 use utoipa_swagger_ui::SwaggerUi;
@@ -64,7 +64,7 @@ use crate::{
 #[derive(OpenApi)]
 #[openapi(
         paths(
-            invoke::invoke_with_object,
+            invoke::invoke_with_object_v1,
             graph_requests,
             find_invocation,
             compute_graphs::create_or_update_compute_graph_v1,
@@ -141,7 +141,7 @@ fn v1_namespace_routes(route_state: RouteState) -> Router {
         )
         .route(
             "/compute-graphs/{compute_graph}",
-            post(invoke_with_object).with_state(route_state.clone()),
+            post(invoke_with_object_v1).with_state(route_state.clone()),
         )
         .route(
             "/compute-graphs/{compute_graph}/requests",

--- a/server/src/state_store/invocation_events.rs
+++ b/server/src/state_store/invocation_events.rs
@@ -105,6 +105,13 @@ pub struct TaskCompleted {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct FunctionOutput {
+    pub request_id: String,
+    pub fn_name: String,
+    pub output_uri_path: String,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct TaskMatchedCache {
     pub request_id: String,
     pub fn_name: String,

--- a/server/src/state_store/invocation_events.rs
+++ b/server/src/state_store/invocation_events.rs
@@ -14,12 +14,28 @@ pub enum InvocationStateChangeEvent {
 
 impl InvocationStateChangeEvent {
     pub fn from_task_finished(event: AllocationOutput) -> Self {
+        let mut output_uri_paths = vec![];
+        for output_index in 0..event.node_output.payloads.len() {
+            output_uri_paths.push(TaskOutput {
+                uri_path: format!(
+                    "/v1/namespaces/{}/compute-graphs/{}/requests/{}/fn/{}/outputs/{}/index/{}",
+                    event.namespace,
+                    event.compute_graph,
+                    event.invocation_id,
+                    event.compute_fn,
+                    event.node_output.id,
+                    output_index,
+                ),
+                mime_type: event.node_output.encoding.clone(),
+            });
+        }
         Self::TaskCompleted(TaskCompleted {
             request_id: event.invocation_id,
             fn_name: event.compute_fn,
             task_id: event.allocation.task_id.get().to_string(),
             outcome: (&event.allocation.outcome).into(),
             allocation_id: event.allocation.id.to_string(),
+            outputs: output_uri_paths,
         })
     }
 
@@ -96,19 +112,19 @@ impl From<&TaskOutcome> for TaskOutcomeSummary {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct TaskOutput {
+    pub uri_path: String,
+    pub mime_type: String,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct TaskCompleted {
     pub request_id: String,
     pub fn_name: String,
     pub task_id: String,
     pub allocation_id: String,
     pub outcome: TaskOutcomeSummary,
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct FunctionOutput {
-    pub request_id: String,
-    pub fn_name: String,
-    pub output_uri_path: String,
+    pub outputs: Vec<TaskOutput>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/server/src/state_store/scanner.rs
+++ b/server/src/state_store/scanner.rs
@@ -698,26 +698,6 @@ impl StateReader {
         Ok(Some(invocation_ctx))
     }
 
-    pub fn invocation_payload(
-        &self,
-        namespace: &str,
-        compute_graph: &str,
-        invocation_id: &str,
-    ) -> Result<InvocationPayload> {
-        let kvs = &[KeyValue::new("op", "invocation_payload")];
-        let _timer = Timer::start_with_labels(&self.metrics.state_read, kvs);
-
-        let key = InvocationPayload::key_from(namespace, compute_graph, invocation_id);
-        let value = self.db.get_cf(
-            &IndexifyObjectsColumns::GraphInvocations.cf_db(&self.db),
-            &key,
-        )?;
-        match value {
-            Some(value) => Ok(JsonEncoder::decode(&value)?),
-            None => Err(anyhow!("invocation payload not found")),
-        }
-    }
-
     pub fn fn_output_payload(
         &self,
         namespace: &str,


### PR DESCRIPTION
1. Making the invoke api return just request id if the Accept header passed by the client is application/json and SSE events if it sets text/event-stream. This is more idiomatic than using a query parameter to determine whether the user wants to block. 
2. Make the compute graph record the input parameter and return types of the functions so that they can be used for tool calling




Test Plan - 

```
{
  "name": "sequence_summer",
  "namespace": "default",
  "description": "Simple Sequence Summer",
  "tombstoned": false,
  "entrypoint": {
    "name": "generate_sequence",
    "fn_name": "generate_sequence",
    "description": "Generates sequence of numbersArgs:    a: the number of elements to generate",
    "reducer": false,
    "input_encoder": "cloudpickle",
    "output_encoder": "cloudpickle",
    "image_information": {
      "image_name": "python:3.13-slim-bookworm",
      "image_hash": "6c268fb2970c7cf11a0d0a560dab5860f0a945013e54c796aa5b3ffd61b1e324",
      "tag": "",
      "base_image": "",
      "run_strs": [],
      "image_uri": "",
      "sdk_version": "0.2.31"
    },
    "secret_names": [],
    "timeout_sec": 300,
    "resources": {
      "cpus": 1,
      "memory_mb": 1024,
      "ephemeral_disk_mb": 2048,
      "gpus": []
    },
    "retry_policy": {
      "max_retries": 0,
      "initial_delay_sec": 1,
      "max_delay_sec": 60,
      "delay_multiplier": 2
    },
    "cache_key": null,
    "parameters": [
      {
        "name": "a",
        "description": "the number of elements to generate",
        "required": true,
        "data_type": {
          "type": "integer"
        }
      }
    ],
    "return_type": {
      "items": {
        "type": "integer"
      },
      "type": "array"
    }
  },
  "version": "OWZRJcbSFOv6q9svENGBj",
  "tags": {},
  "functions": {
    "squared": {
      "name": "squared",
      "fn_name": "squared",
      "description": "",
      "reducer": false,
      "input_encoder": "cloudpickle",
      "output_encoder": "cloudpickle",
      "image_information": {
        "image_name": "python:3.13-slim-bookworm",
        "image_hash": "6c268fb2970c7cf11a0d0a560dab5860f0a945013e54c796aa5b3ffd61b1e324",
        "tag": "",
        "base_image": "",
        "run_strs": [],
        "image_uri": "",
        "sdk_version": "0.2.31"
      },
      "secret_names": [],
      "timeout_sec": 300,
      "resources": {
        "cpus": 1,
        "memory_mb": 1024,
        "ephemeral_disk_mb": 2048,
        "gpus": []
      },
      "retry_policy": {
        "max_retries": 0,
        "initial_delay_sec": 1,
        "max_delay_sec": 60,
        "delay_multiplier": 2
      },
      "cache_key": null,
      "parameters": [
        {
          "name": "x",
          "description": null,
          "required": true,
          "data_type": {
            "type": "integer"
          }
        }
      ],
      "return_type": {
        "type": "integer"
      }
    },
    "generate_sequence": {
      "name": "generate_sequence",
      "fn_name": "generate_sequence",
      "description": "Generates sequence of numbersArgs:    a: the number of elements to generate",
      "reducer": false,
      "input_encoder": "cloudpickle",
      "output_encoder": "cloudpickle",
      "image_information": {
        "image_name": "python:3.13-slim-bookworm",
        "image_hash": "6c268fb2970c7cf11a0d0a560dab5860f0a945013e54c796aa5b3ffd61b1e324",
        "tag": "",
        "base_image": "",
        "run_strs": [],
        "image_uri": "",
        "sdk_version": "0.2.31"
      },
      "secret_names": [],
      "timeout_sec": 300,
      "resources": {
        "cpus": 1,
        "memory_mb": 1024,
        "ephemeral_disk_mb": 2048,
        "gpus": []
      },
      "retry_policy": {
        "max_retries": 0,
        "initial_delay_sec": 1,
        "max_delay_sec": 60,
        "delay_multiplier": 2
      },
      "cache_key": null,
      "parameters": [
        {
          "name": "a",
          "description": "the number of elements to generate",
          "required": true,
          "data_type": {
            "type": "integer"
          }
        }
      ],
      "return_type": {
        "items": {
          "type": "integer"
        },
        "type": "array"
      }
    }
  },
  "edges": {
    "generate_sequence": [
      "squared"
    ]
  },
  "created_at": 0,
  "runtime_information": {
    "major_version": 3,
    "minor_version": 13,
    "sdk_version": "0.2.31"
  }
}
```