### PR TITLE
Don't tag ECR with the version.

### DIFF
--- a/.github/workflows/build_ecr_image.yaml
+++ b/.github/workflows/build_ecr_image.yaml
@@ -53,6 +53,6 @@ jobs:
         uses: aws-actions/amazon-ecr-login@v2
 
       - run: |
-          docker buildx build --platform=linux/amd64 --push . -t ${{ steps.login-ecr.outputs.registry }}/indexify-server:${{ github.sha }} -t ${{ steps.login-ecr.outputs.registry }}/indexify-server:latest -t ${{ steps.login-ecr.outputs.registry }}/indexify-server:$VERSION_TAG -f dockerfiles/Dockerfile.local
+          docker buildx build --platform=linux/amd64 --push . -t ${{ steps.login-ecr.outputs.registry }}/indexify-server:${{ github.sha }} -t ${{ steps.login-ecr.outputs.registry }}/indexify-server:latest -f dockerfiles/Dockerfile.local
         env:
           VERSION_TAG: ${{ inputs.version }}


### PR DESCRIPTION
## Context

This addresses one of the causes of a recent outage. We no longer tag on-merge builds with the version tag.

## What

Don't tag ECR builds with version tag.

## Testing

<!--
Please include steps used to verify the change.

Consider providing screenshots, logs, code or other visual aids to help the reviewer in their testing.
-->

## Contribution Checklist

- [ ] If a Python package was changed, please run `make fmt` in the package directory.
- [ ] If the server was changed, please run `make fmt` in `server/`.
- [ ] Make sure all PR Checks are passing.
<!--
Notes:

Tests of a Python package can be run manually. Start a Server and an Executor then
run `make test` in the Python package directory.

To test if changes to the server are backward compatible with the latest
release, label the PR with `ci_compat_test`. This might report failures
unrelated to your change if previous incompatible changes were pushed without
being released yet
-->
