### PR TITLE
feat: add event IDs to SSE stream events

### DIFF
--- a/server/src/routes/invoke.rs
+++ b/server/src/routes/invoke.rs
@@ -20,7 +20,9 @@ use crate::{
     http_objects::{IndexifyAPIError, RequestId},
     state_store::{
         invocation_events::{
-            InvocationStateChangeEvent, RequestFinishedEvent, REQUEST_FINISHED_EVENT_ID,
+            InvocationStateChangeEvent,
+            RequestFinishedEvent,
+            REQUEST_FINISHED_EVENT_ID,
         },
         requests::{InvokeComputeGraphRequest, RequestPayload, StateMachineUpdateRequest},
     },

--- a/server/src/state_store/invocation_events.rs
+++ b/server/src/state_store/invocation_events.rs
@@ -2,6 +2,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::{data_model::TaskOutcome, state_store::requests::AllocationOutput};
 
+pub const REQUEST_FINISHED_EVENT_ID: &str = "request_finished";
+
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum InvocationStateChangeEvent {
     TaskCreated(TaskCreated),
@@ -64,6 +66,13 @@ impl InvocationStateChangeEvent {
                 request_id: invocation_id,
                 ..
             }) => invocation_id.clone(),
+        }
+    }
+
+    pub fn to_event_id(&self) -> String {
+        match self {
+            InvocationStateChangeEvent::RequestFinished(_) => REQUEST_FINISHED_EVENT_ID.to_string(),
+            _ => "state_change".to_string(),
         }
     }
 }


### PR DESCRIPTION
## Context

While integrating the Inkwell service to the Indexify SSE APIs, I've realized that having IDs on the events (a supported [SSE event property](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events#id)) would make working with the API significantly easier.

## What

Add two basic event IDs to the state change progress and the Invoke API

