### PR TITLE
Reduce log verbosity on hot paths

### DIFF
--- a/server/src/executor_api.rs
+++ b/server/src/executor_api.rs
@@ -740,7 +740,7 @@ fn log_desired_executor_state_delta(
             match last_assignments.get(fn_executor_id) {
                 Some(last_allocation_id) => {
                     if allocation_id != last_allocation_id {
-                        info!(
+                        debug!(
                             %fn_executor_id,
                             %allocation_id, %last_allocation_id, "re-assigning FE"
                         )
@@ -748,14 +748,14 @@ fn log_desired_executor_state_delta(
                     last_assignments.remove(fn_executor_id);
                 }
                 None => {
-                    info!(%fn_executor_id, %allocation_id, "assigning FE")
+                    debug!(%fn_executor_id, %allocation_id, "assigning FE")
                 }
             }
         }
     }
 
     for (fn_executor_id, last_allocation_id) in last_assignments {
-        info!(%fn_executor_id, %last_allocation_id, "idling FE")
+        debug!(%fn_executor_id, %last_allocation_id, "idling FE")
     }
 }
 

--- a/server/src/processor/task_allocator.rs
+++ b/server/src/processor/task_allocator.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use tracing::{debug, info, info_span, warn};
+use tracing::{debug, info_span, warn};
 
 use crate::{
     data_model::{AllocationBuilder, Task, TaskFailureReason, TaskOutcome, TaskStatus},
@@ -141,7 +141,7 @@ impl<'a> TaskAllocationProcessor<'a> {
             .outcome(TaskOutcome::Unknown)
             .build()?;
 
-        info!(allocation_id = allocation.id, "created allocation");
+        debug!(allocation_id = allocation.id, "created allocation");
         update
             .updated_tasks
             .insert(updated_task.id.clone(), updated_task.clone());


### PR DESCRIPTION
## Context

Recent stress tests in dev caused log ingestion alerts.

## What

These log statements appear to be the ones in Indexify on the hot path of task execution; they don't appear to be critically necessary in production.  (This change does leave allocation outcome logging at the INFO level when a task fails, but we might want to turn that one down as well.)

## Testing

Well, it compiles; we'll see what happens in stress :-)

## Contribution Checklist

- [ ] If a Python package was changed, please run `make fmt` in the package directory.
- [X] If the server was changed, please run `make fmt` in `server/`.
- [ ] Make sure all PR Checks are passing.
