### PR TITLE
Update graph state on server startup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1700,7 +1700,7 @@ dependencies = [
 
 [[package]]
 name = "indexify-server"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/server/src/data_model/mod.rs
+++ b/server/src/data_model/mod.rs
@@ -425,6 +425,12 @@ pub struct ParameterMetadata {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum ComputeGraphState {
+    Active,
+    Disabled { reason: String },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct ComputeGraph {
     pub namespace: String,
     pub name: String,
@@ -440,6 +446,7 @@ pub struct ComputeGraph {
     pub nodes: HashMap<String, ComputeFn>,
     pub edges: HashMap<String, Vec<String>>,
     pub runtime_information: RuntimeInformation,
+    pub state: ComputeGraphState,
 }
 
 impl ComputeGraph {
@@ -482,6 +489,7 @@ impl ComputeGraph {
             nodes: self.nodes.clone(),
             edges: self.edges.clone(),
             runtime_information: self.runtime_information.clone(),
+            state: self.state.clone(),
         }
     }
 }
@@ -505,6 +513,7 @@ pub struct ComputeGraphVersion {
     pub nodes: HashMap<String, ComputeFn>,
     pub edges: HashMap<String, Vec<String>>,
     pub runtime_information: RuntimeInformation,
+    pub state: ComputeGraphState,
 }
 
 impl ComputeGraphVersion {
@@ -2200,6 +2209,7 @@ mod tests {
             tombstoned: false,
             description: "description1".to_string(),
             tags: HashMap::new(),
+            state: ComputeGraphState::Active,
             nodes: HashMap::from([
                 ("fn_a".to_string(), fn_a.clone()),
                 ("fn_b".to_string(), fn_b.clone()),

--- a/server/src/data_model/test_objects.rs
+++ b/server/src/data_model/test_objects.rs
@@ -117,6 +117,7 @@ pub mod tests {
 
         ComputeGraph {
             namespace: TEST_NAMESPACE.to_string(),
+            state: ComputeGraphState::Active,
             name: "graph_A".to_string(),
             tags: HashMap::from([
                 ("tag1".to_string(), "val1".to_string()),

--- a/server/src/http_objects.rs
+++ b/server/src/http_objects.rs
@@ -57,6 +57,10 @@ impl IndexifyAPIError {
     pub fn bad_request(message: &str) -> Self {
         Self::new(StatusCode::BAD_REQUEST, message)
     }
+
+    pub fn conflict(message: &str) -> Self {
+        Self::new(StatusCode::CONFLICT, message)
+    }
 }
 
 impl IntoResponse for IndexifyAPIError {
@@ -647,6 +651,7 @@ impl ComputeGraph {
             created_at: 0,
             runtime_information: self.runtime_information.into(),
             tombstoned: self.tombstoned,
+            state: data_model::ComputeGraphState::Active,
         };
         Ok(compute_graph)
     }

--- a/server/src/http_objects_v1.rs
+++ b/server/src/http_objects_v1.rs
@@ -85,6 +85,7 @@ impl ComputeGraph {
             created_at: 0,
             runtime_information: self.runtime_information.into(),
             tombstoned: self.tombstoned,
+            state: data_model::ComputeGraphState::Active,
         };
         Ok(compute_graph)
     }

--- a/server/src/routes/compute_graphs.rs
+++ b/server/src/routes/compute_graphs.rs
@@ -10,7 +10,7 @@ use utoipa::ToSchema;
 
 use crate::{
     blob_store::PutResult,
-    data_model::ComputeGraphError,
+    data_model::{ComputeGraph, ComputeGraphError},
     http_objects::{self, IndexifyAPIError, ListParams},
     http_objects_v1,
     routes::routes_state::RouteState,
@@ -31,7 +31,7 @@ struct ComputeGraphCreateType {
 }
 
 async fn validate_placement_constraints_against_executor_label_sets(
-    compute_graph: &crate::data_model::ComputeGraph,
+    compute_graph: &ComputeGraph,
     state: &RouteState,
 ) -> Result<(), IndexifyAPIError> {
     let lock_guard = state.indexify_state.in_memory_state.read().await;

--- a/server/src/service.rs
+++ b/server/src/service.rs
@@ -107,6 +107,7 @@ impl Service {
             task_cache.clone(),
             config.queue_size,
         ));
+        graph_processor.validate_graph_constraints().await?;
         Ok(Self {
             config,
             shutdown_tx,


### PR DESCRIPTION
## Context

For performance, we want to check whether a compute graph's label constraints can be satisfied at server startup time, not at invocation or scheduling time.

## What

This change adds a state to the compute graph, updates the state at server startup, and uses the state for determining schedulability.

## Testing

CI

## Contribution Checklist

- [ ] If a Python package was changed, please run `make fmt` in the package directory.
- [X] If the server was changed, please run `make fmt` in `server/`.
- [ ] Make sure all PR Checks are passing.
