### PR TITLE
Default potentially-missing ComputeGraphState

### DIFF
--- a/server/src/data_model/mod.rs
+++ b/server/src/data_model/mod.rs
@@ -429,6 +429,12 @@ pub enum ComputeGraphState {
     Disabled { reason: String },
 }
 
+impl Default for ComputeGraphState {
+    fn default() -> Self {
+        ComputeGraphState::Active
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct ComputeGraph {
     pub namespace: String,
@@ -445,6 +451,7 @@ pub struct ComputeGraph {
     pub nodes: HashMap<String, ComputeFn>,
     pub edges: HashMap<String, Vec<String>>,
     pub runtime_information: RuntimeInformation,
+    #[serde(default)]
     pub state: ComputeGraphState,
 }
 
@@ -505,6 +512,7 @@ pub struct ComputeGraphVersion {
     pub nodes: HashMap<String, ComputeFn>,
     pub edges: HashMap<String, Vec<String>>,
     pub runtime_information: RuntimeInformation,
+    #[serde(default)]
     pub state: ComputeGraphState,
 }
 


### PR DESCRIPTION
## Context

The ComputeGraphState may be missing from the database, causing server startup to fail.

## What

This change defaults ComputeGraphState to Active for existing ComputeGraph and ComputeGraphVersion entities that don't have a ComputeGraphState defined; since the value of this field is recomputed at server startup, it's okay to treat missing values as being active.

## Testing

Reproduced the issue locally, then verified that this change fixes it.
`cargo test --workspace -- --test-threads 1`

## Contribution Checklist

- [ ] If a Python package was changed, please run `make fmt` in the package directory.
- [X] If the server was changed, please run `make fmt` in `server/`.
- [ ] Make sure all PR Checks are passing.
