### PR TITLE
Process a task alloc outcome only if the task is running the alloc

### DIFF
--- a/indexify/src/indexify/proto/executor_api.proto
+++ b/indexify/src/indexify/proto/executor_api.proto
@@ -240,9 +240,10 @@ enum TaskOutcomeCode {
 enum TaskFailureReason {
     TASK_FAILURE_REASON_UNKNOWN = 0;
     // Internal error on Executor aka platform error.
-    // Includes grey failures when we can't determine the exact cause.
     TASK_FAILURE_REASON_INTERNAL_ERROR = 1;
     // Clear function code failure typically by raising an exception from the function code.
+    // Also a grey failure where we can't determine the exact cause. We attribute these to
+    // functions to prevent service abuse but not billed intenionally failing functions.
     TASK_FAILURE_REASON_FUNCTION_ERROR = 2;
     // Function code run time exceeded its configured timeout.
     TASK_FAILURE_REASON_FUNCTION_TIMEOUT = 3;

--- a/indexify/tests/features/test_function_retries.py
+++ b/indexify/tests/features/test_function_retries.py
@@ -65,7 +65,6 @@ class TestFunctionRetries(unittest.TestCase):
         outputs = graph.output(invocation_id, function_aways_fails.name)
         self.assertEqual(len(outputs), 0)
 
-    @unittest.skip("Function timeout retries feature has a bug")
     def test_function_fails_after_exhausting_timeout_retries(self):
         graph = Graph(
             name=test_graph_name(self),

--- a/server/proto/executor_api.proto
+++ b/server/proto/executor_api.proto
@@ -240,9 +240,10 @@ enum TaskOutcomeCode {
 enum TaskFailureReason {
     TASK_FAILURE_REASON_UNKNOWN = 0;
     // Internal error on Executor aka platform error.
-    // Includes grey failures when we can't determine the exact cause.
     TASK_FAILURE_REASON_INTERNAL_ERROR = 1;
     // Clear function code failure typically by raising an exception from the function code.
+    // Also a grey failure where we can't determine the exact cause. We attribute these to
+    // functions to prevent service abuse but not billed intenionally failing functions.
     TASK_FAILURE_REASON_FUNCTION_ERROR = 2;
     // Function code run time exceeded its configured timeout.
     TASK_FAILURE_REASON_FUNCTION_TIMEOUT = 3;

--- a/server/src/http_objects.rs
+++ b/server/src/http_objects.rs
@@ -776,7 +776,7 @@ impl From<data_model::TaskStatus> for TaskStatus {
     fn from(status: data_model::TaskStatus) -> Self {
         match status {
             data_model::TaskStatus::Pending => TaskStatus::Pending,
-            data_model::TaskStatus::Running => TaskStatus::Running,
+            data_model::TaskStatus::Running(_) => TaskStatus::Running,
             data_model::TaskStatus::Completed => TaskStatus::Completed,
         }
     }

--- a/server/src/processor/task_policy.rs
+++ b/server/src/processor/task_policy.rs
@@ -1,43 +1,31 @@
 use if_chain::if_chain;
 
-use crate::data_model::{ComputeGraphVersion, Task, TaskFailureReason, TaskOutcome, TaskStatus};
+use crate::data_model::{
+    Allocation,
+    ComputeGraphVersion,
+    Task,
+    TaskFailureReason,
+    TaskOutcome,
+    TaskStatus,
+};
 
 /// Determines task retry policy based on failure reasons and retry
 /// configuration
 pub struct TaskRetryPolicy;
 
 impl TaskRetryPolicy {
-    /// Determines if a task should be retried based on a function executor
-    /// termination, updating the task accordingly
-    pub fn handle_function_executor_termination(
-        task: &mut Task,
-        task_failure_reason: TaskFailureReason,
-        failed_alloc_ids: &[String],
-        alloc_id: &str,
-        compute_graph_version: &ComputeGraphVersion,
-    ) {
-        // Check if this allocation was blamed for the failure
-        if failed_alloc_ids.contains(&alloc_id.to_string()) {
-            // Use the standard allocation failure handling
-            Self::handle_allocation_failure(task, task_failure_reason, compute_graph_version);
-        } else {
-            // This allocation wasn't blamed for the failure, allow retry
-            task.status = TaskStatus::Pending;
-        }
-    }
-
     /// Determines if a task should be retried based on an allocation failure
-    /// reason, updating the task accordingly
-    pub fn handle_allocation_failure(
+    /// reason, updating the task accordingly.
+    fn handle_allocation_failure(
         task: &mut Task,
-        failure_reason: TaskFailureReason,
+        alloc_failure_reason: TaskFailureReason,
         compute_graph_version: &ComputeGraphVersion,
     ) {
-        let uses_attempt = failure_reason.should_count_against_task_retry_attempts();
+        let uses_attempt = alloc_failure_reason.should_count_against_task_retry_attempts();
 
         if_chain! {
             if let Some(max_retries) = compute_graph_version.task_max_retries(task);
-            if failure_reason.is_retriable();
+            if alloc_failure_reason.is_retriable();
         if task.attempt_number < max_retries || !uses_attempt;
             then {
                 // Task can be retried
@@ -49,26 +37,27 @@ impl TaskRetryPolicy {
             else {
                 // Task cannot be retried - either no max retries, not retriable, or exhausted attempts.
                 task.status = TaskStatus::Completed;
-                task.outcome = TaskOutcome::Failure(failure_reason);
+                task.outcome = TaskOutcome::Failure(alloc_failure_reason);
             }
         }
     }
 
     /// Determines if a task should be retried based on allocation
-    /// outcome, leaving the task with the appropriate status
+    /// outcome, leaving the task with the appropriate status.
+    /// The task must be running the allocation to ensure idempotency.
     pub fn handle_allocation_outcome(
         task: &mut Task,
-        outcome: &TaskOutcome,
+        allocation: &Allocation,
         compute_graph_version: &ComputeGraphVersion,
     ) {
-        match outcome {
+        match allocation.outcome {
             TaskOutcome::Success => {
                 task.status = TaskStatus::Completed;
-                task.outcome = *outcome;
+                task.outcome = allocation.outcome.clone();
             }
             TaskOutcome::Failure(failure_reason) => {
                 // Handle allocation failure
-                Self::handle_allocation_failure(task, *failure_reason, compute_graph_version);
+                Self::handle_allocation_failure(task, failure_reason, compute_graph_version);
             }
             TaskOutcome::Unknown => {
                 // For unknown outcomes, set to pending to allow retry

--- a/server/src/testing.rs
+++ b/server/src/testing.rs
@@ -144,7 +144,7 @@ impl TestService {
         let tasks = self.get_all_tasks().await?;
         let allocated_tasks = tasks
             .into_iter()
-            .filter(|t| t.status == TaskStatus::Running)
+            .filter(|t| matches!(t.status, TaskStatus::Running(_)))
             .collect::<Vec<_>>();
         Ok(allocated_tasks)
     }


### PR DESCRIPTION
We have two paths where we handle task alloc outcomes:
* Task Alloc output ingestion
* FE termination

Depending on exact cause Executor can send notifications to Server to activate both paths per alloc or only one path. E.g. when Executor gets shutdown only FE termination path gets activates on Server. Another example is when a task alloc function timesout. In this case Executor sends task outcome to Server but also send FE termination update with the alloc id being blamed for FE termination.

The current idempotency check "if Task Status is Running" to not process an alloc for the second time on one of the paths fails with the following scenario:

1. First alloc (attempt 0) causes FE termination by timing out in the alloc function.
2. Server gets ingest alloc (attempt 0) output notification.
3. Server creates new alloc (attempt 1) for the same FE because it doesn't know yet that it's terminated. The alloc Task status is set to Running.
4. Server recieves notification that the FE was terminated (due to the first alloc attempt 0) and sees that the task is in Running state. Server creates a new alloc because of this and increments retry counter. Now there are two allocs for the same task and the state machine is somewhat inconsistent for the task. E.g. some allocs end up with "Undefined" state but running the task doesn't fail so far.

To fix this the idempotency is ensured by doing the following sequence on each alloc outcome processing path:

1. Check if the task is running the alloc that we're processing.
2. Once alloc is processed set running alloc id in the task to None.

This ensures that we won't process alloc outcome on either of the paths more than once even when we get an outcome for alloc that is not the current alloc that the task is running.

To implement this task's Running status now includes id of the running allocation. And then when we set the task status to pending or completed this effectively sets the running allocation id to None. Storing alloc id in Task looks okay because we persist both Task and Allocation objects in state store.

This breaks state store backward compatibility but it's okay as with the upcoming S3 direct changes state store will need to get wiped anyway so we're free to implement this fix in any way we see fit. There might be a better way to implement this, please let me know.

I also updated some stale comments and refactored existing code a bit on the code paths that I touched.

This fix is not surfacing in tests right now. The test that I uncommented in this PR is passing without this fix. But with S3 direct changes the timings/ordering of events change and this test starts failing consistently.