### PR TITLE
Add support for machine catalog

### DIFF
--- a/server/src/data_model/mod.rs
+++ b/server/src/data_model/mod.rs
@@ -1408,14 +1408,6 @@ pub const GPU_MODEL_NVIDIA_A100_80GB: &str = "A100-80GB";
 pub const GPU_MODEL_NVIDIA_TESLA_T4: &str = "T4";
 pub const GPU_MODEL_NVIDIA_A6000: &str = "A6000";
 pub const GPU_MODEL_NVIDIA_A10: &str = "A10";
-pub const ALL_GPU_MODELS: [&str; 6] = [
-    GPU_MODEL_NVIDIA_H100_80GB,
-    GPU_MODEL_NVIDIA_A100_40GB,
-    GPU_MODEL_NVIDIA_A100_80GB,
-    GPU_MODEL_NVIDIA_TESLA_T4,
-    GPU_MODEL_NVIDIA_A6000,
-    GPU_MODEL_NVIDIA_A10,
-];
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
 pub struct HostResources {

--- a/server/src/http_objects_v1.rs
+++ b/server/src/http_objects_v1.rs
@@ -4,7 +4,6 @@ use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
 use crate::{
-    config::ExecutorConfig,
     data_model::{
         self,
         ComputeGraphCode,
@@ -48,11 +47,11 @@ impl ComputeGraph {
         code_path: &str,
         sha256_hash: &str,
         size: u64,
-        executor_config: &ExecutorConfig,
+        executor_catalog_entries: &Vec<crate::config::ExecutorCatalogEntry>,
     ) -> Result<data_model::ComputeGraph, IndexifyAPIError> {
         let mut nodes = HashMap::new();
         for (name, node) in self.functions {
-            node.validate(executor_config)?;
+            node.validate(executor_catalog_entries)?;
             let converted_node: data_model::ComputeFn = node.try_into().map_err(|e| {
                 IndexifyAPIError::bad_request(&format!(
                     "Invalid placement constraints in function '{}': {}",

--- a/server/src/integration_test_executor_catalog.rs
+++ b/server/src/integration_test_executor_catalog.rs
@@ -28,6 +28,10 @@ mod tests {
         let catalog_entry = ExecutorCatalogEntry {
             name: "custom".to_string(), // name is unused when labels are populated
             regions: vec![],            // regions unused
+            cpu_cores: 1,
+            memory_gb: 1,
+            disk_gb: 1,
+            gpu_models: vec![],
             labels,
         };
 
@@ -156,6 +160,10 @@ mod tests {
         let catalog_entry = ExecutorCatalogEntry {
             name: "custom".to_string(),
             regions: vec![],
+            cpu_cores: 1,
+            memory_gb: 1,
+            disk_gb: 1,
+            gpu_models: vec![],
             labels,
         };
 

--- a/server/src/routes/compute_graphs.rs
+++ b/server/src/routes/compute_graphs.rs
@@ -140,7 +140,7 @@ pub async fn create_or_update_compute_graph_v1(
         &put_result.url,
         &put_result.sha256_hash,
         put_result.size_bytes,
-        &state.config.executor,
+        &state.config.executor_catalog,
     )?;
     let name = compute_graph.name.clone();
 

--- a/server/src/routes_internal.rs
+++ b/server/src/routes_internal.rs
@@ -453,7 +453,7 @@ async fn create_or_update_compute_graph(
         &put_result.url,
         &put_result.sha256_hash,
         put_result.size_bytes,
-        &state.config.executor,
+        &state.config.executor_catalog,
     )?;
     let name = compute_graph.name.clone();
     info!(


### PR DESCRIPTION
We often push graphs which can't be supported by the production clusters. Such as graphs asking for more resources than any machine we could possibly bring up. 

This rejects graphs when they are pushed if node catalogs are present. When catalog is empty it assumes that any resources can be satisfied. 

Backward incompatible config changes. 