### PR TITLE
Fix linting issues.

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -21,11 +21,26 @@ jobs:
     name: Lint Indexify Server
     runs-on: ubuntu-latest
     steps:
+      - name: Install protobuf package
+        run: sudo apt update && sudo apt install -y protobuf-compiler
       - uses: actions/checkout@v4
-      - name: Lint indexify-server
+      - name: Copy rust-toolchain
+        run: cp server/rust-toolchain.toml .
+      - name: Setup Rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          components: clippy, rustfmt
+          cache-directories: |
+            target
+      - name: Install Just
+        uses: extractions/setup-just@v3
+      - name: Check formatting of indexify-server
         run: |
           cd server
           make check
+      - name: Check linting of indexify-server
+        run: |
+          just lint
 
   build_server:
     name: Build Indexify Server
@@ -41,19 +56,10 @@ jobs:
         with:
           cache-directories: |
             target
-      - name: Setup Rust
-        uses: actions-rust-lang/setup-rust-toolchain@v1
-        with:
-          cache-directories: |
-            target
       - name: Build indexify-server
         run: |
           cd server
           cargo build
-      - name: Lint indexify-server
-        run: |
-          cd server
-          make check
       - name: Test indexify-server
         run: |
           cd server

--- a/.justfile
+++ b/.justfile
@@ -96,3 +96,11 @@ run-server:
 [working-directory: 'indexify']
 run-executor:
     poetry run indexify-cli executor --grpc-server-addr localhost:8901 --verbose
+
+[doc('Check linting of Rust projects')]
+lint:
+	cargo clippy --all -- -D warnings
+
+[doc('Fix Rust linting issues that can be solved automatically')]
+fix-lint:
+    cargo clippy --fix --allow-dirty

--- a/server/src/blob_store/mod.rs
+++ b/server/src/blob_store/mod.rs
@@ -168,7 +168,7 @@ impl BlobStorage {
         let client_clone = self.object_store.clone();
         let (tx, rx) = mpsc::unbounded_channel();
         let options = GetOptions {
-            range: range.map(|r| object_store::GetRange::Bounded(r)),
+            range: range.map(object_store::GetRange::Bounded),
             ..Default::default()
         };
         let get_result = client_clone

--- a/server/src/data_model/mod.rs
+++ b/server/src/data_model/mod.rs
@@ -384,16 +384,13 @@ pub struct ParameterMetadata {
     pub data_type: serde_json::Value,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
 pub enum ComputeGraphState {
+    #[default]
     Active,
-    Disabled { reason: String },
-}
-
-impl Default for ComputeGraphState {
-    fn default() -> Self {
-        ComputeGraphState::Active
-    }
+    Disabled {
+        reason: String,
+    },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -445,6 +442,7 @@ impl ComputeGraph {
         self.tags = update.tags;
     }
 
+    #[allow(clippy::wrong_self_convention)]
     pub fn into_version(&self) -> ComputeGraphVersion {
         ComputeGraphVersion {
             namespace: self.namespace.clone(),
@@ -462,7 +460,7 @@ impl ComputeGraph {
 
     pub fn can_be_scheduled(
         &self,
-        executor_catalog_entries: &Vec<crate::config::ExecutorCatalogEntry>,
+        executor_catalog_entries: &[crate::config::ExecutorCatalogEntry],
     ) -> Result<()> {
         if executor_catalog_entries.is_empty() {
             return Ok(());
@@ -1193,10 +1191,10 @@ impl Display for TaskStatus {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let str_val = match self {
             TaskStatus::Pending => "Pending".to_string(),
-            TaskStatus::Running(status) => format!("Running({:?})", status),
+            TaskStatus::Running(status) => format!("Running({status:?})"),
             TaskStatus::Completed => "Completed".to_string(),
         };
-        write!(f, "{}", str_val)
+        write!(f, "{str_val}")
     }
 }
 
@@ -1876,7 +1874,6 @@ impl FunctionExecutorBuilder {
             .ok_or(anyhow!("resources is required"))?;
         let max_concurrency = self
             .max_concurrency
-            .clone()
             .ok_or(anyhow!("max_concurrency is required"))?;
         Ok(FunctionExecutor {
             id,
@@ -1895,7 +1892,7 @@ impl FunctionExecutorBuilder {
 #[builder(build_fn(skip))]
 pub struct ExecutorServerMetadata {
     pub executor_id: ExecutorId,
-    pub function_executors: HashMap<FunctionExecutorId, Box<FunctionExecutorServerMetadata>>,
+    pub function_executors: HashMap<FunctionExecutorId, FunctionExecutorServerMetadata>,
     pub free_resources: HostResources,
     pub resource_claims: HashMap<FunctionExecutorId, FunctionExecutorResources>,
 }

--- a/server/src/executor_api.rs
+++ b/server/src/executor_api.rs
@@ -384,7 +384,7 @@ impl TryFrom<FunctionExecutorState> for data_model::FunctionExecutor {
         let max_concurrency = function_executor_state
             .description
             .as_ref()
-            .and_then(|description| description.max_concurrency.clone())
+            .and_then(|description| description.max_concurrency)
             .unwrap_or(1);
         // TODO: uncomment this once Executor gets deployed and provides this.
         // .ok_or(anyhow::anyhow!("max_concurrency is required"))?;
@@ -466,7 +466,7 @@ fn to_function_executor_diagnostics(
 }
 
 fn to_function_executor_diagnostics_vector(
-    function_executor_updates: &Vec<executor_api_pb::FunctionExecutorUpdate>,
+    function_executor_updates: &[executor_api_pb::FunctionExecutorUpdate],
     blob_storage_registry: &BlobStorageRegistry,
 ) -> Result<Vec<FunctionExecutorDiagnostics>> {
     function_executor_updates

--- a/server/src/executors.rs
+++ b/server/src/executors.rs
@@ -249,7 +249,7 @@ impl ExecutorManager {
                 Some(existing_executor) => {
                     let mut existing_executor = existing_executor.clone();
                     existing_executor.update(executor.clone());
-                    *existing_executor
+                    existing_executor
                 }
             };
 
@@ -554,7 +554,7 @@ impl ExecutorManager {
             .executors
             .values()
         {
-            executors.push(*executor.clone());
+            executors.push(executor.clone());
         }
         Ok(executors)
     }
@@ -583,7 +583,7 @@ impl ExecutorManager {
                                 .map(|allocations| {
                                     allocations
                                         .iter()
-                                        .map(|allocation| allocation.as_ref().clone().into())
+                                        .map(|allocation| allocation.clone().into())
                                         .collect::<Vec<_>>()
                                 })
                                 .unwrap_or_default()
@@ -618,9 +618,7 @@ impl ExecutorManager {
 }
 
 /// Helper function to compute a hash of function executors' desired states
-fn compute_function_executors_hash(
-    function_executors: &Vec<Box<DesiredStateFunctionExecutor>>,
-) -> String {
+fn compute_function_executors_hash(function_executors: &[DesiredStateFunctionExecutor]) -> String {
     let mut hasher = DefaultHasher::new();
 
     // Sort function executors by ID to ensure consistent hashing

--- a/server/src/gc_test.rs
+++ b/server/src/gc_test.rs
@@ -42,7 +42,7 @@ mod tests {
         let compute_graph = {
             let mut compute_graph = test_graph_a().clone();
             let data = "code";
-            let path = (&compute_graph.code.path).to_string();
+            let path = compute_graph.code.path.to_string();
 
             let data_stream = Box::pin(stream::once(async { Ok(Bytes::from(data)) }));
             let res = blob_storage_registry
@@ -53,13 +53,12 @@ mod tests {
 
             indexify_state
                 .write(StateMachineUpdateRequest {
-                    payload: RequestPayload::CreateOrUpdateComputeGraph(
-                        CreateOrUpdateComputeGraphRequest {
-                            namespace: TEST_NAMESPACE.to_string(),
-                            compute_graph: compute_graph.clone(),
-                            upgrade_tasks_to_current_version: false,
-                        },
-                    ),
+                    payload: CreateOrUpdateComputeGraphRequest {
+                        namespace: TEST_NAMESPACE.to_string(),
+                        compute_graph: compute_graph.clone(),
+                        upgrade_tasks_to_current_version: false,
+                    }
+                    .into(),
                 })
                 .await?;
 

--- a/server/src/http_objects.rs
+++ b/server/src/http_objects.rs
@@ -516,16 +516,14 @@ impl ComputeGraph {
             node.validate()?;
             let converted_node: data_model::ComputeFn = node.try_into().map_err(|e| {
                 IndexifyAPIError::bad_request(&format!(
-                    "Invalid placement constraints in node '{}': {}",
-                    name, e
+                    "Invalid placement constraints in node '{name}': {e}"
                 ))
             })?;
             nodes.insert(name, converted_node);
         }
         let start_fn: data_model::ComputeFn = self.start_node.try_into().map_err(|e| {
             IndexifyAPIError::bad_request(&format!(
-                "Invalid placement constraints in start node: {}",
-                e
+                "Invalid placement constraints in start node: {e}"
             ))
         })?;
 
@@ -981,10 +979,7 @@ pub struct ExecutorMetadata {
 pub fn from_data_model_executor_metadata(
     executor: data_model::ExecutorMetadata,
     free_resources: data_model::HostResources,
-    function_executor_server_metadata: HashMap<
-        FunctionExecutorId,
-        Box<FunctionExecutorServerMetadata>,
-    >,
+    function_executor_server_metadata: HashMap<FunctionExecutorId, FunctionExecutorServerMetadata>,
 ) -> ExecutorMetadata {
     let function_allowlist = executor.function_allowlist.map(|allowlist| {
         allowlist
@@ -1210,7 +1205,7 @@ mod tests {
 
         let data_model_filter: crate::data_model::filter::LabelsFilter =
             http_filter.clone().try_into().unwrap();
-        println!("{:?}", data_model_filter);
+        println!("{data_model_filter:?}");
         assert_eq!(data_model_filter.0.len(), 3);
 
         // Test data_model LabelsFilter to HTTP conversion

--- a/server/src/http_objects_v1.rs
+++ b/server/src/http_objects_v1.rs
@@ -53,16 +53,14 @@ impl ComputeGraph {
             node.validate()?;
             let converted_node: data_model::ComputeFn = node.try_into().map_err(|e| {
                 IndexifyAPIError::bad_request(&format!(
-                    "Invalid placement constraints in function '{}': {}",
-                    name, e
+                    "Invalid placement constraints in function '{name}': {e}"
                 ))
             })?;
             nodes.insert(name, converted_node);
         }
         let start_fn: data_model::ComputeFn = self.entrypoint.try_into().map_err(|e| {
             IndexifyAPIError::bad_request(&format!(
-                "Invalid placement constraints in entrypoint: {}",
-                e
+                "Invalid placement constraints in entrypoint: {e}"
             ))
         })?;
 

--- a/server/src/integration_test_executor_catalog.rs
+++ b/server/src/integration_test_executor_catalog.rs
@@ -11,11 +11,7 @@ mod tests {
             test_objects::tests::{self as test_objects, TEST_NAMESPACE},
             ComputeGraphState,
         },
-        state_store::requests::{
-            CreateOrUpdateComputeGraphRequest,
-            RequestPayload,
-            StateMachineUpdateRequest,
-        },
+        state_store::requests::{CreateOrUpdateComputeGraphRequest, StateMachineUpdateRequest},
         testing::TestService,
     };
 
@@ -65,7 +61,7 @@ mod tests {
         };
         indexify_state
             .write(StateMachineUpdateRequest {
-                payload: RequestPayload::CreateOrUpdateComputeGraph(cg_request),
+                payload: cg_request.into(),
             })
             .await?;
 
@@ -85,7 +81,7 @@ mod tests {
             .get(&key)
             .expect("compute graph not found in state");
 
-        println!("stored_graph: {:?}", stored_graph);
+        println!("stored_graph: {stored_graph:?}");
 
         match &stored_graph.state {
             ComputeGraphState::Disabled { .. } => {}
@@ -120,7 +116,7 @@ mod tests {
         };
         indexify_state
             .write(StateMachineUpdateRequest {
-                payload: RequestPayload::CreateOrUpdateComputeGraph(sat_cg_request),
+                payload: sat_cg_request.into(),
             })
             .await?;
 
@@ -225,13 +221,12 @@ mod tests {
         ] {
             indexify_state
                 .write(StateMachineUpdateRequest {
-                    payload: RequestPayload::CreateOrUpdateComputeGraph(
-                        CreateOrUpdateComputeGraphRequest {
-                            namespace: TEST_NAMESPACE.to_string(),
-                            compute_graph,
-                            upgrade_tasks_to_current_version: true,
-                        },
-                    ),
+                    payload: CreateOrUpdateComputeGraphRequest {
+                        namespace: TEST_NAMESPACE.to_string(),
+                        compute_graph,
+                        upgrade_tasks_to_current_version: true,
+                    }
+                    .into(),
                 })
                 .await?;
         }
@@ -415,13 +410,12 @@ mod tests {
         ] {
             indexify_state
                 .write(StateMachineUpdateRequest {
-                    payload: RequestPayload::CreateOrUpdateComputeGraph(
-                        CreateOrUpdateComputeGraphRequest {
-                            namespace: TEST_NAMESPACE.to_string(),
-                            compute_graph,
-                            upgrade_tasks_to_current_version: true,
-                        },
-                    ),
+                    payload: CreateOrUpdateComputeGraphRequest {
+                        namespace: TEST_NAMESPACE.to_string(),
+                        compute_graph,
+                        upgrade_tasks_to_current_version: true,
+                    }
+                    .into(),
                 })
                 .await?;
         }

--- a/server/src/metrics/mod.rs
+++ b/server/src/metrics/mod.rs
@@ -14,12 +14,14 @@ pub fn low_latency_boundaries() -> Vec<f64> {
     ]
 }
 
+trait TimedFunction: FnOnce(Duration) {}
+
 pin_project! {
     #[must_use = "futures do nothing unless you `.await` or poll them"]
     pub struct TimedFuture<F, C>
     where
         F: Future,
-        C: FnOnce(Duration),
+        C: TimedFunction,
     {
         #[pin]
         inner: F,
@@ -31,7 +33,7 @@ pin_project! {
 impl<F, C> Future for TimedFuture<F, C>
 where
     F: Future,
-    C: FnOnce(Duration),
+    C: TimedFunction,
 {
     type Output = F::Output;
 

--- a/server/src/processor/function_executor_manager.rs
+++ b/server/src/processor/function_executor_manager.rs
@@ -67,7 +67,7 @@ impl FunctionExecutorManager {
                 reason: FunctionExecutorTerminationReason::DesiredStateRemoved,
                 failed_alloc_ids: Vec::new(),
             };
-            update.new_function_executors.push(*update_fe);
+            update.new_function_executors.push(update_fe);
 
             info!(
                 target: targets::SCHEDULER,
@@ -257,7 +257,7 @@ impl FunctionExecutorManager {
                 if executor_fe.state != server_fe.function_executor.state {
                     let mut server_fe_clone = server_fe.clone();
                     server_fe_clone.function_executor.update(executor_fe);
-                    new_function_executors.push(*server_fe_clone);
+                    new_function_executors.push(server_fe_clone);
                 }
             }
         }
@@ -345,7 +345,7 @@ impl FunctionExecutorManager {
                         if let FunctionExecutorState::Terminated { reason: termination_reason, failed_alloc_ids: blame_alloc_ids } = &fe.state;
                 then {
                             if blame_alloc_ids.contains(&alloc.id.to_string()) {
-                                let mut updated_alloc = *alloc.clone();
+                                let mut updated_alloc = alloc.clone();
                                 updated_alloc.outcome = TaskOutcome::Failure((*termination_reason).into());
                                 TaskRetryPolicy::handle_allocation_outcome(
                                     &mut task,
@@ -368,7 +368,7 @@ impl FunctionExecutorManager {
                             task.status = TaskStatus::Pending;
                         }
                     }
-                update.updated_tasks.insert(task.id.clone(), *task.clone());
+                update.updated_tasks.insert(task.id.clone(), task.clone());
                 let invocation_ctx_key = GraphInvocationCtx::key_from(
                     &task.namespace,
                     &task.compute_graph_name,
@@ -383,7 +383,7 @@ impl FunctionExecutorManager {
                         let mut invocation_ctx = invocation_ctx.clone();
                         invocation_ctx.completed = true;
                         invocation_ctx.outcome = task.outcome.into();
-                        update.updated_invocations_states.push(*invocation_ctx);
+                        update.updated_invocations_states.push(invocation_ctx);
                     }
                 }
             }

--- a/server/src/processor/graph_processor.rs
+++ b/server/src/processor/graph_processor.rs
@@ -79,7 +79,7 @@ impl GraphProcessor {
                 };
 
                 if target_state != compute_graph.state {
-                    let mut updated_graph = *compute_graph.clone();
+                    let mut updated_graph = compute_graph.clone();
                     updated_graph.state = target_state;
                     Some(updated_graph)
                 } else {
@@ -92,13 +92,12 @@ impl GraphProcessor {
         for compute_graph in updated_compute_graphs {
             self.indexify_state
                 .write(StateMachineUpdateRequest {
-                    payload: RequestPayload::CreateOrUpdateComputeGraph(
-                        CreateOrUpdateComputeGraphRequest {
-                            namespace: compute_graph.namespace.clone(),
-                            compute_graph,
-                            upgrade_tasks_to_current_version: true,
-                        },
-                    ),
+                    payload: CreateOrUpdateComputeGraphRequest {
+                        namespace: compute_graph.namespace.clone(),
+                        compute_graph,
+                        upgrade_tasks_to_current_version: true,
+                    }
+                    .into(),
                 })
                 .await?;
         }

--- a/server/src/processor/task_allocator.rs
+++ b/server/src/processor/task_allocator.rs
@@ -66,7 +66,7 @@ impl<'a> TaskAllocationProcessor<'a> {
                             state_store::in_memory_state::Error::ConstraintUnsatisfiable { .. }
                         ) {
                             // Fail the task
-                            let mut failed_task = (*task).clone();
+                            let mut failed_task = task.clone();
                             failed_task.status = TaskStatus::Completed;
                             failed_task.outcome =
                                 TaskOutcome::Failure(TaskFailureReason::ConstraintUnsatisfiable);
@@ -85,7 +85,7 @@ impl<'a> TaskAllocationProcessor<'a> {
                             if let Some(invocation_ctx_box) =
                                 in_memory_state.invocation_ctx.get(&invocation_key)
                             {
-                                let mut invocation_ctx = (**invocation_ctx_box).clone();
+                                let mut invocation_ctx = invocation_ctx_box.clone();
                                 invocation_ctx.complete_invocation(
                                     true, // force_complete
                                     crate::data_model::GraphInvocationOutcome::Failure(

--- a/server/src/processor/task_cache.rs
+++ b/server/src/processor/task_cache.rs
@@ -132,7 +132,7 @@ impl TaskCache {
 
             debug!("Cache entry found; ingesting previous outputs");
             to_remove.push(task_id.clone());
-            let mut task = *(task.clone());
+            let mut task = task.clone();
             task.status = TaskStatus::Completed;
             task.outcome = TaskOutcome::Success;
             task.cache_hit = true;

--- a/server/src/processor/task_creator.rs
+++ b/server/src/processor/task_creator.rs
@@ -192,11 +192,11 @@ impl TaskCreator {
 
             // If task is pending (being retried), return early
             if task.status == TaskStatus::Pending {
-                scheduler_update.updated_tasks = HashMap::from([(task.id.clone(), *task.clone())]);
+                scheduler_update.updated_tasks = HashMap::from([(task.id.clone(), task.clone())]);
                 return Ok(scheduler_update);
             }
 
-            scheduler_update.updated_tasks = HashMap::from([(task.id.clone(), *task.clone())]);
+            scheduler_update.updated_tasks = HashMap::from([(task.id.clone(), task.clone())]);
             in_memory_state.update_state(
                 self.clock,
                 &RequestPayload::SchedulerUpdate((Box::new(scheduler_update.clone()), vec![])),
@@ -207,9 +207,9 @@ impl TaskCreator {
         let task_creation_result = self
             .handle_task_finished(
                 in_memory_state,
-                *invocation_ctx.clone(),
-                *task.clone(),
-                *compute_graph_version,
+                invocation_ctx.clone(),
+                task.clone(),
+                compute_graph_version,
                 task_finished_event.node_output_key.clone(),
             )
             .await?;
@@ -311,7 +311,7 @@ impl TaskCreator {
             tasks: vec![task],
             new_reduction_tasks: vec![],
             processed_reduction_tasks: vec![],
-            invocation_ctx: Some(*invocation_ctx.clone()),
+            invocation_ctx: Some(invocation_ctx.clone()),
         })
     }
 

--- a/server/src/processor/task_policy.rs
+++ b/server/src/processor/task_policy.rs
@@ -53,7 +53,7 @@ impl TaskRetryPolicy {
         match allocation.outcome {
             TaskOutcome::Success => {
                 task.status = TaskStatus::Completed;
-                task.outcome = allocation.outcome.clone();
+                task.outcome = allocation.outcome;
             }
             TaskOutcome::Failure(failure_reason) => {
                 // Handle allocation failure

--- a/server/src/routes/compute_graphs.rs
+++ b/server/src/routes/compute_graphs.rs
@@ -53,12 +53,11 @@ async fn validate_placement_constraints_against_executor_label_sets(
                 .placement_constraints
                 .0
                 .iter()
-                .map(|expr| format!("{}", expr))
+                .map(|expr| format!("{expr}"))
                 .collect::<Vec<_>>()
                 .join(", ");
             return Err(IndexifyAPIError::bad_request(&format!(
-                "Function '{}' has unsatisfiable placement constraints [{}].",
-                function_name, constraints_str
+                "Function '{function_name}' has unsatisfiable placement constraints [{constraints_str}]."
             )));
         }
     }
@@ -153,11 +152,12 @@ pub async fn create_or_update_compute_graph_v1(
         name,
         upgrade_tasks_to_current_version.unwrap_or(false)
     );
-    let request = RequestPayload::CreateOrUpdateComputeGraph(CreateOrUpdateComputeGraphRequest {
+    let request = CreateOrUpdateComputeGraphRequest {
         namespace,
         compute_graph,
         upgrade_tasks_to_current_version: upgrade_tasks_to_current_version.unwrap_or(false),
-    });
+    }
+    .into();
     let result = state
         .indexify_state
         .write(StateMachineUpdateRequest { payload: request })

--- a/server/src/routes/download.rs
+++ b/server/src/routes/download.rs
@@ -169,7 +169,7 @@ pub async fn v1_download_fn_output_payload(
 
     let payload = &output.payloads[index];
     let blob_storage = state.blob_storage.get_blob_store(&namespace);
-    stream_data_payload(&payload, &blob_storage, &encoding).await
+    stream_data_payload(payload, &blob_storage, &encoding).await
 }
 
 /// Get function output
@@ -209,7 +209,7 @@ pub async fn v1_download_fn_output_payload_simple(
 
     let payload = &output.payloads[0];
     let blob_storage = state.blob_storage.get_blob_store(&namespace);
-    stream_data_payload(&payload, &blob_storage, &encoding).await
+    stream_data_payload(payload, &blob_storage, &encoding).await
 }
 
 async fn stream_data_payload(

--- a/server/src/routes/invoke.rs
+++ b/server/src/routes/invoke.rs
@@ -53,12 +53,11 @@ async fn validate_placement_constraints_against_executor_catalog(
                 .placement_constraints
                 .0
                 .iter()
-                .map(|expr| format!("{}", expr))
+                .map(|expr| format!("{expr}"))
                 .collect::<Vec<_>>()
                 .join(", ");
             return Err(IndexifyAPIError::bad_request(&format!(
-                "Function '{}' has unsatisfiable placement constraints [{}]. The executor catalog may have changed since this graph was created.",
-                function_name, constraints_str
+                "Function '{function_name}' has unsatisfiable placement constraints [{constraints_str}]. The executor catalog may have changed since this graph was created."
             )));
         }
     }

--- a/server/src/routes_internal.rs
+++ b/server/src/routes_internal.rs
@@ -117,7 +117,6 @@ use crate::{
             (name = "indexify", description = "Indexify API")
         )
     )]
-
 pub struct ApiDoc;
 
 pub fn configure_internal_routes(route_state: RouteState) -> Router {
@@ -456,11 +455,12 @@ async fn create_or_update_compute_graph(
         name,
         upgrade_tasks_to_current_version.unwrap_or(false)
     );
-    let request = RequestPayload::CreateOrUpdateComputeGraph(CreateOrUpdateComputeGraphRequest {
+    let request = CreateOrUpdateComputeGraphRequest {
         namespace,
         compute_graph,
         upgrade_tasks_to_current_version: upgrade_tasks_to_current_version.unwrap_or(false),
-    });
+    }
+    .into();
     let result = state
         .indexify_state
         .write(StateMachineUpdateRequest { payload: request })
@@ -743,7 +743,7 @@ async fn list_unallocated_tasks(
         .clone()
         .iter()
         .filter_map(|unallocated_task_id| state.tasks.get(&unallocated_task_id.task_key))
-        .map(|t| Task::from_data_model_task(*t.clone(), vec![]))
+        .map(|t| Task::from_data_model_task(t.clone(), vec![]))
         .collect();
 
     Ok(Json(UnallocatedTasks {

--- a/server/src/routes_v1.rs
+++ b/server/src/routes_v1.rs
@@ -103,7 +103,6 @@ use crate::{
             (name = "indexify", description = "Indexify API")
         )
     )]
-
 pub struct ApiDoc;
 
 pub fn configure_v1_routes(route_state: RouteState) -> Router {

--- a/server/src/state_store/kv.rs
+++ b/server/src/state_store/kv.rs
@@ -25,6 +25,7 @@ pub struct ReadContextData {
     pub key: String,
 }
 
+#[allow(clippy::upper_case_acronyms)]
 pub struct KVS {
     kv_store: Arc<Db>,
     metrics: Metrics,

--- a/server/src/state_store/mod.rs
+++ b/server/src/state_store/mod.rs
@@ -27,7 +27,7 @@ use crate::{
     metrics::{StateStoreMetrics, Timer},
 };
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct ExecutorCatalog {
     pub entries: Vec<ExecutorCatalogEntry>,
 }
@@ -44,14 +44,6 @@ impl ExecutorCatalog {
     /// labels are allowed.
     pub fn allows_any_labels(&self) -> bool {
         self.entries.is_empty()
-    }
-}
-
-impl Default for ExecutorCatalog {
-    fn default() -> Self {
-        ExecutorCatalog {
-            entries: Vec::new(),
-        }
     }
 }
 
@@ -219,7 +211,7 @@ impl IndexifyState {
                 state_machine::mark_state_changes_processed(
                     self.db.clone(),
                     &txn,
-                    &processed_state_changes,
+                    processed_state_changes,
                 )?;
                 new_state_changes
             }
@@ -249,7 +241,7 @@ impl IndexifyState {
                 state_machine::mark_state_changes_processed(
                     self.db.clone(),
                     &txn,
-                    &processed_state_changes,
+                    processed_state_changes,
                 )?;
                 vec![]
             }
@@ -261,7 +253,7 @@ impl IndexifyState {
                 state_machine::mark_state_changes_processed(
                     self.db.clone(),
                     &txn,
-                    &processed_state_changes,
+                    processed_state_changes,
                 )?;
                 vec![]
             }
@@ -318,7 +310,7 @@ impl IndexifyState {
                 vec![]
             }
             RequestPayload::ProcessStateChanges(state_changes) => {
-                state_machine::mark_state_changes_processed(self.db.clone(), &txn, &state_changes)?;
+                state_machine::mark_state_changes_processed(self.db.clone(), &txn, state_changes)?;
                 vec![]
             }
         };
@@ -636,13 +628,12 @@ mod tests {
     ) -> Result<()> {
         indexify_state
             .write(StateMachineUpdateRequest {
-                payload: RequestPayload::CreateOrUpdateComputeGraph(
-                    CreateOrUpdateComputeGraphRequest {
-                        namespace: TEST_NAMESPACE.to_string(),
-                        compute_graph: compute_graph.clone(),
-                        upgrade_tasks_to_current_version: false,
-                    },
-                ),
+                payload: CreateOrUpdateComputeGraphRequest {
+                    namespace: TEST_NAMESPACE.to_string(),
+                    compute_graph: compute_graph.clone(),
+                    upgrade_tasks_to_current_version: false,
+                }
+                .into(),
             })
             .await
     }

--- a/server/src/state_store/requests.rs
+++ b/server/src/state_store/requests.rs
@@ -28,7 +28,7 @@ pub struct StateMachineUpdateRequest {
 pub enum RequestPayload {
     InvokeComputeGraph(InvokeComputeGraphRequest),
     CreateNameSpace(NamespaceRequest),
-    CreateOrUpdateComputeGraph(CreateOrUpdateComputeGraphRequest),
+    CreateOrUpdateComputeGraph(Box<CreateOrUpdateComputeGraphRequest>),
     TombstoneComputeGraph(DeleteComputeGraphRequest),
     TombstoneInvocation(DeleteInvocationRequest),
     SchedulerUpdate((Box<SchedulerUpdateRequest>, Vec<StateChange>)),
@@ -143,4 +143,76 @@ pub struct UpsertExecutorRequest {
 #[derive(Debug, Clone)]
 pub struct DeregisterExecutorRequest {
     pub executor_id: ExecutorId,
+}
+
+impl From<InvokeComputeGraphRequest> for RequestPayload {
+    fn from(request: InvokeComputeGraphRequest) -> Self {
+        RequestPayload::InvokeComputeGraph(request)
+    }
+}
+
+impl From<NamespaceRequest> for RequestPayload {
+    fn from(request: NamespaceRequest) -> Self {
+        RequestPayload::CreateNameSpace(request)
+    }
+}
+
+impl From<CreateOrUpdateComputeGraphRequest> for RequestPayload {
+    fn from(request: CreateOrUpdateComputeGraphRequest) -> Self {
+        RequestPayload::CreateOrUpdateComputeGraph(Box::new(request))
+    }
+}
+
+impl From<DeleteComputeGraphRequest> for RequestPayload {
+    fn from(request: DeleteComputeGraphRequest) -> Self {
+        RequestPayload::TombstoneComputeGraph(request)
+    }
+}
+
+impl From<DeleteInvocationRequest> for RequestPayload {
+    fn from(request: DeleteInvocationRequest) -> Self {
+        RequestPayload::TombstoneInvocation(request)
+    }
+}
+
+impl From<(SchedulerUpdateRequest, Vec<StateChange>)> for RequestPayload {
+    fn from(request: (SchedulerUpdateRequest, Vec<StateChange>)) -> Self {
+        RequestPayload::SchedulerUpdate((Box::new(request.0), request.1))
+    }
+}
+
+impl From<UpsertExecutorRequest> for RequestPayload {
+    fn from(request: UpsertExecutorRequest) -> Self {
+        RequestPayload::UpsertExecutor(request)
+    }
+}
+
+impl From<DeregisterExecutorRequest> for RequestPayload {
+    fn from(request: DeregisterExecutorRequest) -> Self {
+        RequestPayload::DeregisterExecutor(request)
+    }
+}
+
+impl From<Vec<GcUrl>> for RequestPayload {
+    fn from(gc_urls: Vec<GcUrl>) -> Self {
+        RequestPayload::RemoveGcUrls(gc_urls)
+    }
+}
+
+impl From<(DeleteComputeGraphRequest, Vec<StateChange>)> for RequestPayload {
+    fn from(request: (DeleteComputeGraphRequest, Vec<StateChange>)) -> Self {
+        RequestPayload::DeleteComputeGraphRequest(request)
+    }
+}
+
+impl From<(DeleteInvocationRequest, Vec<StateChange>)> for RequestPayload {
+    fn from(request: (DeleteInvocationRequest, Vec<StateChange>)) -> Self {
+        RequestPayload::DeleteInvocationRequest(request)
+    }
+}
+
+impl From<Vec<StateChange>> for RequestPayload {
+    fn from(state_changes: Vec<StateChange>) -> Self {
+        RequestPayload::ProcessStateChanges(state_changes)
+    }
 }

--- a/server/src/state_store/state_machine.rs
+++ b/server/src/state_store/state_machine.rs
@@ -589,6 +589,7 @@ pub fn remove_gc_urls(
     Ok(())
 }
 
+#[allow(clippy::type_complexity)]
 pub fn make_prefix_iterator<'a>(
     txn: &'a Transaction<TransactionDB>,
     cf_handle: &impl AsColumnFamilyRef,

--- a/server/src/state_store/test_state_store.rs
+++ b/server/src/state_store/test_state_store.rs
@@ -44,7 +44,7 @@ pub async fn with_simple_retry_graph(indexify_state: &IndexifyState, max_retries
     };
     indexify_state
         .write(StateMachineUpdateRequest {
-            payload: RequestPayload::CreateOrUpdateComputeGraph(cg_request),
+            payload: cg_request.into(),
         })
         .await
         .unwrap();

--- a/server/src/testing.rs
+++ b/server/src/testing.rs
@@ -434,7 +434,7 @@ impl TestExecutor<'_> {
             .ok_or(anyhow::anyhow!("Executor not found in state store"))?;
 
         // Clone base executor
-        let mut executor = *executor.clone();
+        let mut executor = executor.clone();
 
         executor.function_executors = executor_server_metadata
             .function_executors
@@ -476,41 +476,29 @@ impl TestExecutor<'_> {
         args: FinalizeTaskArgs,
     ) -> Result<()> {
         let allocation_id = task_allocation.allocation_id.clone().unwrap();
+        let task_ref = task_allocation.task.as_ref().unwrap();
         let graph_version = self
             .test_service
             .service
             .indexify_state
             .reader()
             .get_compute_graph_version(
-                task_allocation.task.as_ref().unwrap().namespace(),
-                task_allocation.task.as_ref().unwrap().graph_name(),
-                &GraphVersion(
-                    task_allocation
-                        .task
-                        .as_ref()
-                        .unwrap()
-                        .graph_version()
-                        .to_string(),
-                ),
+                task_ref.namespace(),
+                task_ref.graph_name(),
+                &GraphVersion(task_ref.graph_version().to_string()),
             )?
             .unwrap();
+        let function_name = task_ref.function_name();
         let node_output = test_node_fn_output(
-            task_allocation.task.as_ref().unwrap().graph_invocation_id(),
-            task_allocation.task.as_ref().unwrap().graph_name(),
-            task_allocation.task.as_ref().unwrap().function_name(),
+            task_ref.graph_invocation_id(),
+            task_ref.graph_name(),
+            function_name,
             args.reducer_fn.clone(),
             args.num_outputs as usize,
             allocation_id,
             graph_version
                 .edges
-                .get(
-                    &task_allocation
-                        .task
-                        .as_ref()
-                        .unwrap()
-                        .function_name()
-                        .to_string(),
-                )
+                .get(function_name)
                 .cloned()
                 .unwrap_or_default(),
         );
@@ -522,11 +510,11 @@ impl TestExecutor<'_> {
             .indexify_state
             .reader()
             .get_task(
-                task_allocation.task.as_ref().unwrap().namespace(),
-                task_allocation.task.as_ref().unwrap().graph_name(),
-                task_allocation.task.as_ref().unwrap().graph_invocation_id(),
-                task_allocation.task.as_ref().unwrap().function_name(),
-                task_allocation.task.as_ref().unwrap().id(),
+                task_ref.namespace(),
+                task_ref.graph_name(),
+                task_ref.graph_invocation_id(),
+                task_ref.function_name(),
+                task_ref.id(),
             )
             .unwrap()
             .unwrap();


### PR DESCRIPTION
## Context

<!--
In a few sentences or less, please explain the context behind this change to help answer why this change is needed.

If this is a bug fix, make sure to include "fixes #xxxx", or
"closes #xxxx".

Screenshots, logs, code or other visual aids are greatly appreciated.
 -->

This PR address the accumulated linting issues in the server's codebase. It also adds a step in the CI workflow to check linting issues before marking the job as successful.

## What

<!--
In a few sentences, please summarize the change to help reviewers.

Consider providing screenshots, logs, code or other visual aids to help the reviewer understand the approach taken.
-->

Besides addressing a bunch of minor linting issues in the codebase, there are a couple of big and interesting changes that I'd like to bring to your attention:

1. Usage of `From<T> for RequestPayload` makes it easier to centralize how `RequestPayload` objects are constructed. If there are any changes in the definitions of any variants, there should only be 1 place that you need to update to make it work again.
2. Removal of double heap allocation for structs inside `Vec` and `HashMap` in `in_memory_state.rs`. There is no need to box structs when you put them inside `Vec` or `HashMap` because they will be automatically allocated in the heap for you. Removing the explicit boxing makes the code a little more efficient and also easier to work with. 

## Testing

<!--
Please include steps used to verify the change.

Consider providing screenshots, logs, code or other visual aids to help the reviewer in their testing.
-->

All tests and lints should pass.

## Contribution Checklist

- [ ] If a Python package was changed, please run `make fmt` in the package directory.
- [x] If the server was changed, please run `make fmt` in `server/`.
- [ ] Make sure all PR Checks are passing.
<!--
Notes:

Tests of a Python package can be run manually. Start a Server and an Executor then
run `make test` in the Python package directory.

To test if changes to the server are backward compatible with the latest
release, label the PR with `ci_compat_test`. This might report failures
unrelated to your change if previous incompatible changes were pushed without
being released yet
-->
