### PR TITLE
Add vector clocks to the structs that are stored in the state store.

### DIFF
--- a/server/src/data_model/clocks.rs
+++ b/server/src/data_model/clocks.rs
@@ -1,0 +1,93 @@
+use std::sync::{
+    atomic::{AtomicU64, Ordering},
+    Arc,
+    RwLock,
+};
+
+use serde::{Deserialize, Serialize};
+
+/// A thread-safe vector clock using AtomicU64 for clock values.
+#[derive(Clone, Debug)]
+pub struct VectorClock {
+    clock: Arc<RwLock<AtomicU64>>,
+}
+
+impl VectorClock {
+    /// Create a new vector clock initialized to one.
+    pub fn new() -> Self {
+        Self {
+            clock: Arc::new(RwLock::new(AtomicU64::new(1))),
+        }
+    }
+
+    /// Create a new vector clock initialized to a specific value.
+    /// This is used only for deserialization from stored values in the state
+    /// store.
+    fn new_with_value(value: u64) -> Self {
+        Self {
+            clock: Arc::new(RwLock::new(AtomicU64::new(value))),
+        }
+    }
+
+    /// Increment the clock value for a given key and return the new value.
+    /// It uses SeqCst ordering to ensure strong consistency across threads.
+    #[allow(dead_code)]
+    pub fn increment(&self) -> u64 {
+        let value = self.clock.write().unwrap();
+
+        value.fetch_add(1, Ordering::SeqCst)
+    }
+
+    /// Get the current clock value for a given key.
+    /// It uses SeqCst ordering to ensure strong consistency across threads.
+    pub fn value(&self) -> u64 {
+        let value = self.clock.read().unwrap();
+        value.load(Ordering::SeqCst)
+    }
+
+    /// Compare this vector clock with another.
+    /// Returns an Ordering indicating whether this clock is less than, equal
+    /// to, or greater than the other clock based on their values.
+    pub fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.value().cmp(&other.value())
+    }
+}
+
+impl From<u64> for VectorClock {
+    fn from(value: u64) -> Self {
+        Self::new_with_value(value)
+    }
+}
+
+impl Default for VectorClock {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl PartialEq for VectorClock {
+    fn eq(&self, other: &Self) -> bool {
+        self.cmp(other) == std::cmp::Ordering::Equal
+    }
+}
+
+impl Eq for VectorClock {}
+
+impl Serialize for VectorClock {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_u64(self.value())
+    }
+}
+
+impl<'de> Deserialize<'de> for VectorClock {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let value = u64::deserialize(deserializer)?;
+        Ok(value.into())
+    }
+}

--- a/server/src/data_model/test_objects.rs
+++ b/server/src/data_model/test_objects.rs
@@ -10,6 +10,7 @@ pub mod tests {
         DataPayload,
         ExecutorId,
         ExecutorMetadata,
+        ExecutorMetadataBuilder,
         FunctionRetryPolicy,
         GraphInvocationCtx,
         GraphInvocationCtxBuilder,
@@ -151,24 +152,24 @@ pub mod tests {
     }
 
     pub fn test_executor_metadata(id: ExecutorId) -> ExecutorMetadata {
-        ExecutorMetadata {
-            id,
-            executor_version: "1.0.0".to_string(),
-            function_allowlist: None,
-            addr: "".to_string(),
-            labels: Default::default(),
-            // Executor must have resources to be schedulable.
-            host_resources: crate::data_model::HostResources {
+        ExecutorMetadataBuilder::default()
+            .id(id)
+            .executor_version("1.0.0".to_string())
+            .function_allowlist(None)
+            .addr("".to_string())
+            .labels(Default::default())
+            .host_resources(crate::data_model::HostResources {
                 cpu_ms_per_sec: 8 * 1000, // 8 cores
                 memory_bytes: 16 * 1024 * 1024 * 1024,
                 disk_bytes: 100 * 1024 * 1024 * 1024,
                 gpu: None,
-            },
-            state: Default::default(),
-            function_executors: Default::default(),
-            tombstoned: false,
-            state_hash: "state_hash".to_string(),
-            clock: 0,
-        }
+            })
+            .state(Default::default())
+            .function_executors(Default::default())
+            .tombstoned(false)
+            .state_hash("state_hash".to_string())
+            .clock(0)
+            .build()
+            .unwrap()
     }
 }

--- a/server/src/executors.rs
+++ b/server/src/executors.rs
@@ -653,7 +653,7 @@ mod tests {
 
     use super::*;
     use crate::{
-        data_model::{ExecutorId, ExecutorMetadata},
+        data_model::{ExecutorId, ExecutorMetadata, ExecutorMetadataBuilder},
         service::Service,
         state_store::requests::UpsertExecutorRequest,
         testing,
@@ -693,47 +693,50 @@ mod tests {
             ..
         } = test_srv.service.clone();
 
-        let executor1 = ExecutorMetadata {
-            id: ExecutorId::new("test-executor-1".to_string()),
-            executor_version: "1.0".to_string(),
-            function_allowlist: None,
-            addr: "".to_string(),
-            labels: Default::default(),
-            function_executors: Default::default(),
-            host_resources: Default::default(),
-            state: Default::default(),
-            tombstoned: false,
-            state_hash: "state_hash".to_string(),
-            clock: 0,
-        };
+        let executor1 = ExecutorMetadataBuilder::default()
+            .id(ExecutorId::new("test-executor-1".to_string()))
+            .executor_version("1.0".to_string())
+            .function_allowlist(None)
+            .addr("".to_string())
+            .labels(Default::default())
+            .function_executors(Default::default())
+            .host_resources(Default::default())
+            .state(Default::default())
+            .tombstoned(false)
+            .state_hash("state_hash".to_string())
+            .clock(0)
+            .build()
+            .unwrap();
 
-        let executor2 = ExecutorMetadata {
-            id: ExecutorId::new("test-executor-2".to_string()),
-            executor_version: "1.0".to_string(),
-            function_allowlist: None,
-            addr: "".to_string(),
-            labels: Default::default(),
-            function_executors: Default::default(),
-            host_resources: Default::default(),
-            state: Default::default(),
-            tombstoned: false,
-            state_hash: "state_hash".to_string(),
-            clock: 0,
-        };
+        let executor2 = ExecutorMetadataBuilder::default()
+            .id(ExecutorId::new("test-executor-2".to_string()))
+            .executor_version("1.0".to_string())
+            .function_allowlist(None)
+            .addr("".to_string())
+            .labels(Default::default())
+            .function_executors(Default::default())
+            .host_resources(Default::default())
+            .state(Default::default())
+            .tombstoned(false)
+            .state_hash("state_hash".to_string())
+            .clock(0)
+            .build()
+            .unwrap();
 
-        let executor3 = ExecutorMetadata {
-            id: ExecutorId::new("test-executor-3".to_string()),
-            executor_version: "1.0".to_string(),
-            function_allowlist: None,
-            addr: "".to_string(),
-            labels: Default::default(),
-            function_executors: Default::default(),
-            host_resources: Default::default(),
-            state: Default::default(),
-            tombstoned: false,
-            state_hash: "state_hash".to_string(),
-            clock: 0,
-        };
+        let executor3 = ExecutorMetadataBuilder::default()
+            .id(ExecutorId::new("test-executor-3".to_string()))
+            .executor_version("1.0".to_string())
+            .function_allowlist(None)
+            .addr("".to_string())
+            .labels(Default::default())
+            .function_executors(Default::default())
+            .host_resources(Default::default())
+            .state(Default::default())
+            .tombstoned(false)
+            .state_hash("state_hash".to_string())
+            .clock(0)
+            .build()
+            .unwrap();
 
         // Pause time and send an initial heartbeats
         {

--- a/server/src/state_store/writer.rs
+++ b/server/src/state_store/writer.rs
@@ -1,0 +1,17 @@
+trait Transaction {
+    fn write(&self, key: &[u8], value: &[u8]) -> Result<()>;
+    fn read(&self, key: &[u8]) -> Result<Option<Vec<u8>>>;
+    fn delete(&self, key: &[u8]) -> Result<()>;
+    fn commit(&self) -> Result<()>;
+    fn rollback(&self) -> Result<()>;
+}
+
+trait Write {
+    fn start_transaction(&self) -> Result<Arc<dyn Transaction>>;
+    fn compare_and_set(
+        &self,
+        transaction: Arc<dyn Transaction>,
+        key: &[u8],
+        value: &[u8],
+    ) -> Result<bool>;
+}


### PR DESCRIPTION
## Context

<!--
In a few sentences or less, please explain the context behind this change to help answer why this change is needed.

If this is a bug fix, make sure to include "fixes #xxxx", or
"closes #xxxx".

Screenshots, logs, code or other visual aids are greatly appreciated.
 -->

This is a precondition to address #1711. Instead of making all the changes at once. I thought it'd be better to introduce vector clocks first, and then start using them as necessary.

## What

<!--
In a few sentences, please summarize the change to help reviewers.

Consider providing screenshots, logs, code or other visual aids to help the reviewer understand the approach taken.
-->

Implement a simple vector clock using AtomicU64 and add it to the structures that are serialized into the state store.

The clock is not used for anything at the moment, allowing us to introduce CAS semantics gradually over futures changes.

## Testing

<!--
Please include steps used to verify the change.

Consider providing screenshots, logs, code or other visual aids to help the reviewer in their testing.
-->

I'm adding tests for the new builders, and updating existent tests.

## Contribution Checklist

- [ ] If a Python package was changed, please run `make fmt` in the package directory.
- [x] If the server was changed, please run `make fmt` in `server/`.
- [ ] Make sure all PR Checks are passing.
<!--
Notes:

Tests of a Python package can be run manually. Start a Server and an Executor then
run `make test` in the Python package directory.

To test if changes to the server are backward compatible with the latest
release, label the PR with `ci_compat_test`. This might report failures
unrelated to your change if previous incompatible changes were pushed without
being released yet
-->
