### PR TITLE
Simplify builders

### DIFF
--- a/server/src/data_model/mod.rs
+++ b/server/src/data_model/mod.rs
@@ -8,7 +8,6 @@ use std::{
     hash::{DefaultHasher, Hash, Hasher},
     ops::Deref,
     str,
-    time::{SystemTime, UNIX_EPOCH},
     vec,
 };
 

--- a/server/src/data_model/test_objects.rs
+++ b/server/src/data_model/test_objects.rs
@@ -102,9 +102,9 @@ pub mod tests {
             .compute_graph_name(compute_graph.name.clone())
             .graph_version(GraphVersion::default())
             .invocation_id(invocation_payload.id.clone())
-            .fn_task_analytics(HashMap::new())
-            .created_at(invocation_payload.created_at)
-            .build(compute_graph.clone())
+            .fn_task_analytics(compute_graph.fn_task_analytics())
+            .created_at(invocation_payload.created_at.clone())
+            .build()
             .unwrap()
     }
 

--- a/server/src/executor_api.rs
+++ b/server/src/executor_api.rs
@@ -411,6 +411,7 @@ impl TryFrom<FunctionExecutorState> for data_model::FunctionExecutor {
             .resources(resources)
             .max_concurrency(max_concurrency)
             .build()
+            .map_err(Into::into)
     }
 }
 

--- a/server/src/executor_api.rs
+++ b/server/src/executor_api.rs
@@ -306,7 +306,7 @@ impl TryFrom<ExecutorState> for ExecutorMetadata {
         if let Some(server_clock) = executor_state.server_clock {
             executor_metadata.clock(server_clock);
         }
-        executor_metadata.build()
+        executor_metadata.build().map_err(Into::into)
     }
 }
 

--- a/server/src/executors.rs
+++ b/server/src/executors.rs
@@ -448,7 +448,7 @@ impl ExecutorManager {
                 };
                 let task_allocation_pb = TaskAllocation {
                     function_executor_id: Some(fe_id.get().to_string()),
-                    allocation_id: Some(task.allocation_id.clone()),
+                    allocation_id: Some(task.allocation_id.to_string()),
                     task: Some(Task {
                         id: Some(task.task.id.get().to_string()),
                         namespace: Some(task.task.namespace.clone()),

--- a/server/src/gc_test.rs
+++ b/server/src/gc_test.rs
@@ -1,7 +1,5 @@
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
-
     use anyhow::Result;
     use bytes::Bytes;
     use futures::stream;
@@ -25,7 +23,6 @@ mod tests {
             state_machine::IndexifyObjectsColumns,
         },
         testing,
-        utils::get_epoch_time_in_ms,
     };
 
     #[tokio::test]
@@ -76,7 +73,6 @@ mod tests {
                 .await?;
 
             let invocation = InvocationPayloadBuilder::default()
-                .id("invocation_id".to_string())
                 .namespace(TEST_NAMESPACE.to_string())
                 .compute_graph_name(compute_graph.name.clone())
                 .payload(crate::data_model::DataPayload {
@@ -85,7 +81,6 @@ mod tests {
                     sha256_hash: res.sha256_hash.clone(),
                     offset: 0, // All BLOB operations are not offset-aware
                 })
-                .created_at(get_epoch_time_in_ms())
                 .encoding("application/octet-stream".to_string())
                 .build()?;
 
@@ -106,10 +101,8 @@ mod tests {
                 ))
                 .outstanding_tasks(0)
                 .outstanding_reducer_tasks(0)
-                .fn_task_analytics(HashMap::new())
-                .created_at(get_epoch_time_in_ms())
-                .invocation_error(None)
-                .build(compute_graph.clone())?;
+                .fn_task_analytics(compute_graph.fn_task_analytics())
+                .build()?;
 
             indexify_state.db.put_cf(
                 &IndexifyObjectsColumns::GraphInvocationCtx.cf_db(&indexify_state.db),

--- a/server/src/gc_test.rs
+++ b/server/src/gc_test.rs
@@ -118,7 +118,6 @@ mod tests {
             )?;
 
             let output = NodeOutputBuilder::default()
-                .id("id".to_string())
                 .namespace(TEST_NAMESPACE.to_string())
                 .compute_fn_name("fn_a".to_string())
                 .compute_graph_name(compute_graph.name.clone())
@@ -129,7 +128,6 @@ mod tests {
                     sha256_hash: res.sha256_hash.clone(),
                     offset: 0,
                 }])
-                .created_at(5)
                 .reducer_output(false)
                 .allocation_id("allocation_id".to_string())
                 .next_functions(vec!["fn_b".to_string(), "fn_c".to_string()])

--- a/server/src/http_objects.rs
+++ b/server/src/http_objects.rs
@@ -743,7 +743,7 @@ impl Task {
             reducer_input_payload: None,
             output_payload_uri_prefix: None,
             allocations,
-            creation_time_ns: task.creation_time_ns,
+            creation_time_ns: task.creation_time_ns.into(),
         }
     }
 }

--- a/server/src/http_objects.rs
+++ b/server/src/http_objects.rs
@@ -846,7 +846,7 @@ pub struct Invocation {
     pub outstanding_tasks: u64,
     pub task_analytics: HashMap<String, TaskAnalytics>,
     pub graph_version: String,
-    pub created_at: u64,
+    pub created_at: u128,
     pub invocation_error: Option<RequestError>,
 }
 
@@ -882,7 +882,7 @@ impl From<GraphInvocationCtx> for Invocation {
             outstanding_tasks: value.outstanding_tasks,
             task_analytics,
             graph_version: value.graph_version.0,
-            created_at: value.created_at,
+            created_at: value.created_at.into(),
             invocation_error: None, // Set by API handlers if needed
         }
     }

--- a/server/src/http_objects.rs
+++ b/server/src/http_objects.rs
@@ -758,7 +758,7 @@ pub struct Tasks {
 pub struct FnOutput {
     pub id: String,
     pub compute_fn: String,
-    pub created_at: u64,
+    pub created_at: u128,
 }
 
 #[derive(Debug, Serialize, Deserialize, ToSchema, Clone)]

--- a/server/src/http_objects.rs
+++ b/server/src/http_objects.rs
@@ -1108,7 +1108,7 @@ impl From<data_model::Allocation> for Allocation {
             function_executor_id: allocation.target.function_executor_id.get().to_string(),
             task_id: allocation.task_id.to_string(),
             invocation_id: allocation.invocation_id.to_string(),
-            created_at: allocation.created_at,
+            created_at: allocation.created_at.into(),
             outcome: allocation.outcome.into(),
             attempt_number: allocation.attempt_number,
             execution_duration_ms: allocation.execution_duration_ms,

--- a/server/src/http_objects_v1.rs
+++ b/server/src/http_objects_v1.rs
@@ -123,7 +123,7 @@ pub struct ComputeGraphsList {
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
 pub struct ShallowGraphRequest {
     pub id: String,
-    pub created_at: u64,
+    pub created_at: u128,
     pub status: RequestStatus,
     pub outcome: RequestOutcome,
 }
@@ -132,7 +132,7 @@ impl From<GraphInvocationCtx> for ShallowGraphRequest {
     fn from(ctx: GraphInvocationCtx) -> Self {
         Self {
             id: ctx.invocation_id.to_string(),
-            created_at: ctx.created_at,
+            created_at: ctx.created_at.into(),
             status: if ctx.completed {
                 RequestStatus::Complete
             } else if ctx.outstanding_tasks > 0 {
@@ -253,7 +253,7 @@ pub struct Request {
     pub outstanding_tasks: u64,
     pub request_progress: HashMap<String, RequestProgress>,
     pub graph_version: String,
-    pub created_at: u64,
+    pub created_at: u128,
     pub request_error: Option<RequestError>,
     pub outputs: Vec<FnOutput>,
 }
@@ -294,7 +294,7 @@ impl Request {
             outstanding_tasks: ctx.outstanding_tasks,
             request_progress: task_analytics,
             graph_version: ctx.graph_version.0,
-            created_at: ctx.created_at,
+            created_at: ctx.created_at.into(),
             request_error: invocation_error,
             outputs,
         }

--- a/server/src/http_objects_v1.rs
+++ b/server/src/http_objects_v1.rs
@@ -170,7 +170,7 @@ impl Task {
             status: task.status.into(),
             graph_version: task.graph_version.into(),
             allocations,
-            created_at: task.creation_time_ns,
+            created_at: task.creation_time_ns.into(),
         }
     }
 }

--- a/server/src/http_objects_v1.rs
+++ b/server/src/http_objects_v1.rs
@@ -240,7 +240,7 @@ pub struct FnOutput {
     pub id: String,
     pub num_outputs: u64,
     pub compute_fn: String,
-    pub created_at: u64,
+    pub created_at: u128,
 }
 
 #[derive(Debug, Serialize, Deserialize, ToSchema, Clone)]

--- a/server/src/http_objects_v1.rs
+++ b/server/src/http_objects_v1.rs
@@ -325,7 +325,7 @@ impl From<data_model::Allocation> for Allocation {
             id: allocation.id.to_string(),
             executor_id: allocation.target.executor_id.to_string(),
             function_executor_id: allocation.target.function_executor_id.get().to_string(),
-            created_at: allocation.created_at,
+            created_at: allocation.created_at.into(),
             outcome: allocation.outcome.into(),
             attempt_number: allocation.attempt_number,
             execution_duration_ms: allocation.execution_duration_ms,

--- a/server/src/processor/task_allocator.rs
+++ b/server/src/processor/task_allocator.rs
@@ -145,7 +145,7 @@ impl<'a> TaskAllocationProcessor<'a> {
             .outcome(TaskOutcome::Unknown)
             .build()?;
 
-        debug!(allocation_id = allocation.id, "created allocation");
+        debug!(allocation_id = %allocation.id, "created allocation");
 
         let mut updated_task = task.clone();
         updated_task.status = TaskStatus::Running(RunningTaskStatus {

--- a/server/src/routes/invoke.rs
+++ b/server/src/routes/invoke.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, pin::Pin, time::Duration};
+use std::{pin::Pin, time::Duration};
 
 use anyhow::anyhow;
 use axum::{
@@ -211,9 +211,9 @@ pub async fn invoke_with_object_v1(
         .compute_graph_name(compute_graph.name.to_string())
         .graph_version(compute_graph.version.clone())
         .invocation_id(invocation_payload.id.clone())
-        .fn_task_analytics(HashMap::new())
-        .created_at(invocation_payload.created_at)
-        .build(compute_graph.clone())
+        .fn_task_analytics(compute_graph.fn_task_analytics())
+        .created_at(invocation_payload.created_at.clone())
+        .build()
         .map_err(|e| {
             IndexifyAPIError::internal_error(anyhow!("failed to upload content: {}", e))
         })?;
@@ -362,9 +362,9 @@ pub async fn invoke_with_object(
         .compute_graph_name(compute_graph.name.to_string())
         .graph_version(compute_graph.version.clone())
         .invocation_id(invocation_payload.id.clone())
-        .fn_task_analytics(HashMap::new())
-        .created_at(invocation_payload.created_at)
-        .build(compute_graph.clone())
+        .fn_task_analytics(compute_graph.fn_task_analytics())
+        .created_at(invocation_payload.created_at.clone())
+        .build()
         .map_err(|e| {
             IndexifyAPIError::internal_error(anyhow!("failed to upload content: {}", e))
         })?;

--- a/server/src/routes_internal.rs
+++ b/server/src/routes_internal.rs
@@ -878,7 +878,7 @@ async fn list_outputs(
             http_outputs.push(FnOutput {
                 id: format!("{}|{}", output.id, idx),
                 compute_fn: output.compute_fn_name.clone(),
-                created_at: output.created_at,
+                created_at: output.created_at.clone().into(),
             });
         }
     }

--- a/server/src/routes_v1.rs
+++ b/server/src/routes_v1.rs
@@ -373,7 +373,7 @@ async fn find_invocation(
             id: output.id.clone(),
             num_outputs: output.payloads.len() as u64,
             compute_fn: output.compute_fn_name.clone(),
-            created_at: output.created_at,
+            created_at: output.created_at.clone().into(),
         });
     }
 

--- a/server/src/state_store/in_memory_state.rs
+++ b/server/src/state_store/in_memory_state.rs
@@ -1,6 +1,7 @@
 use std::{
     cmp::Ordering,
     collections::{HashMap, HashSet},
+    ops::Deref,
     sync::Arc,
 };
 
@@ -15,6 +16,7 @@ use tracing::{debug, error, warn};
 use crate::{
     data_model::{
         Allocation,
+        AllocationId,
         ComputeGraph,
         ComputeGraphState,
         ComputeGraphVersion,
@@ -100,7 +102,7 @@ impl Error {
 #[derive(Debug, Clone)]
 pub struct DesiredStateTask {
     pub task: Box<Task>,
-    pub allocation_id: String,
+    pub allocation_id: AllocationId,
     pub timeout_ms: u32,
     pub retry_policy: FunctionRetryPolicy,
 }
@@ -795,7 +797,7 @@ impl InMemoryState {
                             graph = &allocation.compute_graph,
                             "fn" = &allocation.compute_fn,
                             executor_id = allocation.target.executor_id.get(),
-                            allocation_id = allocation.id,
+                            allocation_id = %allocation.id,
                             invocation_id = &allocation.invocation_id,
                             task_id = allocation.task_id.get(),
                             "task not found for new allocation"
@@ -879,7 +881,7 @@ impl InMemoryState {
                                         // Record metrics
                                         self.allocation_running_latency.record(
                                             get_elapsed_time(
-                                                allocation.created_at,
+                                                *allocation.created_at.deref(),
                                                 TimeUnit::Milliseconds,
                                             ),
                                             &[KeyValue::new(
@@ -904,7 +906,7 @@ impl InMemoryState {
                     // Record metrics
                     self.allocation_completion_latency.record(
                         get_elapsed_time(
-                            allocation_output.allocation.created_at,
+                            *allocation_output.allocation.created_at.deref(),
                             TimeUnit::Milliseconds,
                         ),
                         &[KeyValue::new(

--- a/server/src/state_store/in_memory_state.rs
+++ b/server/src/state_store/in_memory_state.rs
@@ -349,7 +349,10 @@ impl InMemoryMetrics {
                                 .values()
                                 .filter(|inv| !inv.completed)
                                 .map(|inv| {
-                                    get_elapsed_time(inv.created_at.into(), TimeUnit::Milliseconds)
+                                    get_elapsed_time(
+                                        *inv.created_at.deref(),
+                                        TimeUnit::Milliseconds,
+                                    )
                                 })
                                 .max_by(|a, b| {
                                     a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal)

--- a/server/src/state_store/in_memory_state.rs
+++ b/server/src/state_store/in_memory_state.rs
@@ -135,7 +135,7 @@ pub struct UnallocatedTaskId {
 impl UnallocatedTaskId {
     pub fn new(task: &Task) -> Self {
         Self {
-            task_creation_time_ns: task.creation_time_ns,
+            task_creation_time_ns: task.creation_time_ns.clone().into(),
             task_key: task.key(),
         }
     }
@@ -394,7 +394,10 @@ impl InMemoryMetrics {
                                 .values()
                                 .filter(|task| !task.is_terminal())
                                 .map(|task| {
-                                    get_elapsed_time(task.creation_time_ns, TimeUnit::Nanoseconds)
+                                    get_elapsed_time(
+                                        *task.creation_time_ns.deref(),
+                                        TimeUnit::Nanoseconds,
+                                    )
                                 })
                                 .max_by(|a, b| {
                                     a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal)
@@ -788,7 +791,7 @@ impl InMemoryState {
 
                         // Record metrics
                         self.task_pending_latency.record(
-                            get_elapsed_time(task.creation_time_ns, TimeUnit::Nanoseconds),
+                            get_elapsed_time(*task.creation_time_ns.deref(), TimeUnit::Nanoseconds),
                             &[],
                         );
 
@@ -1488,8 +1491,6 @@ mod test_helpers {
 
 #[cfg(test)]
 mod tests {
-    use std::time::{SystemTime, UNIX_EPOCH};
-
     use crate::{
         data_model::{
             DataPayload,
@@ -1503,7 +1504,6 @@ mod tests {
             Task,
             TaskBuilder,
             TaskFailureReason,
-            TaskId,
             TaskOutcome,
             TaskStatus,
         },
@@ -1597,15 +1597,9 @@ mod tests {
             compute_graph: &str,
             invocation_id: &str,
             compute_fn: &str,
-            task_id: &str,
             outcome: TaskOutcome,
         ) -> Task {
-            let current_time = SystemTime::now();
-            let duration = current_time.duration_since(UNIX_EPOCH).unwrap();
-            let creation_time_ns = duration.as_nanos();
-
             TaskBuilder::default()
-                .id(TaskId::from(task_id))
                 .namespace(namespace.to_string())
                 .compute_fn_name(compute_fn.to_string())
                 .compute_graph_name(compute_graph.to_string())
@@ -1620,7 +1614,6 @@ mod tests {
                 .acc_input(None)
                 .status(TaskStatus::Pending)
                 .outcome(outcome)
-                .creation_time_ns(creation_time_ns)
                 .graph_version(GraphVersion("1.0".to_string()))
                 .cache_key(None)
                 .attempt_number(0)
@@ -1663,7 +1656,6 @@ mod tests {
             "test-graph",
             "inv-1",
             "test-function",
-            "task-1",
             TaskOutcome::Success,
         );
         state
@@ -1677,7 +1669,6 @@ mod tests {
             "test-graph",
             "inv-2",
             "test-function",
-            "task-2",
             TaskOutcome::Failure(TaskFailureReason::FunctionError),
         );
         state
@@ -1691,7 +1682,6 @@ mod tests {
             "test-graph",
             "inv-3",
             "test-function",
-            "task-3",
             TaskOutcome::Unknown,
         );
         state
@@ -1706,7 +1696,6 @@ mod tests {
             "different-graph",
             "inv-4",
             "test-function",
-            "task-4",
             TaskOutcome::Unknown,
         );
         state
@@ -1721,7 +1710,6 @@ mod tests {
             "test-graph",
             "inv-5",
             "different-function",
-            "task-5",
             TaskOutcome::Unknown,
         );
         state
@@ -1735,7 +1723,6 @@ mod tests {
             "test-graph",
             "inv-6",
             "test-function",
-            "task-6",
             TaskOutcome::Unknown,
         );
         state

--- a/server/src/state_store/mod.rs
+++ b/server/src/state_store/mod.rs
@@ -534,7 +534,8 @@ mod tests {
             .compute_graph_name("cg1".to_string())
             .invocation_id("foo1".to_string())
             .graph_version(GraphVersion("1".to_string()))
-            .build(tests::test_graph_a())?;
+            .fn_task_analytics(tests::test_graph_a().fn_task_analytics())
+            .build()?;
         let state_change_1 = state_changes::invoke_compute_graph(
             &indexify_state.state_change_id_seq,
             &InvokeComputeGraphRequest {

--- a/server/src/state_store/state_machine.rs
+++ b/server/src/state_store/state_machine.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, sync::Arc};
+use std::{collections::HashMap, ops::Deref, sync::Arc};
 
 use anyhow::{anyhow, Result};
 use rocksdb::{
@@ -686,7 +686,7 @@ pub(crate) fn handle_scheduler_update(
                 graph = invocation_ctx.compute_graph_name,
                 outcome = invocation_ctx.outcome.to_string(),
                 duration_sec =
-                    get_elapsed_time(invocation_ctx.created_at.into(), TimeUnit::Milliseconds),
+                    get_elapsed_time(*invocation_ctx.created_at.deref(), TimeUnit::Milliseconds),
                 "invocation completed"
             );
         }

--- a/server/src/state_store/state_machine.rs
+++ b/server/src/state_store/state_machine.rs
@@ -652,7 +652,8 @@ pub(crate) fn handle_scheduler_update(
                 task_id = task.id.to_string(),
                 status = task.status.to_string(),
                 outcome = task.outcome.to_string(),
-                duration_sec = get_elapsed_time(task.creation_time_ns, TimeUnit::Nanoseconds),
+                duration_sec =
+                    get_elapsed_time(*task.creation_time_ns.deref(), TimeUnit::Nanoseconds),
                 "updated task",
             ),
             TaskOutcome::Failure(_) => info!(
@@ -663,7 +664,8 @@ pub(crate) fn handle_scheduler_update(
                 task_id = task.id.to_string(),
                 status = task.status.to_string(),
                 outcome = task.outcome.to_string(),
-                duration_sec = get_elapsed_time(task.creation_time_ns, TimeUnit::Nanoseconds),
+                duration_sec =
+                    get_elapsed_time(*task.creation_time_ns.deref(), TimeUnit::Nanoseconds),
                 "updated task",
             ),
         }

--- a/server/src/state_store/state_machine.rs
+++ b/server/src/state_store/state_machine.rs
@@ -233,7 +233,7 @@ pub(crate) fn delete_invocation(
         let value = JsonEncoder::decode::<Allocation>(&value)?;
         if value.invocation_id == req.invocation_id {
             info!(
-                allocation_id = value.id,
+                allocation_id = %value.id,
                 task_id = value.task_id.get(),
                 "fn" = value.compute_fn,
                 "deleting allocation",
@@ -629,7 +629,7 @@ pub(crate) fn handle_scheduler_update(
             invocation_id = alloc.invocation_id,
             "fn" = alloc.compute_fn,
             task_id = alloc.task_id.to_string(),
-            allocation_id = alloc.id,
+            allocation_id = %alloc.id,
             fn_executor_id = alloc.target.function_executor_id.get(),
             executor_id = alloc.target.executor_id.get(),
             "add_allocation",


### PR DESCRIPTION
## Context

<!--
In a few sentences or less, please explain the context behind this change to help answer why this change is needed.

If this is a bug fix, make sure to include "fixes #xxxx", or
"closes #xxxx".

Screenshots, logs, code or other visual aids are greatly appreciated.
 -->

I noticed that the data models don't make use of the derive builder conventions to generate structs. Since it gives you some nice ergonomics, I think it's better to work with the library, instead of against it.

## What

<!--
In a few sentences, please summarize the change to help reviewers.

Consider providing screenshots, logs, code or other visual aids to help the reviewer understand the approach taken.
-->

This change removes the usage of `#[builder(build_fn(skip))]` to take full advantage of the derive builder crate.

I've put individual changes in different commits, so it's easier to review.

## Testing

<!--
Please include steps used to verify the change.

Consider providing screenshots, logs, code or other visual aids to help the reviewer in their testing.
-->

Tests have been updated to ensure the structures are initialized correctly.

## Contribution Checklist

- [ ] If a Python package was changed, please run `make fmt` in the package directory.
- [x] If the server was changed, please run `make fmt` in `server/`.
- [x] Make sure all PR Checks are passing.
<!--
Notes:

Tests of a Python package can be run manually. Start a Server and an Executor then
run `make test` in the Python package directory.

To test if changes to the server are backward compatible with the latest
release, label the PR with `ci_compat_test`. This might report failures
unrelated to your change if previous incompatible changes were pushed without
being released yet
-->
