### PR TITLE
Put Stats and SystemTasks back in the column families.

### DIFF
--- a/server/src/state_store/state_machine.rs
+++ b/server/src/state_store/state_machine.rs
@@ -64,6 +64,16 @@ pub enum IndexifyObjectsColumns {
     FunctionExecutorDiagnostics, // Function Executor ID -> FunctionExecutorDiagnostics
 
     GcUrls, // List of URLs pending deletion
+
+    // IMPORTANT! DO NOT DELETE THE FOLLOWING COLUMNS
+    // SystemTasks and Stats are still in the state store even
+    // though they are not referenced anywhere in the codebase.
+    //
+    // If you remove them, Indexify Server will fail to start
+    // because it won't be able to load the existing RocksDB column families.
+    SystemTasks, // Long running tasks involving multiple invocations
+
+    Stats, // Stats
 }
 
 impl IndexifyObjectsColumns {


### PR DESCRIPTION
## Context

<!--
In a few sentences or less, please explain the context behind this change to help answer why this change is needed.

If this is a bug fix, make sure to include "fixes #xxxx", or
"closes #xxxx".

Screenshots, logs, code or other visual aids are greatly appreciated.
 -->

RocksDB tries to load all column descriptors in the database when it loads. It Descriptors are not associated with column families, it will fail to load the database.

## What

<!--
In a few sentences, please summarize the change to help reviewers.

Consider providing screenshots, logs, code or other visual aids to help the reviewer understand the approach taken.
-->

These change adds Stats and SystemTasks back in the column families.

## Testing

<!--
Please include steps used to verify the change.

Consider providing screenshots, logs, code or other visual aids to help the reviewer in their testing.
-->

## Contribution Checklist

- [ ] If a Python package was changed, please run `make fmt` in the package directory.
- [x] If the server was changed, please run `make fmt` in `server/`.
- [ ] Make sure all PR Checks are passing.
<!--
Notes:

Tests of a Python package can be run manually. Start a Server and an Executor then
run `make test` in the Python package directory.

To test if changes to the server are backward compatible with the latest
release, label the PR with `ci_compat_test`. This might report failures
unrelated to your change if previous incompatible changes were pushed without
being released yet
-->
