### PR TITLE
Remove expect call from ComputeGraph::to_version.

### DIFF
--- a/server/src/state_store/in_memory_state.rs
+++ b/server/src/state_store/in_memory_state.rs
@@ -626,10 +626,11 @@ impl InMemoryState {
             RequestPayload::CreateOrUpdateComputeGraph(req) => {
                 self.compute_graphs
                     .insert(req.compute_graph.key(), Box::new(req.compute_graph.clone()));
-                self.compute_graph_versions.insert(
-                    req.compute_graph.to_version().key(),
-                    Box::new(req.compute_graph.to_version()),
-                );
+                let req_version = req.compute_graph.to_version()?;
+                let version = req_version.version.clone();
+
+                self.compute_graph_versions
+                    .insert(req_version.key(), Box::new(req_version));
 
                 // FIXME - we should set this in the API and not here, so that these things are
                 // not set in the state store
@@ -646,7 +647,7 @@ impl InMemoryState {
                             .take_while(|(k, _v)| k.starts_with(&tasks_key_prefix))
                             .for_each(|(_k, v)| {
                                 let mut task = v.clone();
-                                task.graph_version = req.compute_graph.to_version().version;
+                                task.graph_version = version.clone();
                                 tasks_to_update.push(task);
                             });
 
@@ -668,7 +669,7 @@ impl InMemoryState {
                             .take_while(|(k, _v)| k.starts_with(&invocation_ctx_key_prefix))
                             .for_each(|(_k, v)| {
                                 let mut ctx = v.clone();
-                                ctx.graph_version = req.compute_graph.to_version().version;
+                                ctx.graph_version = version.clone();
                                 invocation_ctx_to_update.push(ctx);
                             });
 

--- a/server/src/state_store/scanner.rs
+++ b/server/src/state_store/scanner.rs
@@ -562,7 +562,7 @@ impl StateReader {
         );
         let compute_graph = self.get_compute_graph(namespace, name)?;
         match compute_graph {
-            Some(compute_graph) => Ok(Some(compute_graph.to_version())),
+            Some(compute_graph) => compute_graph.to_version().map(Some),
             None => Ok(None),
         }
     }

--- a/server/src/state_store/state_machine.rs
+++ b/server/src/state_store/state_machine.rs
@@ -454,12 +454,12 @@ pub(crate) fn create_or_update_compute_graph(
     let new_compute_graph_version = match existing_compute_graph {
         Some(Ok(mut existing_compute_graph)) => {
             existing_compute_graph.update(compute_graph.clone());
-            Ok::<ComputeGraphVersion, anyhow::Error>(existing_compute_graph.to_version())
+            existing_compute_graph.to_version()
         }
         Some(Err(e)) => {
             return Err(anyhow!("failed to decode existing compute graph: {}", e));
         }
-        None => Ok(compute_graph.to_version()),
+        None => compute_graph.to_version(),
     }?;
     info!(
         "new compute graph version: {}",


### PR DESCRIPTION
## Context

<!--
In a few sentences or less, please explain the context behind this change to help answer why this change is needed.

If this is a bug fix, make sure to include "fixes #xxxx", or
"closes #xxxx".

Screenshots, logs, code or other visual aids are greatly appreciated.
 -->

The production codepath shouldn't have any `expect` or `unwrap`. I accidentally added an `expect` in `ComputeGraph::to_version`.

## What

<!--
In a few sentences, please summarize the change to help reviewers.

Consider providing screenshots, logs, code or other visual aids to help the reviewer understand the approach taken.
-->

This change removes the `expect` from ComputeGraph::to_version, and bubble the error up the chain.

## Testing

<!--
Please include steps used to verify the change.

Consider providing screenshots, logs, code or other visual aids to help the reviewer in their testing.
-->

I've updated tests to consider the new return type.

## Contribution Checklist

- [ ] If a Python package was changed, please run `make fmt` in the package directory.
- [x] If the server was changed, please run `make fmt` in `server/`.
- [ ] Make sure all PR Checks are passing.
<!--
Notes:

Tests of a Python package can be run manually. Start a Server and an Executor then
run `make test` in the Python package directory.

To test if changes to the server are backward compatible with the latest
release, label the PR with `ci_compat_test`. This might report failures
unrelated to your change if previous incompatible changes were pushed without
being released yet
-->
