### PR TITLE
Database abstractions.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -475,7 +475,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
 ]
 
 [[package]]
@@ -898,7 +898,7 @@ checksum = "f88959de2d447fd3eddcf1909d1f19fe084e27a056a6904203dc5d8b9e771c1e"
 dependencies = [
  "rust_decimal",
  "serde",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
  "time",
  "winnow 0.6.26",
 ]
@@ -1088,7 +1088,7 @@ dependencies = [
  "parking_lot",
  "pin-project",
  "serde",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
  "tokio",
  "twox-hash",
 ]
@@ -1121,7 +1121,7 @@ dependencies = [
  "parking_lot",
  "pin-project",
  "serde",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
  "tokio",
  "tracing",
 ]
@@ -1155,7 +1155,7 @@ dependencies = [
  "pin-project",
  "rand 0.9.2",
  "serde",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
  "tokio",
  "tracing",
  "twox-hash",
@@ -1723,6 +1723,7 @@ dependencies = [
  "slatedb",
  "strum",
  "tempfile",
+ "thiserror 2.0.16",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -2247,7 +2248,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
  "tokio",
  "tracing",
  "url",
@@ -2284,7 +2285,7 @@ dependencies = [
  "futures-sink",
  "js-sys",
  "pin-project-lite",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
  "tracing",
 ]
 
@@ -2314,7 +2315,7 @@ dependencies = [
  "opentelemetry_sdk",
  "prost 0.13.5",
  "reqwest",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
  "tokio",
  "tonic 0.13.1",
  "tracing",
@@ -2345,7 +2346,7 @@ dependencies = [
  "percent-encoding",
  "rand 0.9.2",
  "serde_json",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
  "tokio",
  "tokio-stream",
 ]
@@ -2695,7 +2696,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2 0.5.10",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
  "tokio",
  "tracing",
  "web-time",
@@ -2716,7 +2717,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.12",
+ "thiserror 2.0.16",
  "tinyvec",
  "tracing",
  "web-time",
@@ -3515,11 +3516,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.12"
+version = "2.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+checksum = "3467d614147380f2e4e374161426ff399c91084acd2363eaf549172b3d5e60c0"
 dependencies = [
- "thiserror-impl 2.0.12",
+ "thiserror-impl 2.0.16",
 ]
 
 [[package]]
@@ -3535,9 +3536,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.12"
+version = "2.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+checksum = "6c5e1be1c48b9172ee610da68fd9cd2770e7a4056cb3fc98710ee6906f0c7960"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -63,6 +63,7 @@ rocksdb = { version = "0.24.0" }
 strum = { version = "0.27.2", features = ["derive"] }
 derive_builder = "0.20.2"
 tempfile = "3.21.0"
+thiserror = "2.0.16"
 
 [dev-dependencies]
 tempfile = "3.20.0"

--- a/server/src/data_model/clocks.rs
+++ b/server/src/data_model/clocks.rs
@@ -152,6 +152,12 @@ impl<'de> Deserialize<'de> for VectorClock {
     }
 }
 
+/// Linearizable is a trait that describes objects
+/// that can be compared using vector clocks.
+pub trait Linearizable {
+    fn vector_clock(&self) -> VectorClock;
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/server/src/data_model/mod.rs
+++ b/server/src/data_model/mod.rs
@@ -19,7 +19,10 @@ use serde::{Deserialize, Serialize};
 use strum::Display;
 use tracing::info;
 
-use crate::{data_model::clocks::VectorClock, utils::get_epoch_time_in_ms};
+use crate::{
+    data_model::clocks::{Linearizable, VectorClock},
+    utils::get_epoch_time_in_ms,
+};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(transparent)]
@@ -186,6 +189,12 @@ pub struct Allocation {
     pub execution_duration_ms: Option<u64>,
     #[builder(default)]
     vector_clock: VectorClock,
+}
+
+impl Linearizable for Allocation {
+    fn vector_clock(&self) -> VectorClock {
+        self.vector_clock.clone()
+    }
 }
 
 impl Allocation {
@@ -458,6 +467,12 @@ pub struct ComputeGraph {
     vector_clock: VectorClock,
 }
 
+impl Linearizable for ComputeGraph {
+    fn vector_clock(&self) -> VectorClock {
+        self.vector_clock.clone()
+    }
+}
+
 impl ComputeGraph {
     pub fn key(&self) -> String {
         ComputeGraph::key_from(&self.namespace, &self.name)
@@ -615,6 +630,12 @@ pub struct ComputeGraphVersion {
     vector_clock: VectorClock,
 }
 
+impl Linearizable for ComputeGraphVersion {
+    fn vector_clock(&self) -> VectorClock {
+        self.vector_clock.clone()
+    }
+}
+
 impl ComputeGraphVersion {
     pub fn key(&self) -> String {
         ComputeGraphVersion::key_from(&self.namespace, &self.compute_graph_name, &self.version)
@@ -698,6 +719,12 @@ pub struct NodeOutput {
 
     #[builder(default)]
     vector_clock: VectorClock,
+}
+
+impl Linearizable for NodeOutput {
+    fn vector_clock(&self) -> VectorClock {
+        self.vector_clock.clone()
+    }
 }
 
 impl NodeOutput {
@@ -789,6 +816,12 @@ pub struct InvocationPayload {
     pub encoding: String,
     #[builder(default)]
     vector_clock: VectorClock,
+}
+
+impl Linearizable for InvocationPayload {
+    fn vector_clock(&self) -> VectorClock {
+        self.vector_clock.clone()
+    }
 }
 
 impl InvocationPayload {
@@ -951,6 +984,12 @@ pub struct GraphInvocationCtx {
     vector_clock: VectorClock,
 }
 
+impl Linearizable for GraphInvocationCtx {
+    fn vector_clock(&self) -> VectorClock {
+        self.vector_clock.clone()
+    }
+}
+
 impl GraphInvocationCtx {
     pub fn create_tasks(&mut self, tasks: &[Task], reducer_tasks: &[ReduceTask]) {
         for task in tasks {
@@ -1061,6 +1100,12 @@ pub struct ReduceTask {
 
     #[builder(default)]
     vector_clock: VectorClock,
+}
+
+impl Linearizable for ReduceTask {
+    fn vector_clock(&self) -> VectorClock {
+        self.vector_clock.clone()
+    }
 }
 
 impl ReduceTask {
@@ -1245,6 +1290,12 @@ pub struct Task {
     pub attempt_number: u32,
     #[builder(default)]
     vector_clock: VectorClock,
+}
+
+impl Linearizable for Task {
+    fn vector_clock(&self) -> VectorClock {
+        self.vector_clock.clone()
+    }
 }
 
 impl Task {
@@ -1760,6 +1811,12 @@ pub struct FunctionExecutorDiagnostics {
     vector_clock: VectorClock,
 }
 
+impl Linearizable for FunctionExecutorDiagnostics {
+    fn vector_clock(&self) -> VectorClock {
+        self.vector_clock.clone()
+    }
+}
+
 impl FunctionExecutorDiagnostics {
     pub fn key(&self) -> String {
         Self::key_from(
@@ -1798,6 +1855,12 @@ pub struct GcUrl {
     vector_clock: VectorClock,
 }
 
+impl Linearizable for GcUrl {
+    fn vector_clock(&self) -> VectorClock {
+        self.vector_clock.clone()
+    }
+}
+
 impl GcUrl {
     pub fn key(&self) -> String {
         format!("{}|{}", self.namespace, self.url)
@@ -1817,6 +1880,12 @@ pub struct FunctionExecutor {
     pub max_concurrency: u32,
     #[builder(default)]
     vector_clock: VectorClock,
+}
+
+impl Linearizable for FunctionExecutor {
+    fn vector_clock(&self) -> VectorClock {
+        self.vector_clock.clone()
+    }
 }
 
 impl PartialEq for FunctionExecutor {
@@ -1929,6 +1998,12 @@ pub struct ExecutorMetadata {
     pub clock: u64,
     #[builder(default)]
     vector_clock: VectorClock,
+}
+
+impl Linearizable for ExecutorMetadata {
+    fn vector_clock(&self) -> VectorClock {
+        self.vector_clock.clone()
+    }
 }
 
 impl ExecutorMetadata {
@@ -2103,6 +2178,13 @@ pub struct StateChange {
     #[builder(default)]
     vector_clock: VectorClock,
 }
+
+impl Linearizable for StateChange {
+    fn vector_clock(&self) -> VectorClock {
+        self.vector_clock.clone()
+    }
+}
+
 impl StateChange {
     pub fn key(&self) -> Vec<u8> {
         let mut key = vec![];
@@ -2137,6 +2219,12 @@ pub struct Namespace {
     pub blob_storage_region: Option<String>,
     #[builder(default)]
     vector_clock: VectorClock,
+}
+
+impl Linearizable for Namespace {
+    fn vector_clock(&self) -> VectorClock {
+        self.vector_clock.clone()
+    }
 }
 
 #[cfg(test)]

--- a/server/src/state_store/driver/mod.rs
+++ b/server/src/state_store/driver/mod.rs
@@ -1,0 +1,140 @@
+//! The driver module centralizes the logic for
+//! reading and writing data in the state store.
+//!
+//! It defines a series of traits that all DB drivers
+//! must implement to be a compliant state store.
+//!
+//! It also executes snapshot tests across different
+//! drivers to ensure that behaviors across drivers
+//! stay consistent.
+
+use std::{fmt, sync::Arc};
+
+use serde::{de::DeserializeOwned, Serialize};
+
+use crate::data_model::clocks::Linearizable;
+
+pub mod rocksdb;
+use rocksdb::RocksDBDriver;
+
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum Error {
+    #[error(
+        "Failed to store record, the records didn't match the vector clock. table: {}, field: {}",
+        table,
+        field
+    )]
+    MismatchedClock { table: String, field: String },
+
+    #[error("Failed to decode a serialized record. error: {}", source)]
+    JsonDecoderFailed { source: anyhow::Error },
+
+    #[error("Failed to encode a new serialized record. error: {}", source)]
+    JsonEncoderFailed { source: anyhow::Error },
+
+    #[error(transparent)]
+    RocksDBFailure {
+        #[from]
+        source: rocksdb::Error,
+    },
+}
+
+impl Error {
+    /// Identifies failed operations that can be
+    /// retried.
+    ///
+    /// At the moment, only `Self::MismatchedClock` errors
+    /// can be retried.
+    #[allow(dead_code)]
+    pub fn is_retryable(&self) -> bool {
+        matches!(&self, Self::MismatchedClock { .. })
+    }
+
+    /// Identifies failed operations that MUST not
+    /// be retried.
+    #[allow(dead_code)]
+    pub fn is_permanent(&self) -> bool {
+        !self.is_retryable()
+    }
+}
+
+/// Writer defines all the write operations for a given driver.
+pub trait Writer {
+    /// Start a new Transaction in the database.
+    #[allow(dead_code)]
+    fn start_transaction(&self) -> Result<Arc<dyn Transaction + '_>, Error>;
+}
+
+/// Reader defines all the read operations for a give driver.
+pub trait Reader {}
+
+/// AtomicComparator defines atomic functions that compare
+/// incoming records with existent records in the database.
+///
+/// These comparisons often use `crate::data_model::clocks::VectorClock`
+/// and `crate::data_model::clocks::Linearizable` structs to check
+/// the "happens-before" relationship between two records.
+pub trait AtomicComparator {
+    /// Compare a persisted record's vector clock against
+    /// the vector clock from an incoming new record, and commit
+    /// the new record if the clocks match.
+    ///
+    /// This function returns an error if the clock in the persisted
+    /// record is higher than the incoming one. This means that
+    /// a different event updated the record before, and the client
+    /// needs to reconcile the changes before trying to write its
+    /// changes.
+    #[allow(dead_code)]
+    fn compare_and_swap<R>(
+        &self,
+        tx: Arc<dyn Transaction>,
+        table: &str,
+        key: &str,
+        record: R,
+    ) -> Result<(), Error>
+    where
+        R: Linearizable + Serialize + DeserializeOwned + fmt::Debug;
+}
+
+/// Transaction is a wrapper around specific database transactions.
+/// Since different databases have different transaction semantics,
+/// this trait allow us to hide those semantics from the caller's
+/// point of view.
+pub trait Transaction {
+    #[allow(dead_code)]
+    fn commit(self) -> Result<(), Error>;
+    #[allow(dead_code)]
+    fn rollback(&self) -> Result<(), Error>;
+
+    fn get_for_update(&self, table: &str, key: &str) -> Result<Option<Vec<u8>>, Error>;
+    fn put(&self, table: &str, key: &str, record: &[u8]) -> Result<(), Error>;
+}
+
+/// Driver defines all the operations a database driver needs to support.
+/// It combines Writer + Reader to make implementing a driver more ergonomic.
+#[allow(dead_code)]
+pub trait Driver: Writer + Reader {}
+
+/// Multiple options to configure different database drivers.
+///
+/// The only option at the moment is RocksDB
+#[non_exhaustive]
+pub enum ConnectionOptions {
+    RocksDB(rocksdb::Options),
+}
+
+/// Open a connection to a database.
+///
+/// This is the main entry point to connect Indexify server with a database to
+/// keep the state.
+///
+/// It returns a `RocksDBDriver` at the moment because there is no other option
+/// supported. This helps keep the code backward compatible.
+pub fn open_database(options: ConnectionOptions) -> Result<Arc<RocksDBDriver>, Error> {
+    match options {
+        ConnectionOptions::RocksDB(options) => {
+            rocksdb::RocksDBDriver::open(options).map_err(Into::into)
+        }
+    }
+}

--- a/server/src/state_store/driver/rocksdb.rs
+++ b/server/src/state_store/driver/rocksdb.rs
@@ -1,0 +1,171 @@
+use std::{fmt, path::PathBuf, sync::Arc};
+
+use rocksdb::{
+    ColumnFamily,
+    ColumnFamilyDescriptor,
+    Error as RocksDBError,
+    Options as RocksDBOptions,
+    Transaction,
+    TransactionDB,
+    TransactionDBOptions,
+};
+use serde::{de::DeserializeOwned, Serialize};
+use tracing::error;
+
+use crate::{
+    data_model::clocks::Linearizable,
+    state_store::{
+        driver::{AtomicComparator, Driver, Error as DriverError, Reader, Writer},
+        serializer::{JsonEncode, JsonEncoder},
+    },
+    utils::OptionInspectNone,
+};
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("Failed to open RocksDB database. error: {}", source)]
+    OpenDatabaseFailed { source: RocksDBError },
+
+    #[error("Failed to load column handle. table: {}", name)]
+    ColumnFamilyLocationFailed { name: String },
+
+    #[error(transparent)]
+    GenericRocksDBFailure { source: RocksDBError },
+}
+
+/// Options to start a connection with RocksDB.
+pub(crate) struct Options {
+    pub path: PathBuf,
+    pub column_families: Vec<ColumnFamilyDescriptor>,
+}
+
+/// Driver to connect with a RocksDB database.
+pub(crate) struct RocksDBDriver {
+    // This field is public, so Indexify server can use keep using
+    // RocksDB's connection directly until all the operations can be
+    // put behind an interface. That will keep the codebase
+    // backwards compatible with what we have now.
+    pub db: Arc<TransactionDB>,
+}
+
+impl RocksDBDriver {
+    /// Open a new connection with a RocksDB database.
+    pub(crate) fn open(driver_options: Options) -> Result<Arc<RocksDBDriver>, Error> {
+        let mut db_opts = RocksDBOptions::default();
+        db_opts.create_missing_column_families(true);
+        db_opts.create_if_missing(true);
+
+        let db = TransactionDB::open_cf_descriptors(
+            &db_opts,
+            &TransactionDBOptions::default(),
+            &driver_options.path,
+            driver_options.column_families,
+        )
+        .map_err(|source| Error::OpenDatabaseFailed { source })?;
+
+        Ok(Arc::new(RocksDBDriver { db: Arc::new(db) }))
+    }
+}
+
+impl Writer for RocksDBDriver {
+    #[allow(clippy::arc_with_non_send_sync)]
+    fn start_transaction(&self) -> Result<Arc<dyn super::Transaction + '_>, DriverError> {
+        let tx = self.db.transaction();
+
+        Ok(Arc::new(RocksDBTransaction {
+            db: self.db.clone(),
+            tx,
+        }))
+    }
+}
+
+impl AtomicComparator for RocksDBDriver {
+    fn compare_and_swap<R>(
+        &self,
+        tx: Arc<dyn super::Transaction>,
+        table: &str,
+        key: &str,
+        new_record: R,
+    ) -> Result<(), DriverError>
+    where
+        R: Linearizable + Serialize + DeserializeOwned + fmt::Debug,
+    {
+        let existing_record = tx.get_for_update(table, key)?;
+
+        if let Some(record) = existing_record {
+            let old_record: R = JsonEncoder::decode(&record)
+                .map_err(|source| DriverError::JsonDecoderFailed { source })?;
+
+            if old_record.vector_clock() > new_record.vector_clock() {
+                return Err(DriverError::MismatchedClock {
+                    table: table.to_string(),
+                    field: key.to_string(),
+                });
+            }
+        }
+
+        let new_record = JsonEncoder::encode(&new_record)
+            .map_err(|source| DriverError::JsonEncoderFailed { source })?;
+
+        tx.put(table, key, &new_record)
+    }
+}
+
+impl Reader for RocksDBDriver {}
+impl Driver for RocksDBDriver {}
+
+#[allow(dead_code)]
+pub(crate) struct RocksDBTransaction<'a> {
+    db: Arc<TransactionDB>,
+    tx: Transaction<'a, TransactionDB>,
+}
+
+impl<'a> super::Transaction for RocksDBTransaction<'a> {
+    fn commit(self) -> Result<(), DriverError> {
+        self.tx
+            .commit()
+            .map_err(|source| Error::GenericRocksDBFailure { source }.into())
+    }
+
+    fn rollback(&self) -> Result<(), DriverError> {
+        self.tx
+            .rollback()
+            .map_err(|source| Error::GenericRocksDBFailure { source }.into())
+    }
+
+    fn get_for_update(&self, table: &str, key: &str) -> Result<Option<Vec<u8>>, DriverError> {
+        let cf = self.column_family(table)?;
+        self.tx
+            .get_for_update_cf(cf, key, true)
+            .map_err(|source| Error::GenericRocksDBFailure { source }.into())
+    }
+
+    fn put(&self, table: &str, key: &str, value: &[u8]) -> Result<(), DriverError> {
+        let cf = self.column_family(table)?;
+        self.tx
+            .put_cf(cf, key, value)
+            .map_err(|source| Error::GenericRocksDBFailure { source }.into())
+    }
+}
+
+impl<'a> RocksDBTransaction<'a> {
+    /// Get the column family for a key from RocksDB.
+    ///
+    /// TODO(David): Figure out how expensive is to call this operation.
+    /// If it's too expensive, we should probably have column families
+    /// pre-loaded, or cached in memory.
+    #[allow(dead_code)]
+    fn column_family(&self, name: &str) -> Result<&ColumnFamily, DriverError> {
+        self.db
+            .cf_handle(name)
+            .inspect_none(|| {
+                error!("failed to get column family handle for {}", name);
+            })
+            .ok_or_else(|| {
+                Error::ColumnFamilyLocationFailed {
+                    name: name.to_string(),
+                }
+                .into()
+            })
+    }
+}


### PR DESCRIPTION
## Context

<!--
In a few sentences or less, please explain the context behind this change to help answer why this change is needed.

If this is a bug fix, make sure to include "fixes #xxxx", or
"closes #xxxx".

Screenshots, logs, code or other visual aids are greatly appreciated.
 -->

Indexify server relies on RocksDB to store the server state in production. Although RocksDB is highly reliable, it's challenging to manage the service as a stateful server, specially during deployments.

## What

<!--
In a few sentences, please summarize the change to help reviewers.

Consider providing screenshots, logs, code or other visual aids to help the reviewer understand the approach taken.
-->

This change introduces the beginning of abtracting the current RocksDB logic behind an interface. This will allow us at some point to break the hard dependency of the state with RocksDB, and move the state to an extrernal store.

This change also introduces a new operation in the RocksDB driver to perform CompareAndSwap operations. This is an example of how to implement new operations on top of the driver abstraction.

The state store does not currently use most of this abstraction at the moment. This is my way to prevent any regression issue to land this change. The only change in the current code is the way the RockDB connection is initialized, which should still be compatible with the code in production.

## Testing

<!--
Please include steps used to verify the change.

Consider providing screenshots, logs, code or other visual aids to help the reviewer in their testing.
-->

All existent tests should still pass. I'll be adding tests to the driver abstraction as we start using them more.

## Contribution Checklist

- [ ] If a Python package was changed, please run `make fmt` in the package directory.
- [x] If the server was changed, please run `make fmt` in `server/`.
- [ ] Make sure all PR Checks are passing.
<!--
Notes:

Tests of a Python package can be run manually. Start a Server and an Executor then
run `make test` in the Python package directory.

To test if changes to the server are backward compatible with the latest
release, label the PR with `ci_compat_test`. This might report failures
unrelated to your change if previous incompatible changes were pushed without
being released yet
-->
