### PR TITLE
Simplify passing epoch times around functions.

### DIFF
--- a/server/src/data_model/mod.rs
+++ b/server/src/data_model/mod.rs
@@ -28,6 +28,16 @@ use crate::{
 #[serde(transparent)]
 pub struct EpochTime(u128);
 
+impl EpochTime {
+    pub fn as_nanos(&self) -> u128 {
+        self.0
+    }
+
+    fn to_be_bytes(&self) -> [u8; 16] {
+        self.0.to_be_bytes()
+    }
+}
+
 impl Default for EpochTime {
     fn default() -> Self {
         get_epoch_time_in_ms().into()
@@ -37,20 +47,6 @@ impl Default for EpochTime {
 impl fmt::Display for EpochTime {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.0)
-    }
-}
-
-impl Deref for EpochTime {
-    type Target = u128;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl std::ops::DerefMut for EpochTime {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
     }
 }
 

--- a/server/src/processor/graph_processor.rs
+++ b/server/src/processor/graph_processor.rs
@@ -227,7 +227,7 @@ impl GraphProcessor {
 
         // Record the state transition latency
         self.state_transition_latency.record(
-            get_elapsed_time(state_change.created_at.into(), TimeUnit::Milliseconds),
+            get_elapsed_time(&state_change.created_at.into(), TimeUnit::Milliseconds),
             &[KeyValue::new(
                 "type",
                 if state_change.namespace.is_some() {

--- a/server/src/state_store/in_memory_state.rs
+++ b/server/src/state_store/in_memory_state.rs
@@ -1,7 +1,6 @@
 use std::{
     cmp::Ordering,
     collections::{HashMap, HashSet},
-    ops::Deref,
     sync::Arc,
 };
 
@@ -349,10 +348,7 @@ impl InMemoryMetrics {
                                 .values()
                                 .filter(|inv| !inv.completed)
                                 .map(|inv| {
-                                    get_elapsed_time(
-                                        *inv.created_at.deref(),
-                                        TimeUnit::Milliseconds,
-                                    )
+                                    get_elapsed_time(&inv.created_at, TimeUnit::Milliseconds)
                                 })
                                 .max_by(|a, b| {
                                     a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal)
@@ -394,10 +390,7 @@ impl InMemoryMetrics {
                                 .values()
                                 .filter(|task| !task.is_terminal())
                                 .map(|task| {
-                                    get_elapsed_time(
-                                        *task.creation_time_ns.deref(),
-                                        TimeUnit::Nanoseconds,
-                                    )
+                                    get_elapsed_time(&task.creation_time_ns, TimeUnit::Nanoseconds)
                                 })
                                 .max_by(|a, b| {
                                     a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal)
@@ -792,7 +785,7 @@ impl InMemoryState {
 
                         // Record metrics
                         self.task_pending_latency.record(
-                            get_elapsed_time(*task.creation_time_ns.deref(), TimeUnit::Nanoseconds),
+                            get_elapsed_time(&task.creation_time_ns, TimeUnit::Nanoseconds),
                             &[],
                         );
 
@@ -888,7 +881,7 @@ impl InMemoryState {
                                         // Record metrics
                                         self.allocation_running_latency.record(
                                             get_elapsed_time(
-                                                *allocation.created_at.deref(),
+                                                &allocation.created_at,
                                                 TimeUnit::Milliseconds,
                                             ),
                                             &[KeyValue::new(
@@ -913,7 +906,7 @@ impl InMemoryState {
                     // Record metrics
                     self.allocation_completion_latency.record(
                         get_elapsed_time(
-                            *allocation_output.allocation.created_at.deref(),
+                            &allocation_output.allocation.created_at,
                             TimeUnit::Milliseconds,
                         ),
                         &[KeyValue::new(

--- a/server/src/state_store/state_machine.rs
+++ b/server/src/state_store/state_machine.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, ops::Deref, sync::Arc};
+use std::{collections::HashMap, sync::Arc};
 
 use anyhow::{anyhow, Result};
 use rocksdb::{
@@ -662,8 +662,7 @@ pub(crate) fn handle_scheduler_update(
                 task_id = task.id.to_string(),
                 status = task.status.to_string(),
                 outcome = task.outcome.to_string(),
-                duration_sec =
-                    get_elapsed_time(*task.creation_time_ns.deref(), TimeUnit::Nanoseconds),
+                duration_sec = get_elapsed_time(&task.creation_time_ns, TimeUnit::Nanoseconds),
                 "updated task",
             ),
             TaskOutcome::Failure(_) => info!(
@@ -674,8 +673,7 @@ pub(crate) fn handle_scheduler_update(
                 task_id = task.id.to_string(),
                 status = task.status.to_string(),
                 outcome = task.outcome.to_string(),
-                duration_sec =
-                    get_elapsed_time(*task.creation_time_ns.deref(), TimeUnit::Nanoseconds),
+                duration_sec = get_elapsed_time(&task.creation_time_ns, TimeUnit::Nanoseconds),
                 "updated task",
             ),
         }
@@ -697,8 +695,7 @@ pub(crate) fn handle_scheduler_update(
                 namespace = invocation_ctx.namespace,
                 graph = invocation_ctx.compute_graph_name,
                 outcome = invocation_ctx.outcome.to_string(),
-                duration_sec =
-                    get_elapsed_time(*invocation_ctx.created_at.deref(), TimeUnit::Milliseconds),
+                duration_sec = get_elapsed_time(&invocation_ctx.created_at, TimeUnit::Milliseconds),
                 "invocation completed"
             );
         }

--- a/server/src/utils/mod.rs
+++ b/server/src/utils/mod.rs
@@ -9,6 +9,8 @@ use anyhow::{anyhow, Result};
 use futures::Stream;
 use pin_project::{pin_project, pinned_drop};
 
+use crate::data_model::EpochTime;
+
 pub mod dynamic_sleep;
 
 #[macro_export]
@@ -59,14 +61,16 @@ pub enum TimeUnit {
     Nanoseconds,
 }
 
-pub fn get_elapsed_time(at: u128, unit: TimeUnit) -> f64 {
+pub fn get_elapsed_time(at: &EpochTime, unit: TimeUnit) -> f64 {
     match SystemTime::now().duration_since(UNIX_EPOCH) {
         Ok(duration) => {
             // Convert both times to the same unit (nanoseconds) for comparison
             let current_ns = duration.as_nanos();
+            let at_ns = at.as_nanos();
+
             let at_ns = match unit {
-                TimeUnit::Milliseconds => at * 1_000_000,
-                TimeUnit::Nanoseconds => at,
+                TimeUnit::Milliseconds => at_ns * 1_000_000,
+                TimeUnit::Nanoseconds => at_ns,
             };
 
             if current_ns < at_ns {
@@ -153,28 +157,28 @@ pub mod tests {
     fn test_get_elapsed_time() {
         {
             let now = get_epoch_time_in_ms();
-            let elapsed = get_elapsed_time(now.into(), TimeUnit::Milliseconds);
+            let elapsed = get_elapsed_time(&now.into(), TimeUnit::Milliseconds);
             assert!((0.0..0.1).contains(&elapsed));
         }
 
         {
             let now = get_epoch_time_in_ms();
             let past = now - 10; // 10ms ago
-            let elapsed = get_elapsed_time(past.into(), TimeUnit::Milliseconds);
+            let elapsed = get_elapsed_time(&past.into(), TimeUnit::Milliseconds);
             assert!((0.01..0.21).contains(&elapsed), "{}", elapsed);
         }
 
         {
             let now = get_epoch_time_in_ms();
             let past = now - 5000; // 5 seconds ago
-            let elapsed = get_elapsed_time(past.into(), TimeUnit::Milliseconds);
+            let elapsed = get_elapsed_time(&past.into(), TimeUnit::Milliseconds);
             assert!((5.0..5.1).contains(&elapsed));
         }
 
         {
             let now = get_epoch_time_in_ms();
             let future = now + 5000; // 5 seconds in the future
-            let elapsed = get_elapsed_time(future.into(), TimeUnit::Milliseconds);
+            let elapsed = get_elapsed_time(&future.into(), TimeUnit::Milliseconds);
             assert_eq!(elapsed, 0.0); // Should handle future times gracefully
         }
     }


### PR DESCRIPTION
## Context

<!--
In a few sentences or less, please explain the context behind this change to help answer why this change is needed.

If this is a bug fix, make sure to include "fixes #xxxx", or
"closes #xxxx".

Screenshots, logs, code or other visual aids are greatly appreciated.
 -->

Some time based tests in indexify starting acting up in CI when I changed the code that passes epoch times around. This PR changes the logic to attempt to get those tests passing again in CI

## What

<!--
In a few sentences, please summarize the change to help reviewers.

Consider providing screenshots, logs, code or other visual aids to help the reviewer understand the approach taken.
-->

Pass a reference to the struct that holds the time to calculate the elapsed time instead of de-referencing it twice.

## Testing

<!--
Please include steps used to verify the change.

Consider providing screenshots, logs, code or other visual aids to help the reviewer in their testing.
-->

Existent tests should pass.

## Contribution Checklist

- [ ] If a Python package was changed, please run `make fmt` in the package directory.
- [x] If the server was changed, please run `make fmt` in `server/`.
- [ ] Make sure all PR Checks are passing.
<!--
Notes:

Tests of a Python package can be run manually. Start a Server and an Executor then
run `make test` in the Python package directory.

To test if changes to the server are backward compatible with the latest
release, label the PR with `ci_compat_test`. This might report failures
unrelated to your change if previous incompatible changes were pushed without
being released yet
-->
