### PR TITLE
Replace the direct usage of TransactionDB.

### DIFF
--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -27,7 +27,7 @@ nanoid = "0.4.0"
 object_store = { version="0.12.3", features = ["aws"] }
 uuid = { version = "1.18.0", features = ["v4"] }
 tower-http = { version = "0.6.6", default-features = false, features = ["cors", "trace"] }
-bytes = "1.10.1"
+bytes = { version = "1.10.1", features = ["serde"] }
 ciborium = "0.2.2"
 rand = "0.9.2"
 hex = "0.4.3"

--- a/server/src/gc_test.rs
+++ b/server/src/gc_test.rs
@@ -85,7 +85,9 @@ mod tests {
                 .build()?;
 
             indexify_state.db.put_cf(
-                &IndexifyObjectsColumns::GraphInvocations.cf_db(&indexify_state.db),
+                indexify_state
+                    .db
+                    .column_family(IndexifyObjectsColumns::GraphInvocations.as_ref()),
                 invocation.key().as_bytes(),
                 &JsonEncoder::encode(&invocation)?,
             )?;
@@ -105,7 +107,9 @@ mod tests {
                 .build()?;
 
             indexify_state.db.put_cf(
-                &IndexifyObjectsColumns::GraphInvocationCtx.cf_db(&indexify_state.db),
+                indexify_state
+                    .db
+                    .column_family(IndexifyObjectsColumns::GraphInvocationCtx.as_ref()),
                 invocation.key().as_bytes(),
                 &JsonEncoder::encode(&graph_ctx)?,
             )?;
@@ -130,7 +134,9 @@ mod tests {
             let key = output.key();
             let serialized_output = JsonEncoder::encode(&output)?;
             indexify_state.db.put_cf(
-                &IndexifyObjectsColumns::FnOutputs.cf_db(&indexify_state.db),
+                indexify_state
+                    .db
+                    .column_family(IndexifyObjectsColumns::FnOutputs.as_ref()),
                 key,
                 &serialized_output,
             )?;

--- a/server/src/state_store/driver/rocksdb.rs
+++ b/server/src/state_store/driver/rocksdb.rs
@@ -1,6 +1,8 @@
 use std::{fmt, path::PathBuf, sync::Arc};
 
+use bytes::Bytes;
 use rocksdb::{
+    AsColumnFamilyRef,
     ColumnFamily,
     ColumnFamilyDescriptor,
     Error as RocksDBError,
@@ -10,7 +12,7 @@ use rocksdb::{
     TransactionDBOptions,
 };
 use serde::{de::DeserializeOwned, Serialize};
-use tracing::error;
+use tracing::{error, warn};
 
 use crate::{
     data_model::clocks::Linearizable,
@@ -18,7 +20,6 @@ use crate::{
         driver::{AtomicComparator, Driver, Error as DriverError, Reader, Writer},
         serializer::{JsonEncode, JsonEncoder},
     },
-    utils::OptionInspectNone,
 };
 
 #[derive(Debug, thiserror::Error)]
@@ -42,15 +43,15 @@ pub(crate) struct Options {
 /// Driver to connect with a RocksDB database.
 pub(crate) struct RocksDBDriver {
     // This field is public, so Indexify server can use keep using
-    // RocksDB's connection directly until all the operations can be
+    // the RocksDB's connection directly until all the operations can be
     // put behind an interface. That will keep the codebase
     // backwards compatible with what we have now.
-    pub db: Arc<TransactionDB>,
+    pub db: TransactionDB,
 }
 
 impl RocksDBDriver {
     /// Open a new connection with a RocksDB database.
-    pub(crate) fn open(driver_options: Options) -> Result<Arc<RocksDBDriver>, Error> {
+    pub(crate) fn open(driver_options: Options) -> Result<RocksDBDriver, Error> {
         let mut db_opts = RocksDBOptions::default();
         db_opts.create_missing_column_families(true);
         db_opts.create_if_missing(true);
@@ -63,17 +64,65 @@ impl RocksDBDriver {
         )
         .map_err(|source| Error::OpenDatabaseFailed { source })?;
 
-        Ok(Arc::new(RocksDBDriver { db: Arc::new(db) }))
+        Ok(RocksDBDriver { db })
+    }
+}
+
+impl RocksDBDriver {
+    /// Fetch a column family from RocksDB.
+    ///
+    /// If the name does not exist in the database,
+    /// this function panics because it's an irrecoverable error.
+    pub fn column_family(&self, name: &str) -> &ColumnFamily {
+        let Some(handle) = self.db.cf_handle(name) else {
+            panic!("failed to get column family handle for {name}");
+        };
+
+        handle
+    }
+
+    pub fn get_cf<K>(
+        &self,
+        cf: &impl AsColumnFamilyRef,
+        key: K,
+    ) -> Result<Option<Vec<u8>>, RocksDBError>
+    where
+        K: AsRef<[u8]>,
+    {
+        self.db.get_cf(cf, key)
+    }
+
+    pub fn put_cf<K, V>(
+        &self,
+        cf: &impl AsColumnFamilyRef,
+        key: K,
+        value: V,
+    ) -> Result<(), RocksDBError>
+    where
+        K: AsRef<[u8]>,
+        V: AsRef<[u8]>,
+    {
+        self.db.put_cf(cf, key, value)
+    }
+
+    pub fn drop_cf(&mut self, name: &str) -> Result<(), RocksDBError> {
+        self.db.drop_cf(name)
+    }
+
+    pub fn create_cf<N>(&mut self, name: N, opts: &RocksDBOptions) -> Result<(), RocksDBError>
+    where
+        N: AsRef<str>,
+    {
+        self.db.create_cf(name, opts)
     }
 }
 
 impl Writer for RocksDBDriver {
-    #[allow(clippy::arc_with_non_send_sync)]
-    fn start_transaction(&self) -> Result<Arc<dyn super::Transaction + '_>, DriverError> {
+    fn start_transaction(&self) -> Result<super::Transaction, DriverError> {
         let tx = self.db.transaction();
 
-        Ok(Arc::new(RocksDBTransaction {
-            db: self.db.clone(),
+        Ok(super::Transaction::RocksDB(RocksDBTransaction {
+            db: self,
             tx,
         }))
     }
@@ -82,7 +131,7 @@ impl Writer for RocksDBDriver {
 impl AtomicComparator for RocksDBDriver {
     fn compare_and_swap<R>(
         &self,
-        tx: Arc<dyn super::Transaction>,
+        tx: Arc<super::Transaction>,
         table: &str,
         key: &str,
         new_record: R,
@@ -90,7 +139,10 @@ impl AtomicComparator for RocksDBDriver {
     where
         R: Linearizable + Serialize + DeserializeOwned + fmt::Debug,
     {
-        let existing_record = tx.get_for_update(table, key)?;
+        let tx = unwrap_rocksdb_transaction(&tx);
+        let cf = tx.column_family(table);
+
+        let existing_record = tx.get_for_update_cf(cf, key)?;
 
         if let Some(record) = existing_record {
             let old_record: R = JsonEncoder::decode(&record)
@@ -107,45 +159,59 @@ impl AtomicComparator for RocksDBDriver {
         let new_record = JsonEncoder::encode(&new_record)
             .map_err(|source| DriverError::JsonEncoderFailed { source })?;
 
-        tx.put(table, key, &new_record)
+        tx.put_cf(cf, key, &new_record)
     }
 }
 
-impl Reader for RocksDBDriver {}
+impl Reader for RocksDBDriver {
+    fn list_existent_items(
+        &self,
+        column: &str,
+        keys: Vec<&[u8]>,
+    ) -> Result<Vec<Bytes>, DriverError> {
+        let cf_handle =
+            self.db
+                .cf_handle(column)
+                .ok_or_else(|| Error::ColumnFamilyLocationFailed {
+                    name: column.to_string(),
+                })?;
+
+        let mut items = Vec::with_capacity(keys.len());
+        let multi_get_keys: Vec<_> = keys.iter().map(|k| (&cf_handle, k.to_vec())).collect();
+        let values = self.db.multi_get_cf(multi_get_keys);
+
+        for (key, value) in keys.into_iter().zip(values.into_iter()) {
+            match value.map_err(|source| Error::GenericRocksDBFailure { source })? {
+                Some(v) => items.push(v.into()),
+                None => {
+                    warn!(
+                        "Key not found: {}",
+                        String::from_utf8(key.to_vec()).unwrap_or_default()
+                    );
+                }
+            }
+        }
+        Ok(items)
+    }
+}
+
 impl Driver for RocksDBDriver {}
+
+#[allow(irrefutable_let_patterns)]
+/// Ensure that the transaction we're using has been generated by the RocksDB
+/// driver. Using a transaction from another driver is an irrecoverable failure
+/// and we should crash the server.
+fn unwrap_rocksdb_transaction<'db>(tx: &'db super::Transaction) -> &'db RocksDBTransaction<'db> {
+    let super::Transaction::RocksDB(tx) = tx else {
+        panic!("tried to unwrap a RocksDBTransaction from a Transaction that was not created by the RocksDB driver: {tx:?}");
+    };
+    tx
+}
 
 #[allow(dead_code)]
 pub(crate) struct RocksDBTransaction<'a> {
-    db: Arc<TransactionDB>,
+    db: &'a RocksDBDriver,
     tx: Transaction<'a, TransactionDB>,
-}
-
-impl<'a> super::Transaction for RocksDBTransaction<'a> {
-    fn commit(self) -> Result<(), DriverError> {
-        self.tx
-            .commit()
-            .map_err(|source| Error::GenericRocksDBFailure { source }.into())
-    }
-
-    fn rollback(&self) -> Result<(), DriverError> {
-        self.tx
-            .rollback()
-            .map_err(|source| Error::GenericRocksDBFailure { source }.into())
-    }
-
-    fn get_for_update(&self, table: &str, key: &str) -> Result<Option<Vec<u8>>, DriverError> {
-        let cf = self.column_family(table)?;
-        self.tx
-            .get_for_update_cf(cf, key, true)
-            .map_err(|source| Error::GenericRocksDBFailure { source }.into())
-    }
-
-    fn put(&self, table: &str, key: &str, value: &[u8]) -> Result<(), DriverError> {
-        let cf = self.column_family(table)?;
-        self.tx
-            .put_cf(cf, key, value)
-            .map_err(|source| Error::GenericRocksDBFailure { source }.into())
-    }
 }
 
 impl<'a> RocksDBTransaction<'a> {
@@ -155,17 +221,49 @@ impl<'a> RocksDBTransaction<'a> {
     /// If it's too expensive, we should probably have column families
     /// pre-loaded, or cached in memory.
     #[allow(dead_code)]
-    fn column_family(&self, name: &str) -> Result<&ColumnFamily, DriverError> {
-        self.db
-            .cf_handle(name)
-            .inspect_none(|| {
-                error!("failed to get column family handle for {}", name);
-            })
-            .ok_or_else(|| {
-                Error::ColumnFamilyLocationFailed {
-                    name: name.to_string(),
-                }
-                .into()
-            })
+    fn column_family(&self, name: &str) -> &ColumnFamily {
+        self.db.column_family(name)
+    }
+
+    #[allow(dead_code)]
+    fn commit(self) -> Result<(), DriverError> {
+        self.tx
+            .commit()
+            .map_err(|source| Error::GenericRocksDBFailure { source }.into())
+    }
+
+    #[allow(dead_code)]
+    fn rollback(&self) -> Result<(), DriverError> {
+        self.tx
+            .rollback()
+            .map_err(|source| Error::GenericRocksDBFailure { source }.into())
+    }
+
+    #[allow(dead_code)]
+    fn get_for_update(&self, table: &str, key: &str) -> Result<Option<Vec<u8>>, DriverError> {
+        let cf = self.column_family(table);
+        self.get_for_update_cf(cf, key)
+    }
+
+    fn get_for_update_cf(
+        &self,
+        cf: &ColumnFamily,
+        key: &str,
+    ) -> Result<Option<Vec<u8>>, DriverError> {
+        self.tx
+            .get_for_update_cf(cf, key, true)
+            .map_err(|source| Error::GenericRocksDBFailure { source }.into())
+    }
+
+    #[allow(dead_code)]
+    fn put(&self, table: &str, key: &str, value: &[u8]) -> Result<(), DriverError> {
+        let cf = self.column_family(table);
+        self.put_cf(cf, key, value)
+    }
+
+    fn put_cf(&self, cf: &ColumnFamily, key: &str, value: &[u8]) -> Result<(), DriverError> {
+        self.tx
+            .put_cf(cf, key, value)
+            .map_err(|source| Error::GenericRocksDBFailure { source }.into())
     }
 }

--- a/server/src/state_store/migration_runner.rs
+++ b/server/src/state_store/migration_runner.rs
@@ -7,6 +7,7 @@ use tracing::info;
 use crate::{
     data_model::StateMachineMetadata,
     state_store::{
+        driver::rocksdb::RocksDBDriver,
         migrations::{
             contexts::{MigrationContext, PrepareContext},
             registry::MigrationRegistry,
@@ -82,7 +83,7 @@ pub fn run(path: &Path) -> Result<StateMachineMetadata> {
             .with_context(|| format!("Preparing DB for migration to v{to_version}"))?;
 
         // Apply migration in a transaction
-        let txn = db.transaction();
+        let txn = db.db.transaction();
 
         // Create migration context
         let migration_ctx = MigrationContext::new(&db, &txn);
@@ -112,9 +113,9 @@ pub fn run(path: &Path) -> Result<StateMachineMetadata> {
 }
 
 /// Read state machine metadata from the database
-pub fn read_sm_meta(db: &TransactionDB) -> Result<StateMachineMetadata> {
+pub fn read_sm_meta(db: &RocksDBDriver) -> Result<StateMachineMetadata> {
     let meta = db.get_cf(
-        &IndexifyObjectsColumns::StateMachineMetadata.cf_db(db),
+        db.column_family(IndexifyObjectsColumns::StateMachineMetadata.as_ref()),
         b"sm_meta",
     )?;
     match meta {
@@ -128,13 +129,13 @@ pub fn read_sm_meta(db: &TransactionDB) -> Result<StateMachineMetadata> {
 
 /// Write state machine metadata to the database
 pub fn write_sm_meta(
-    db: &TransactionDB,
+    db: &RocksDBDriver,
     txn: &Transaction<TransactionDB>,
     sm_meta: &StateMachineMetadata,
 ) -> Result<()> {
     let serialized_meta = JsonEncoder::encode(sm_meta)?;
     txn.put_cf(
-        &IndexifyObjectsColumns::StateMachineMetadata.cf_db(db),
+        db.column_family(IndexifyObjectsColumns::StateMachineMetadata.as_ref()),
         b"sm_meta",
         &serialized_meta,
     )?;
@@ -143,12 +144,12 @@ pub fn write_sm_meta(
 
 #[cfg(test)]
 mod tests {
-    use rocksdb::{ColumnFamilyDescriptor, Options, TransactionDBOptions};
+    use rocksdb::{ColumnFamilyDescriptor, Options};
     use strum::IntoEnumIterator;
     use tempfile::TempDir;
 
     use super::*;
-    use crate::state_store::migrations::migration_trait::Migration;
+    use crate::state_store::{self, migrations::migration_trait::Migration};
 
     #[derive(Clone)]
     struct MockMigration {
@@ -165,7 +166,7 @@ mod tests {
             self.name
         }
 
-        fn prepare(&self, ctx: &PrepareContext) -> Result<TransactionDB> {
+        fn prepare(&self, ctx: &PrepareContext) -> Result<RocksDBDriver> {
             // Simple mock - just open DB
             ctx.open_db()
         }
@@ -215,19 +216,10 @@ mod tests {
         let sm_column_families = IndexifyObjectsColumns::iter()
             .map(|cf| ColumnFamilyDescriptor::new(cf.to_string(), Options::default()));
 
-        let mut db_opts = Options::default();
-        db_opts.create_missing_column_families(true);
-        db_opts.create_if_missing(true);
-
-        let db = TransactionDB::open_cf_descriptors(
-            &db_opts,
-            &TransactionDBOptions::default(),
-            path,
-            sm_column_families,
-        )?;
+        let db = state_store::open_database(path.to_path_buf(), sm_column_families)?;
 
         // Set initial version to 1
-        let txn = db.transaction();
+        let txn = db.db.transaction();
         let initial_meta = StateMachineMetadata {
             db_version: 0,
             last_change_idx: 0,

--- a/server/src/state_store/migrations/migration_trait.rs
+++ b/server/src/state_store/migrations/migration_trait.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
-use rocksdb::TransactionDB;
 
 use super::contexts::{MigrationContext, PrepareContext};
+use crate::state_store::driver::rocksdb::RocksDBDriver;
 
 /// Trait defining a database migration
 pub trait Migration {
@@ -13,7 +13,7 @@ pub trait Migration {
 
     /// DB preparation - column family operations before transaction
     /// Default implementation simply opens the DB with existing column families
-    fn prepare(&self, ctx: &PrepareContext) -> Result<TransactionDB> {
+    fn prepare(&self, ctx: &PrepareContext) -> Result<RocksDBDriver> {
         ctx.open_db()
     }
 

--- a/server/src/state_store/migrations/testing.rs
+++ b/server/src/state_store/migrations/testing.rs
@@ -1,27 +1,22 @@
 use anyhow::Result;
-use rocksdb::{Options, TransactionDB, TransactionDBOptions};
+use rocksdb::ColumnFamilyDescriptor;
 use tempfile::TempDir;
 
 use super::{
     contexts::{MigrationContext, PrepareContext},
     migration_trait::Migration,
 };
+use crate::state_store::{self, driver::rocksdb::RocksDBDriver};
 
 /// A more complete test utility that handles custom column families
 pub struct MigrationTestBuilder {
     column_families: Vec<String>,
-    db_opts: Options,
 }
 
 impl MigrationTestBuilder {
     pub fn new() -> Self {
-        let mut db_opts = Options::default();
-        db_opts.create_missing_column_families(true);
-        db_opts.create_if_missing(true);
-
         Self {
             column_families: vec!["default".to_string()],
-            db_opts,
         }
     }
 
@@ -35,19 +30,19 @@ impl MigrationTestBuilder {
     pub fn run_test<M, S, V>(self, migration: &M, setup: S, verify: V) -> Result<()>
     where
         M: Migration,
-        S: FnOnce(&TransactionDB) -> Result<()>,
-        V: FnOnce(&TransactionDB) -> Result<()>,
+        S: FnOnce(&RocksDBDriver) -> Result<()>,
+        V: FnOnce(&RocksDBDriver) -> Result<()>,
     {
         // Create temporary database directory
         let temp_dir = TempDir::new()?;
         let path = temp_dir.path();
 
         // Create database with specified column families
-        let db = TransactionDB::open_cf(
-            &self.db_opts,
-            &TransactionDBOptions::default(),
-            path,
-            &self.column_families,
+        let db = state_store::open_database(
+            path.to_path_buf(),
+            self.column_families
+                .into_iter()
+                .map(|s| ColumnFamilyDescriptor::new(s, Default::default())),
         )?;
 
         // Run setup function to populate test data
@@ -61,7 +56,7 @@ impl MigrationTestBuilder {
         let db = migration.prepare(&prepare_ctx)?;
 
         // Apply the migration
-        let txn = db.transaction();
+        let txn = db.db.transaction();
         let migration_ctx = MigrationContext::new(&db, &txn);
 
         migration.apply(&migration_ctx)?;
@@ -93,7 +88,7 @@ mod tests {
             "Mock Migration"
         }
 
-        fn prepare(&self, ctx: &PrepareContext) -> Result<TransactionDB> {
+        fn prepare(&self, ctx: &PrepareContext) -> Result<RocksDBDriver> {
             ctx.open_db()
         }
 
@@ -127,7 +122,7 @@ mod tests {
                 |db| {
                     // Verify migration was applied
                     let result = db.get_cf(
-                        IndexifyObjectsColumns::StateMachineMetadata.cf_db(db),
+                        db.column_family(IndexifyObjectsColumns::StateMachineMetadata.as_ref()),
                         b"migration_test",
                     )?;
 

--- a/server/src/state_store/migrations/v1_task_status.rs
+++ b/server/src/state_store/migrations/v1_task_status.rs
@@ -143,7 +143,7 @@ mod tests {
 
                     for (key, value) in tasks {
                         db.put_cf(
-                            IndexifyObjectsColumns::Tasks.cf_db(db),
+                            db.column_family(IndexifyObjectsColumns::Tasks.as_ref()),
                             &key,
                             serde_json::to_vec(&value)?.as_slice(),
                         )?;
@@ -154,9 +154,8 @@ mod tests {
                 |db| {
                     // Verify: Check that status fields were added properly
                     let verify_status = |key: &[u8], expected_status: &str| -> Result<()> {
-                        let bytes = db
-                            .get_cf(IndexifyObjectsColumns::Tasks.cf_db(db), key)?
-                            .unwrap();
+                        let cf = db.column_family(IndexifyObjectsColumns::Tasks.as_ref());
+                        let bytes = db.get_cf(cf, key)?.unwrap();
                         let task: serde_json::Value = serde_json::from_slice(&bytes)?;
                         assert_eq!(task["status"].as_str().unwrap(), expected_status);
                         Ok(())

--- a/server/src/state_store/migrations/v4_drop_executors.rs
+++ b/server/src/state_store/migrations/v4_drop_executors.rs
@@ -5,6 +5,7 @@ use super::{
     contexts::{MigrationContext, PrepareContext},
     migration_trait::Migration,
 };
+use crate::state_store::driver::rocksdb::RocksDBDriver;
 
 #[derive(Clone)]
 /// Migration to remove the deprecated Executors column family
@@ -19,7 +20,7 @@ impl Migration for V4DropExecutorsMigration {
         "Drop Executors column family"
     }
 
-    fn prepare(&self, ctx: &PrepareContext) -> Result<rocksdb::TransactionDB> {
+    fn prepare(&self, ctx: &PrepareContext) -> Result<RocksDBDriver> {
         // Check if the Executors CF exists and drop it if needed
         let existing_cfs = ctx.list_cfs()?;
 
@@ -48,10 +49,10 @@ impl Migration for V4DropExecutorsMigration {
 
 #[cfg(test)]
 mod tests {
-    use rocksdb::{ColumnFamilyDescriptor, Options, TransactionDB, TransactionDBOptions};
+    use rocksdb::ColumnFamilyDescriptor;
 
     use super::*;
-    use crate::state_store::migrations::testing::MigrationTestBuilder;
+    use crate::state_store::{self, migrations::testing::MigrationTestBuilder};
 
     #[test]
     fn test_v4_migration_with_executors_cf() -> Result<()> {
@@ -63,21 +64,12 @@ mod tests {
 
         // First create a DB with Executors CF
         {
-            let mut db_opts = Options::default();
-            db_opts.create_missing_column_families(true);
-            db_opts.create_if_missing(true);
-
             let cf_descriptors = vec![
-                ColumnFamilyDescriptor::new("default", Options::default()),
-                ColumnFamilyDescriptor::new("Executors", Options::default()),
+                ColumnFamilyDescriptor::new("default", Default::default()),
+                ColumnFamilyDescriptor::new("Executors", Default::default()),
             ];
 
-            let _db: TransactionDB = TransactionDB::open_cf_descriptors(
-                &db_opts,
-                &TransactionDBOptions::default(),
-                path,
-                cf_descriptors,
-            )?;
+            let _db = state_store::open_database(path.to_path_buf(), cf_descriptors.into_iter())?;
             // DB is dropped here when it goes out of scope
         }
 
@@ -90,7 +82,7 @@ mod tests {
         assert!(!cfs.contains(&"Executors".to_string()));
 
         // Run apply phase (no-op in this case)
-        let txn = db.transaction();
+        let txn = db.db.transaction();
         let migration_ctx = MigrationContext::new(&db, &txn);
         migration.apply(&migration_ctx)?;
         txn.commit()?;
@@ -110,7 +102,7 @@ mod tests {
             },
             |db| {
                 // Verify migration completes without error
-                let txn = db.transaction();
+                let txn = db.db.transaction();
                 txn.commit()?;
                 Ok(())
             },

--- a/server/src/state_store/migrations/v6_clean_orphaned_tasks.rs
+++ b/server/src/state_store/migrations/v6_clean_orphaned_tasks.rs
@@ -122,7 +122,7 @@ mod tests {
 
                     for (key, value) in &tasks {
                         db.put_cf(
-                            IndexifyObjectsColumns::Tasks.cf_db(db),
+                            db.column_family(IndexifyObjectsColumns::Tasks.as_ref()),
                             key,
                             serde_json::to_vec(value)?.as_slice(),
                         )?;
@@ -148,7 +148,7 @@ mod tests {
                     );
 
                     db.put_cf(
-                        IndexifyObjectsColumns::GraphInvocationCtx.cf_db(db),
+                        db.column_family(IndexifyObjectsColumns::GraphInvocationCtx.as_ref()),
                         key,
                         serde_json::to_vec(&invocation_ctx)?.as_slice(),
                     )?;
@@ -159,18 +159,15 @@ mod tests {
                     // Verify: Check that orphaned task was deleted
 
                     // Task1 (not orphaned) should still exist
+                    let cf = db.column_family(IndexifyObjectsColumns::Tasks.as_ref());
                     let task1_key = b"test_ns|test_graph|invocation1|test_fn|task1";
-                    let task1_exists = db
-                        .get_cf(IndexifyObjectsColumns::Tasks.cf_db(db), task1_key)?
-                        .is_some();
+                    let task1_exists = db.get_cf(cf, task1_key)?.is_some();
 
                     assert!(task1_exists, "Task1 should still exist");
 
                     // Task2 (orphaned) should be deleted
                     let task2_key = b"test_ns|test_graph|invocation2|test_fn|task2";
-                    let task2_exists = db
-                        .get_cf(IndexifyObjectsColumns::Tasks.cf_db(db), task2_key)?
-                        .is_some();
+                    let task2_exists = db.get_cf(cf, task2_key)?.is_some();
 
                     assert!(!task2_exists, "Task2 should be deleted");
 

--- a/server/src/utils/mod.rs
+++ b/server/src/utils/mod.rs
@@ -24,30 +24,6 @@ macro_rules! unwrap_or_continue {
     };
 }
 
-pub trait OptionInspectNone<T> {
-    fn inspect_none(self, inspector_function: impl FnOnce()) -> Self;
-}
-
-impl<T> OptionInspectNone<T> for Option<T> {
-    fn inspect_none(self, inspector_function: impl FnOnce()) -> Self {
-        match &self {
-            Some(_) => (),
-            None => inspector_function(),
-        }
-        self
-    }
-}
-
-impl<T> OptionInspectNone<T> for &Option<T> {
-    fn inspect_none(self, inspector_function: impl FnOnce()) -> Self {
-        match &self {
-            Some(_) => (),
-            None => inspector_function(),
-        }
-        self
-    }
-}
-
 /// A [`Stream`] wrapper that automatically runs a custom action when dropped.
 #[pin_project(PinnedDrop)]
 pub struct StreamGuard<S, F>


### PR DESCRIPTION
## Context

<!--
In a few sentences or less, please explain the context behind this change to help answer why this change is needed.

If this is a bug fix, make sure to include "fixes #xxxx", or
"closes #xxxx".

Screenshots, logs, code or other visual aids are greatly appreciated.
 -->

This PR continues abstracting the DB logic behind the Driver interface.

## What

<!--
In a few sentences, please summarize the change to help reviewers.

Consider providing screenshots, logs, code or other visual aids to help the reviewer understand the approach taken.
-->

Instead of passing TransactionDB objects, we're passing RocksDBDriver. This doesn't change much what we have, but it allow us to start putting more logic behing the driver trait.

Repace all usage of `cf_db` with `column_family` to be more explicit of what it is, and also remove the call from within the enum implementation. This makes the code more consistent across the board.

Stop calling `column_family` from within iterators. That call uses a RwLock to access column families. If the lock is held for writing, all read operation wait for it. Instead of calling it for every iteration within loops, we can call it before looping, reducing the lock contention in specific areas.

## Testing

<!--
Please include steps used to verify the change.

Consider providing screenshots, logs, code or other visual aids to help the reviewer in their testing.
-->

Added new tests to verify more behavior changes.

## Contribution Checklist

- [ ] If a Python package was changed, please run `make fmt` in the package directory.
- [x] If the server was changed, please run `make fmt` in `server/`.
- [ ] Make sure all PR Checks are passing.
<!--
Notes:

Tests of a Python package can be run manually. Start a Server and an Executor then
run `make test` in the Python package directory.

To test if changes to the server are backward compatible with the latest
release, label the PR with `ci_compat_test`. This might report failures
unrelated to your change if previous incompatible changes were pushed without
being released yet
-->
