### PR TITLE
chore: bump axios to 1.12.0

### DIFF
--- a/server/ui/package-lock.json
+++ b/server/ui/package-lock.json
@@ -23,7 +23,7 @@
         "@types/react": "^18.2.48",
         "@types/react-dom": "^18.2.18",
         "@types/react-router-dom": "^5.3.3",
-        "axios": "^1.11.0",
+        "axios": "^1.12.0",
         "crypto": "^1.0.1",
         "date-fns": "^4.1.0",
         "getindexify": "^0.1.5",
@@ -5944,9 +5944,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
-      "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
+      "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",

--- a/server/ui/package.json
+++ b/server/ui/package.json
@@ -23,7 +23,7 @@
     "@types/react": "^18.2.48",
     "@types/react-dom": "^18.2.18",
     "@types/react-router-dom": "^5.3.3",
-    "axios": "^1.11.0",
+    "axios": "^1.12.0",
     "crypto": "^1.0.1",
     "date-fns": "^4.1.0",
     "getindexify": "^0.1.5",


### PR DESCRIPTION
## Context

PR addresses an Axios 1.11.0 vulnerability.

## What

Bumps Axios to 1.12.0.

## Testing

Built and ran server locally.

## Contribution Checklist

- [x] Make sure all PR Checks are passing.
