### PR TITLE
feat: app navigation update

### DIFF
--- a/server/ui/src/components/cards/ApplicationsCard.tsx
+++ b/server/ui/src/components/cards/ApplicationsCard.tsx
@@ -159,7 +159,7 @@ export function ApplicationsCard({
     if (!localApplications.length)
       return (
         <Alert variant="outlined" severity="info" sx={{ my: 2 }}>
-          No Graphs Found
+          No Applications Found
         </Alert>
       )
 

--- a/server/ui/src/components/cards/ApplicationsCard.tsx
+++ b/server/ui/src/components/cards/ApplicationsCard.tsx
@@ -83,8 +83,8 @@ export function ApplicationsCard({
               {Object.keys(application.functions).length > 0 ? (
                 <>
                   <ul style={{ margin: '0 0 6px 0', paddingLeft: '20px' }}>
-                    {Object.values(application.functions).map((func) => (
-                      <li key={func.name}>{func.name} </li>
+                    {Object.values(application.functions).map((func, index) => (
+                      <li key={func.name + '_' + index}>{func.name} </li>
                     ))}
                   </ul>
                 </>
@@ -100,8 +100,8 @@ export function ApplicationsCard({
               {Object.keys(application.tags).length > 0 ? (
                 <>
                   <ul style={{ margin: '0 0 6px 0', paddingLeft: '20px' }}>
-                    {Object.values(application.tags).map((tag) => (
-                      <li key={tag}>{tag} </li>
+                    {Object.values(application.tags).map((tag, index) => (
+                      <li key={tag + '_' + index}>{tag} </li>
                     ))}
                   </ul>
                 </>
@@ -117,9 +117,11 @@ export function ApplicationsCard({
               {Object.keys(application.entrypoint).length > 0 ? (
                 <>
                   <ul style={{ margin: '0 0 6px 0', paddingLeft: '20px' }}>
-                    {Object.values(application.entrypoint).map((entry) => (
-                      <li key={entry}>{entry} </li>
-                    ))}
+                    {Object.values(application.entrypoint).map(
+                      (entry, index) => (
+                        <li key={entry + '_' + index}>{entry} </li>
+                      )
+                    )}
                   </ul>
                 </>
               ) : (

--- a/server/ui/src/routes/root.tsx
+++ b/server/ui/src/routes/root.tsx
@@ -23,6 +23,7 @@ import {
   Outlet,
   redirect,
   useLocation,
+  useNavigate,
   useParams,
 } from 'react-router-dom'
 import theme from '../theme'
@@ -53,12 +54,13 @@ export async function loader({ params }: LoaderFunctionArgs) {
 
 function Dashboard() {
   const location = useLocation()
+  const navigate = useNavigate()
   const { namespace = 'default' } = useParams<{ namespace: string }>()
   const { namespaces } = useLoaderData() as RootLoaderData
 
   const handleNamespaceChange = (event: SelectChangeEvent) => {
     const newNamespace = event.target.value
-    window.location.href = window.location.origin + `/ui/${newNamespace}`
+    navigate(`/${newNamespace}`)
   }
 
   const navItems: NavItem[] = [

--- a/server/ui/src/routes/root.tsx
+++ b/server/ui/src/routes/root.tsx
@@ -58,8 +58,7 @@ function Dashboard() {
 
   const handleNamespaceChange = (event: SelectChangeEvent) => {
     const newNamespace = event.target.value
-    const newPath = location.pathname.replace(/^\/[^/]+/, `/${newNamespace}`)
-    window.location.href = window.location.origin + '/ui' + newPath
+    window.location.href = window.location.origin + `/ui/${newNamespace}`
   }
 
   const navItems: NavItem[] = [
@@ -143,8 +142,8 @@ function Dashboard() {
                     label="Namespace"
                     onChange={handleNamespaceChange}
                   >
-                    {namespaces.map((ns) => (
-                      <MenuItem key={ns.name} value={ns.name}>
+                    {namespaces.map((ns, index) => (
+                      <MenuItem key={ns.name + '_' + index} value={ns.name}>
                         {ns.name}
                       </MenuItem>
                     ))}


### PR DESCRIPTION
## Context

Because different namespaces can have different application names, resetting the routing to the application level will ensure proper namespace switches.

## What

When the user switches application namespace it doesn't try to maintain the same application in the URL, to prevent it looking for requests that do not exist.

## Testing

Ran locally while connecting to dev environment.

## Contribution Checklist

- [x] If the server was changed, please run `make fmt` in `server/`.
- [x] Make sure all PR Checks are passing.
