### PR TITLE
Minor request input/ouput/count metrics fixes

### DIFF
--- a/server/src/metrics/mod.rs
+++ b/server/src/metrics/mod.rs
@@ -135,8 +135,7 @@ pub mod api_io_stats {
     #[derive(Debug)]
     pub struct Metrics {
         pub requests: Counter<u64>,
-        pub request_bytes: Counter<u64>,
-        pub fn_outputs: Counter<u64>,
+        pub request_input_bytes: Counter<u64>,
     }
 
     impl Default for Metrics {
@@ -150,20 +149,15 @@ pub mod api_io_stats {
             let meter = opentelemetry::global::meter("service-api");
             let requests = meter
                 .u64_counter("indexify.requests")
-                .with_description("number of requests")
+                .with_description("number of created requests")
                 .build();
-            let request_bytes = meter
-                .u64_counter("indexify.request_bytes")
-                .with_description("number of bytes ingested during requests")
-                .build();
-            let fn_outputs = meter
-                .u64_counter("indexify.fn_outputs")
-                .with_description("number of fn outputs")
+            let request_input_bytes = meter
+                .u64_counter("indexify.request_input_bytes")
+                .with_description("request input bytes ingested during request creations")
                 .build();
             Metrics {
                 requests,
-                request_bytes,
-                fn_outputs,
+                request_input_bytes,
             }
         }
     }

--- a/server/src/routes/invoke.rs
+++ b/server/src/routes/invoke.rs
@@ -187,7 +187,11 @@ pub async fn invoke_application_with_object_v1(
         encoding,
     };
 
-    state.metrics.request_bytes.add(data_payload.size, &[]);
+    state
+        .metrics
+        .request_input_bytes
+        .add(data_payload.size, &[]);
+    state.metrics.requests.add(1, &[]);
 
     let application = state
         .indexify_state
@@ -214,7 +218,7 @@ pub async fn invoke_application_with_object_v1(
         vec![data_payload.clone()],
         Bytes::new(),
     );
-    let cg_version = state
+    let app_version = state
         .indexify_state
         .in_memory_state
         .read()
@@ -224,7 +228,7 @@ pub async fn invoke_application_with_object_v1(
         .ok_or(IndexifyAPIError::not_found(
             "compute graph version not found",
         ))?;
-    let fn_run = cg_version
+    let fn_run = app_version
         .create_function_run(
             &fn_call,
             vec![InputArgs {

--- a/server/src/service.rs
+++ b/server/src/service.rs
@@ -188,7 +188,6 @@ impl Service {
                 .add_service(ExecutorApiServer::new(ExecutorAPIService::new(
                     indexify_state,
                     executor_manager,
-                    api_metrics,
                     blog_storage_registry,
                 )))
                 .add_service(reflection_service)


### PR DESCRIPTION
Remote fn_outputs counter metric as it doesn't give any value now. Instead of it we need to track request output bytes size because it's plumbed through server and can be many GB. This is a TODO.

Rename request_bytes to request_input_bytes for clarity.
